### PR TITLE
[Java]: Add missing `stateTemplate` field and copy in MappedTermBuffers

### DIFF
--- a/aeron-driver/src/main/java/uk/co/real_logic/aeron/driver/buffer/MappedTermBuffers.java
+++ b/aeron-driver/src/main/java/uk/co/real_logic/aeron/driver/buffer/MappedTermBuffers.java
@@ -42,6 +42,7 @@ class MappedTermBuffers implements TermBuffers
     private static final String STATE_SUFFIX = "-state";
 
     private final FileChannel logTemplate;
+    private final FileChannel stateTemplate;
     private final int logBufferLength;
     private final int stateBufferLength;
     private final MappedRawLog[] buffers;
@@ -61,6 +62,7 @@ class MappedTermBuffers implements TermBuffers
         this.logTemplate = logTemplate;
         this.logBufferLength = logBufferLength;
         this.stateBufferLength = stateBufferSize;
+        this.stateTemplate = stateTemplate;
 
         try
         {
@@ -150,8 +152,8 @@ class MappedTermBuffers implements TermBuffers
                 stateFile,
                 logFileChannel,
                 stateFileChannel,
-                mapBufferFile(logFileChannel, logBufferLength),
-                mapBufferFile(stateFileChannel, stateBufferLength),
+                mapBufferFile(logFileChannel, logTemplate, logBufferLength),
+                mapBufferFile(stateFileChannel, stateTemplate, stateBufferLength),
                 logger);
         }
         catch (final IOException ex)
@@ -165,9 +167,12 @@ class MappedTermBuffers implements TermBuffers
         return new RandomAccessFile(file, "rw").getChannel();
     }
 
-    private MappedByteBuffer mapBufferFile(final FileChannel channel, final long bufferSize)
+    private MappedByteBuffer mapBufferFile(
+        final FileChannel channel,
+        final FileChannel template,
+        final long bufferSize)
     {
-        reset(channel, logTemplate, bufferSize);
+        reset(channel, template, bufferSize);
 
         try
         {


### PR DESCRIPTION
A very minor fix. While reading through Aeron's log buffer management code, I noticed that `MappedTermBuffers` initializes state files using the log file template rather than the state file template. In fact, the class lacks a `stateTemplate` field to begin with. I couldn't tell from documentation or `git log` history if this was intentional, but I'm assuming it's a wiring oversight.

This change adds a private `MappedTermBuffers.stateTemplate` field and threads it down to the state file call to `reset`. Aeron compiles and tests cleanly.
