### PR TITLE
[C++] Missing include of <functional>, breaks the build on RHEL6 devtool...

### DIFF
--- a/aeron-common/src/main/cpp/concurrent/ringbuffer/ManyToOneRingBuffer.h
+++ b/aeron-common/src/main/cpp/concurrent/ringbuffer/ManyToOneRingBuffer.h
@@ -17,6 +17,7 @@
 #ifndef INCLUDED_AERON_CONCURRENT_RINGBUFFER_MANY_TO_ONE_RING_BUFFER__
 #define INCLUDED_AERON_CONCURRENT_RINGBUFFER_MANY_TO_ONE_RING_BUFFER__
 
+#include <functional>
 #include <util/Index.h>
 #include <concurrent/AtomicBuffer.h>
 #include "RingBufferDescriptor.h"


### PR DESCRIPTION
...set-2
