### PR TITLE
[Java]: Default tmpfs paths should support multi-user environments

### DIFF
--- a/aeron-common/src/main/java/uk/co/real_logic/aeron/common/CommonContext.java
+++ b/aeron-common/src/main/java/uk/co/real_logic/aeron/common/CommonContext.java
@@ -45,17 +45,20 @@ public class CommonContext implements AutoCloseable
     /** Directory of the data buffers */
     public static final String DATA_DIR_PROP_NAME = "aeron.dir.data";
     /** Default directory for data buffers */
-    public static final String DATA_DIR_PROP_DEFAULT = IoUtil.tmpDirName() + "aeron" + File.separator + DATA_DIR_NAME;
+    public static final String DATA_DIR_PROP_DEFAULT = IoUtil.tmpDirName() + "aeron" + File.separator +
+            System.getProperty("user.name") + File.separator + DATA_DIR_NAME;
 
     /** Directory of the conductor buffers */
     public static final String ADMIN_DIR_PROP_NAME = "aeron.dir.conductor";
     /** Default directory for conductor buffers */
-    public static final String ADMIN_DIR_PROP_DEFAULT = IoUtil.tmpDirName() + "aeron" + File.separator + CONDUCTOR_DIR_NAME;
+    public static final String ADMIN_DIR_PROP_DEFAULT = IoUtil.tmpDirName() + "aeron" + File.separator +
+            System.getProperty("user.name") + File.separator + CONDUCTOR_DIR_NAME;
 
     /** Directory for the counters */
     public static final String COUNTERS_DIR_PROP_NAME = "aeron.dir.counters";
     /** Default directory for conductor buffers */
-    public static final String COUNTERS_DIR_PROP_DEFAULT = IoUtil.tmpDirName() + "aeron" + File.separator + COUNTERS_DIR_NAME;
+    public static final String COUNTERS_DIR_PROP_DEFAULT = IoUtil.tmpDirName() + "aeron" + File.separator +
+            System.getProperty("user.name") + File.separator + COUNTERS_DIR_NAME;
 
     /** Name of the default multicast interface */
     public static final String MULTICAST_DEFAULT_INTERFACE_PROP_NAME = "aeron.multicast.default.interface";

--- a/aeron-samples/src/main/java/uk/co/real_logic/aeron/samples/SamplesUtil.java
+++ b/aeron-samples/src/main/java/uk/co/real_logic/aeron/samples/SamplesUtil.java
@@ -45,17 +45,17 @@ public class SamplesUtil
         {
             if (null == System.getProperty(ADMIN_DIR_PROP_NAME))
             {
-                System.setProperty(ADMIN_DIR_PROP_NAME, "/dev/shm/aeron/conductor");
+                System.setProperty(ADMIN_DIR_PROP_NAME, "/dev/shm/aeron/" + System.getProperty("user.name") + "/conductor");
             }
 
             if (null == System.getProperty(COUNTERS_DIR_PROP_NAME))
             {
-                System.setProperty(COUNTERS_DIR_PROP_NAME, "/dev/shm/aeron/counters");
+                System.setProperty(COUNTERS_DIR_PROP_NAME, "/dev/shm/aeron/" + System.getProperty("user.name") + "/counters");
             }
 
             if (null == System.getProperty(DATA_DIR_PROP_NAME))
             {
-                System.setProperty(DATA_DIR_PROP_NAME, "/dev/shm/aeron/data");
+                System.setProperty(DATA_DIR_PROP_NAME, "/dev/shm/aeron/" + System.getProperty("user.name") + "/data");
             }
         }
     }


### PR DESCRIPTION
Simple modifications to the default path (prefixes) to include the
user.name after “aeron” in order to avoid conflict in multi-user
environments.
- DATA_DIR_PROP_DEFAULT
- ADMIN_DIR_PROP_DEFAULT
- COUNTERS_DIR_PROP_DEFAULT

Example on Linux:
Old: /dev/shm/aeron/{conductor, counters, data}
New: /dev/shm/aeron/kris/{conductor, counters, data}

C++ support forthcoming.
