### PR TITLE
Merge MediaDriverTestWatcher and ClusterTestWatcher into one class

### DIFF
--- a/aeron-system-tests/src/test/java/io/aeron/AsyncResourceTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/AsyncResourceTest.java
@@ -19,8 +19,8 @@ import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.exceptions.RegistrationException;
 import io.aeron.test.SlowTest;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.Tests;
-import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.ErrorHandler;
 import org.junit.jupiter.api.Test;
@@ -37,7 +37,7 @@ class AsyncResourceTest
     private static final String AERON_IPC = "aeron:ipc";
 
     @RegisterExtension
-    final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
+    final SystemTestWatcher testWatcher = new SystemTestWatcher();
 
     @Test
     @Timeout(10)

--- a/aeron-system-tests/src/test/java/io/aeron/BufferClaimMessageTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/BufferClaimMessageTest.java
@@ -22,8 +22,8 @@ import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.Tests;
-import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.collections.MutableBoolean;
@@ -54,7 +54,7 @@ public class BufferClaimMessageTest
     private static final int MESSAGE_LENGTH = 200;
 
     @RegisterExtension
-    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
+    public final SystemTestWatcher testWatcher = new SystemTestWatcher();
 
     private final TestMediaDriver driver = TestMediaDriver.launch(new MediaDriver.Context()
         .errorHandler(Tests::onError)

--- a/aeron-system-tests/src/test/java/io/aeron/ChannelEndpointStatusTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ChannelEndpointStatusTest.java
@@ -26,8 +26,8 @@ import io.aeron.protocol.DataHeaderFlyweight;
 import io.aeron.status.ChannelEndpointStatus;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.Tests;
-import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.ErrorHandler;
@@ -97,7 +97,7 @@ public class ChannelEndpointStatusTest
         };
 
     @RegisterExtension
-    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
+    public final SystemTestWatcher testWatcher = new SystemTestWatcher();
 
     @BeforeEach
     public void before()

--- a/aeron-system-tests/src/test/java/io/aeron/ChannelValidationTests.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ChannelValidationTests.java
@@ -22,8 +22,8 @@ import io.aeron.exceptions.RegistrationException;
 import io.aeron.logbuffer.FrameDescriptor;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.Tests;
-import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.BitUtil;
 import org.agrona.CloseHelper;
@@ -52,7 +52,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 public class ChannelValidationTests
 {
     @RegisterExtension
-    public final MediaDriverTestWatcher watcher = new MediaDriverTestWatcher();
+    public final SystemTestWatcher watcher = new SystemTestWatcher();
 
     private final MediaDriver.Context context = new MediaDriver.Context();
     {

--- a/aeron-system-tests/src/test/java/io/aeron/ClientErrorHandlerTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ClientErrorHandlerTest.java
@@ -34,8 +34,8 @@ import io.aeron.driver.MediaDriver;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.Tests;
-import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.ErrorHandler;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -54,7 +54,7 @@ public class ClientErrorHandlerTest
     private static final String CHANNEL = "aeron:ipc";
 
     @RegisterExtension
-    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
+    public final SystemTestWatcher testWatcher = new SystemTestWatcher();
 
     @Test
     @InterruptAfter(10)

--- a/aeron-system-tests/src/test/java/io/aeron/ControlledMessageTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ControlledMessageTest.java
@@ -22,8 +22,8 @@ import io.aeron.logbuffer.Header;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.Tests;
-import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
@@ -44,7 +44,7 @@ public class ControlledMessageTest
     private static final int PAYLOAD_LENGTH = 10;
 
     @RegisterExtension
-    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
+    public final SystemTestWatcher testWatcher = new SystemTestWatcher();
 
     private final TestMediaDriver driver = TestMediaDriver.launch(new MediaDriver.Context()
         .errorHandler(Tests::onError)

--- a/aeron-system-tests/src/test/java/io/aeron/CounterTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/CounterTest.java
@@ -20,8 +20,8 @@ import io.aeron.driver.ThreadingMode;
 import io.aeron.status.ReadableCounter;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.Tests;
-import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -50,7 +50,7 @@ public class CounterTest
     private TestMediaDriver driver;
 
     @RegisterExtension
-    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
+    public final SystemTestWatcher testWatcher = new SystemTestWatcher();
 
     private volatile ReadableCounter readableCounter;
 

--- a/aeron-system-tests/src/test/java/io/aeron/ErrorHandlerTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ErrorHandlerTest.java
@@ -19,8 +19,8 @@ import io.aeron.driver.MediaDriver;
 import io.aeron.driver.status.SystemCounterDescriptor;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.Tests;
-import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.hamcrest.Matcher;
@@ -41,7 +41,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 public class ErrorHandlerTest
 {
     @RegisterExtension
-    public final MediaDriverTestWatcher watcher = new MediaDriverTestWatcher();
+    public final SystemTestWatcher watcher = new SystemTestWatcher();
 
     private final MediaDriver.Context context = new MediaDriver.Context();
     {

--- a/aeron-system-tests/src/test/java/io/aeron/ExclusivePublicationTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ExclusivePublicationTest.java
@@ -21,8 +21,8 @@ import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.RawBlockHandler;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.Tests;
-import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.collections.MutableInteger;
@@ -67,7 +67,7 @@ public class ExclusivePublicationTest
     private final UnsafeBuffer srcBuffer = new UnsafeBuffer(new byte[65 * 1024]);
 
     @RegisterExtension
-    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
+    public final SystemTestWatcher testWatcher = new SystemTestWatcher();
 
     private final MediaDriver.Context driverContext = new MediaDriver.Context()
         .errorHandler(Tests::onError)

--- a/aeron-system-tests/src/test/java/io/aeron/FragmentedMessageTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/FragmentedMessageTest.java
@@ -22,8 +22,8 @@ import io.aeron.logbuffer.Header;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.Tests;
-import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
@@ -57,7 +57,7 @@ public class FragmentedMessageTest
     private static final int FRAGMENT_COUNT_LIMIT = 10;
 
     @RegisterExtension
-    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
+    public final SystemTestWatcher testWatcher = new SystemTestWatcher();
 
     private final FragmentHandler mockFragmentHandler = mock(FragmentHandler.class);
 

--- a/aeron-system-tests/src/test/java/io/aeron/GapFillLossTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/GapFillLossTest.java
@@ -25,8 +25,8 @@ import io.aeron.logbuffer.Header;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.Tests;
-import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -56,7 +56,7 @@ public class GapFillLossTest
     private static final AtomicLong FINAL_POSITION = new AtomicLong(Long.MAX_VALUE);
 
     @RegisterExtension
-    final MediaDriverTestWatcher watcher = new MediaDriverTestWatcher();
+    final SystemTestWatcher watcher = new SystemTestWatcher();
 
     @Test
     @InterruptAfter(10)

--- a/aeron-system-tests/src/test/java/io/aeron/ImageAvailabilityTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ImageAvailabilityTest.java
@@ -19,8 +19,8 @@ import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.Tests;
-import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.junit.jupiter.api.AfterEach;
@@ -50,7 +50,7 @@ public class ImageAvailabilityTest
     private static final int STREAM_ID = 1001;
 
     @RegisterExtension
-    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
+    public final SystemTestWatcher testWatcher = new SystemTestWatcher();
 
     private final TestMediaDriver driver = TestMediaDriver.launch(new MediaDriver.Context()
         .errorHandler(Tests::onError)

--- a/aeron-system-tests/src/test/java/io/aeron/LifecycleTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/LifecycleTest.java
@@ -18,8 +18,8 @@ package io.aeron;
 import io.aeron.driver.MediaDriver;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.Tests;
-import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.*;
 public class LifecycleTest
 {
     @RegisterExtension
-    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
+    public final SystemTestWatcher testWatcher = new SystemTestWatcher();
 
     @Test
     @InterruptAfter(10)

--- a/aeron-system-tests/src/test/java/io/aeron/MaxFlowControlStrategySystemTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MaxFlowControlStrategySystemTest.java
@@ -24,8 +24,8 @@ import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.protocol.DataHeaderFlyweight;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.Tests;
-import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
@@ -71,7 +71,7 @@ public class MaxFlowControlStrategySystemTest
     private final FragmentHandler fragmentHandlerB = mock(FragmentHandler.class);
 
     @RegisterExtension
-    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
+    public final SystemTestWatcher testWatcher = new SystemTestWatcher();
 
     private void launch()
     {

--- a/aeron-system-tests/src/test/java/io/aeron/MaxPositionPublicationTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MaxPositionPublicationTest.java
@@ -20,8 +20,8 @@ import io.aeron.driver.ThreadingMode;
 import io.aeron.protocol.DataHeaderFlyweight;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.Tests;
-import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -44,7 +44,7 @@ public class MaxPositionPublicationTest
     private final UnsafeBuffer srcBuffer = new UnsafeBuffer(ByteBuffer.allocate(MESSAGE_LENGTH));
 
     @RegisterExtension
-    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
+    public final SystemTestWatcher testWatcher = new SystemTestWatcher();
 
     private final TestMediaDriver driver = TestMediaDriver.launch(new MediaDriver.Context()
         .errorHandler(Tests::onError)

--- a/aeron-system-tests/src/test/java/io/aeron/MemoryOrderingTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MemoryOrderingTest.java
@@ -21,8 +21,8 @@ import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.Header;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.Tests;
-import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
@@ -53,7 +53,7 @@ public class MemoryOrderingTest
     private static volatile String failedMessage = null;
 
     @RegisterExtension
-    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
+    public final SystemTestWatcher testWatcher = new SystemTestWatcher();
 
     private final TestMediaDriver driver = TestMediaDriver.launch(new MediaDriver.Context()
         .errorHandler(Tests::onError)

--- a/aeron-system-tests/src/test/java/io/aeron/MinFlowControlSystemTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MinFlowControlSystemTest.java
@@ -24,11 +24,7 @@ import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.Header;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.protocol.DataHeaderFlyweight;
-import io.aeron.test.InterruptAfter;
-import io.aeron.test.InterruptingTestCallback;
-import io.aeron.test.SlowTest;
-import io.aeron.test.Tests;
-import io.aeron.test.driver.MediaDriverTestWatcher;
+import io.aeron.test.*;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
@@ -80,7 +76,7 @@ public class MinFlowControlSystemTest
     private final FragmentHandler fragmentHandlerB = mock(FragmentHandler.class);
 
     @RegisterExtension
-    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
+    public final SystemTestWatcher testWatcher = new SystemTestWatcher();
 
     private void launch()
     {

--- a/aeron-system-tests/src/test/java/io/aeron/MinPositionSubscriptionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MinPositionSubscriptionTest.java
@@ -20,8 +20,8 @@ import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.Tests;
-import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -39,7 +39,7 @@ public class MinPositionSubscriptionTest
     private static final int STREAM_ID = 1001;
 
     @RegisterExtension
-    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
+    public final SystemTestWatcher testWatcher = new SystemTestWatcher();
 
     private final TestMediaDriver driver = TestMediaDriver.launch(new MediaDriver.Context()
         .errorHandler(Tests::onError)

--- a/aeron-system-tests/src/test/java/io/aeron/MultiDestinationCastTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MultiDestinationCastTest.java
@@ -22,11 +22,7 @@ import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.Header;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.protocol.DataHeaderFlyweight;
-import io.aeron.test.CountingFragmentHandler;
-import io.aeron.test.InterruptAfter;
-import io.aeron.test.InterruptingTestCallback;
-import io.aeron.test.Tests;
-import io.aeron.test.driver.MediaDriverTestWatcher;
+import io.aeron.test.*;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
@@ -89,7 +85,7 @@ public class MultiDestinationCastTest
     private final FragmentHandler fragmentHandlerC = mock(FragmentHandler.class, "fragmentHandlerC");
 
     @RegisterExtension
-    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
+    public final SystemTestWatcher testWatcher = new SystemTestWatcher();
 
     private void launch(final ErrorHandler errorHandler)
     {

--- a/aeron-system-tests/src/test/java/io/aeron/MultiDestinationSubscriptionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MultiDestinationSubscriptionTest.java
@@ -22,11 +22,7 @@ import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.Header;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.protocol.DataHeaderFlyweight;
-import io.aeron.test.InterruptAfter;
-import io.aeron.test.InterruptingTestCallback;
-import io.aeron.test.SlowTest;
-import io.aeron.test.Tests;
-import io.aeron.test.driver.MediaDriverTestWatcher;
+import io.aeron.test.*;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
@@ -86,7 +82,7 @@ public class MultiDestinationSubscriptionTest
     private final FragmentHandler copyFragmentHandler = mock(FragmentHandler.class);
 
     @RegisterExtension
-    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
+    public final SystemTestWatcher testWatcher = new SystemTestWatcher();
 
     private void launch(final ErrorHandler errorHandler)
     {

--- a/aeron-system-tests/src/test/java/io/aeron/NameReResolutionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/NameReResolutionTest.java
@@ -22,7 +22,6 @@ import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.Header;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.test.*;
-import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.RedirectingNameResolver;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.BitUtil;
@@ -84,10 +83,7 @@ public class NameReResolutionTest
     private Publication publication;
 
     @RegisterExtension
-    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
-
-    @RegisterExtension
-    public final ClusterTestWatcher clusterTestWatcher = new ClusterTestWatcher();
+    public final SystemTestWatcher systemTestWatcher = new SystemTestWatcher();
 
     @RegisterExtension
     public final InterruptingTestCallback testCallback = new InterruptingTestCallback();
@@ -111,11 +107,11 @@ public class NameReResolutionTest
 
         try
         {
-            driver = TestMediaDriver.launch(context, testWatcher);
+            driver = TestMediaDriver.launch(context, systemTestWatcher);
         }
         finally
         {
-            clusterTestWatcher.dataCollector().add(context.aeronDirectory());
+            systemTestWatcher.dataCollector().add(context.aeronDirectory());
         }
 
         client = Aeron.connect(new Aeron.Context().aeronDirectoryName(context.aeronDirectoryName()));
@@ -129,8 +125,6 @@ public class NameReResolutionTest
         {
             CloseHelper.closeAll(client, driver);
         }
-
-        assertEquals(0, clusterTestWatcher.errorCount(), "Errors observed in " + this.getClass().getSimpleName());
     }
 
     @SlowTest

--- a/aeron-system-tests/src/test/java/io/aeron/PongTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/PongTest.java
@@ -21,10 +21,10 @@ import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.Header;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.protocol.DataHeaderFlyweight;
-import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.SlowTest;
-import io.aeron.test.driver.TestMediaDriver;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.Tests;
+import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.BitUtil;
 import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
@@ -59,7 +59,7 @@ public class PongTest
     private final FragmentHandler pongHandler = mock(FragmentHandler.class);
 
     @RegisterExtension
-    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
+    public final SystemTestWatcher testWatcher = new SystemTestWatcher();
 
     @BeforeEach
     public void before()

--- a/aeron-system-tests/src/test/java/io/aeron/PubAndSubTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/PubAndSubTest.java
@@ -25,8 +25,8 @@ import io.aeron.logbuffer.Header;
 import io.aeron.logbuffer.RawBlockHandler;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.Tests;
-import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.BitUtil;
 import org.agrona.CloseHelper;
@@ -70,7 +70,7 @@ public class PubAndSubTest
     }
 
     @RegisterExtension
-    public final MediaDriverTestWatcher watcher = new MediaDriverTestWatcher();
+    public final SystemTestWatcher watcher = new SystemTestWatcher();
 
     private static final int STREAM_ID = 1001;
     private static final ThreadingMode THREADING_MODE = ThreadingMode.SHARED;

--- a/aeron-system-tests/src/test/java/io/aeron/PublicationUnblockTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/PublicationUnblockTest.java
@@ -22,8 +22,8 @@ import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.Tests;
-import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.collections.MutableInteger;
@@ -54,7 +54,7 @@ public class PublicationUnblockTest
     private static final int FRAGMENT_COUNT_LIMIT = 10;
 
     @RegisterExtension
-    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
+    public final SystemTestWatcher testWatcher = new SystemTestWatcher();
 
     private final TestMediaDriver driver = TestMediaDriver.launch(new MediaDriver.Context()
         .threadingMode(ThreadingMode.SHARED)

--- a/aeron-system-tests/src/test/java/io/aeron/PublishFromArbitraryPositionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/PublishFromArbitraryPositionTest.java
@@ -22,8 +22,8 @@ import io.aeron.logbuffer.FrameDescriptor;
 import io.aeron.protocol.DataHeaderFlyweight;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.Tests;
-import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.BitUtil;
 import org.agrona.CloseHelper;
@@ -53,7 +53,7 @@ public class PublishFromArbitraryPositionTest
     private final long seed = System.nanoTime();
 
     @RegisterExtension
-    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
+    public final SystemTestWatcher testWatcher = new SystemTestWatcher();
 
     private final TestMediaDriver driver = TestMediaDriver.launch(new MediaDriver.Context()
         .errorHandler(Tests::onError)

--- a/aeron-system-tests/src/test/java/io/aeron/ReentrantClientTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ReentrantClientTest.java
@@ -17,9 +17,9 @@ package io.aeron;
 
 import io.aeron.driver.MediaDriver;
 import io.aeron.exceptions.AeronException;
-import io.aeron.test.driver.MediaDriverTestWatcher;
-import io.aeron.test.driver.TestMediaDriver;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.Tests;
+import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.ErrorHandler;
 import org.agrona.collections.MutableReference;
@@ -29,16 +29,12 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 public class ReentrantClientTest
 {
     @RegisterExtension
-    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
+    public final SystemTestWatcher testWatcher = new SystemTestWatcher();
 
     private final TestMediaDriver mediaDriver = TestMediaDriver.launch(new MediaDriver.Context()
         .errorHandler(Tests::onError)

--- a/aeron-system-tests/src/test/java/io/aeron/RegistrationAndOwnerTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/RegistrationAndOwnerTest.java
@@ -31,8 +31,8 @@
 package io.aeron;
 
 import io.aeron.driver.MediaDriver;
-import io.aeron.test.*;
-import io.aeron.test.driver.MediaDriverTestWatcher;
+import io.aeron.test.SystemTestWatcher;
+import io.aeron.test.Tests;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.concurrent.status.CountersReader;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -47,7 +47,7 @@ public class RegistrationAndOwnerTest
     private static final int STREAM_ID = 1001;
 
     @RegisterExtension
-    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
+    public final SystemTestWatcher testWatcher = new SystemTestWatcher();
 
     @ParameterizedTest
     @ValueSource(strings = { "aeron:udp?endpoint=localhost:24325", "aeron:ipc" })

--- a/aeron-system-tests/src/test/java/io/aeron/ResolvedEndpointSystemTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ResolvedEndpointSystemTest.java
@@ -20,8 +20,8 @@ import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.Tests;
-import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -52,7 +52,7 @@ public class ResolvedEndpointSystemTest
     private Aeron client;
 
     @RegisterExtension
-    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
+    public final SystemTestWatcher testWatcher = new SystemTestWatcher();
 
     @BeforeEach
     void before()

--- a/aeron-system-tests/src/test/java/io/aeron/SessionSpecificPublicationTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/SessionSpecificPublicationTest.java
@@ -20,11 +20,7 @@ import io.aeron.driver.ThreadingMode;
 import io.aeron.exceptions.RegistrationException;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.LogBufferDescriptor;
-import io.aeron.test.InterruptAfter;
-import io.aeron.test.InterruptingTestCallback;
-import io.aeron.test.SlowTest;
-import io.aeron.test.Tests;
-import io.aeron.test.driver.MediaDriverTestWatcher;
+import io.aeron.test.*;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
@@ -63,7 +59,7 @@ class SessionSpecificPublicationTest
     }
 
     @RegisterExtension
-    final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
+    final SystemTestWatcher testWatcher = new SystemTestWatcher();
 
     private final ErrorHandler mockErrorHandler = mock(ErrorHandler.class);
     private final MediaDriver.Context mediaDriverContext = new MediaDriver.Context()

--- a/aeron-system-tests/src/test/java/io/aeron/SpecifiedPositionPublicationTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/SpecifiedPositionPublicationTest.java
@@ -19,7 +19,7 @@ import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.exceptions.RegistrationException;
 import io.aeron.logbuffer.LogBufferDescriptor;
-import io.aeron.test.driver.MediaDriverTestWatcher;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.ErrorHandler;
 import org.junit.jupiter.api.Test;
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.mock;
 class SpecifiedPositionPublicationTest
 {
     @RegisterExtension
-    final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
+    final SystemTestWatcher testWatcher = new SystemTestWatcher();
 
     @Test
     void shouldRejectSpecifiedPositionForConcurrentPublications()

--- a/aeron-system-tests/src/test/java/io/aeron/SpySimulatedConnectionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/SpySimulatedConnectionTest.java
@@ -22,8 +22,8 @@ import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.protocol.DataHeaderFlyweight;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.Tests;
-import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.collections.MutableInteger;
@@ -76,7 +76,7 @@ public class SpySimulatedConnectionTest
     private final FragmentHandler fragmentHandlerSub = (buffer1, offset, length, header) -> fragmentCountSub.value++;
 
     @RegisterExtension
-    public final MediaDriverTestWatcher watcher = new MediaDriverTestWatcher();
+    public final SystemTestWatcher watcher = new SystemTestWatcher();
 
     private void launch()
     {

--- a/aeron-system-tests/src/test/java/io/aeron/SpySubscriptionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/SpySubscriptionTest.java
@@ -21,8 +21,8 @@ import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.Tests;
-import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.collections.MutableInteger;
@@ -62,7 +62,7 @@ public class SpySubscriptionTest
     private final FragmentHandler fragmentHandlerSub = (buffer1, offset, length, header) -> fragmentCountSub.value++;
 
     @RegisterExtension
-    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
+    public final SystemTestWatcher testWatcher = new SystemTestWatcher();
 
     private final TestMediaDriver driver = TestMediaDriver.launch(new MediaDriver.Context()
         .errorHandler(Tests::onError)

--- a/aeron-system-tests/src/test/java/io/aeron/TaggedFlowControlSystemTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/TaggedFlowControlSystemTest.java
@@ -21,11 +21,7 @@ import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.Header;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.protocol.DataHeaderFlyweight;
-import io.aeron.test.InterruptAfter;
-import io.aeron.test.InterruptingTestCallback;
-import io.aeron.test.SlowTest;
-import io.aeron.test.Tests;
-import io.aeron.test.driver.MediaDriverTestWatcher;
+import io.aeron.test.*;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.*;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -80,7 +76,7 @@ public class TaggedFlowControlSystemTest
     private final FragmentHandler fragmentHandlerB = mock(FragmentHandler.class);
 
     @RegisterExtension
-    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
+    public final SystemTestWatcher testWatcher = new SystemTestWatcher();
 
     private void launch()
     {

--- a/aeron-system-tests/src/test/java/io/aeron/TermBufferLengthTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/TermBufferLengthTest.java
@@ -17,8 +17,8 @@ package io.aeron;
 
 import io.aeron.driver.MediaDriver;
 import io.aeron.logbuffer.LogBufferDescriptor;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.Tests;
-import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -32,7 +32,7 @@ public class TermBufferLengthTest
     private static final int STREAM_ID = 1001;
 
     @RegisterExtension
-    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
+    public final SystemTestWatcher testWatcher = new SystemTestWatcher();
 
     @ParameterizedTest
     @ValueSource(strings = {

--- a/aeron-system-tests/src/test/java/io/aeron/TwoBufferOfferMessageTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/TwoBufferOfferMessageTest.java
@@ -20,8 +20,8 @@ import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.Tests;
-import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.collections.MutableReference;
@@ -41,7 +41,7 @@ public class TwoBufferOfferMessageTest
     private static final int FRAGMENT_COUNT_LIMIT = 10;
 
     @RegisterExtension
-    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
+    public final SystemTestWatcher testWatcher = new SystemTestWatcher();
 
     private final MediaDriver.Context driverContext = new MediaDriver.Context()
         .errorHandler(Tests::onError)

--- a/aeron-system-tests/src/test/java/io/aeron/UntetheredSubscriptionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/UntetheredSubscriptionTest.java
@@ -21,8 +21,8 @@ import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.protocol.DataHeaderFlyweight;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.Tests;
-import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -58,7 +58,7 @@ public class UntetheredSubscriptionTest
     private static final int MESSAGE_LENGTH = 512 - DataHeaderFlyweight.HEADER_LENGTH;
 
     @RegisterExtension
-    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
+    public final SystemTestWatcher testWatcher = new SystemTestWatcher();
 
     private final TestMediaDriver driver = TestMediaDriver.launch(new MediaDriver.Context()
         .errorHandler(Tests::onError)

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveAuthenticationTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveAuthenticationTest.java
@@ -24,8 +24,9 @@ import io.aeron.security.Authenticator;
 import io.aeron.security.AuthenticatorSupplier;
 import io.aeron.security.CredentialsSupplier;
 import io.aeron.security.SessionProxy;
-import io.aeron.test.*;
-import io.aeron.test.driver.MediaDriverTestWatcher;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.SystemUtil;
@@ -72,10 +73,7 @@ public class ArchiveAuthenticationTest
     private final String aeronDirectoryName = CommonContext.generateRandomDirName();
 
     @RegisterExtension
-    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
-
-    @RegisterExtension
-    public final ClusterTestWatcher clusterTestWatcher = new ClusterTestWatcher();
+    public final SystemTestWatcher systemTestWatcher = new SystemTestWatcher();
 
     @BeforeEach
     void setUp()
@@ -86,8 +84,6 @@ public class ArchiveAuthenticationTest
     public void after()
     {
         CloseHelper.closeAll(aeronArchive, aeron, archive, driver);
-
-        assertEquals(0, clusterTestWatcher.errorCount(), "Errors observed in " + this.getClass().getSimpleName());
     }
 
     @Test
@@ -374,13 +370,13 @@ public class ArchiveAuthenticationTest
 
         try
         {
-            driver = TestMediaDriver.launch(mediaDriverCtx, testWatcher);
+            driver = TestMediaDriver.launch(mediaDriverCtx, systemTestWatcher);
             archive = Archive.launch(archiveCtx);
         }
         finally
         {
-            clusterTestWatcher.dataCollector().add(mediaDriverCtx.aeronDirectory());
-            clusterTestWatcher.dataCollector().add(archiveCtx.archiveDir());
+            systemTestWatcher.dataCollector().add(mediaDriverCtx.aeronDirectory());
+            systemTestWatcher.dataCollector().add(archiveCtx.archiveDir());
         }
     }
 

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveDeleteAndRestartTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveDeleteAndRestartTest.java
@@ -22,8 +22,10 @@ import io.aeron.archive.codecs.SourceLocation;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.samples.archive.RecordingDescriptorCollector;
-import io.aeron.test.*;
-import io.aeron.test.driver.MediaDriverTestWatcher;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
+import io.aeron.test.Tests;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.SystemUtil;
@@ -53,10 +55,7 @@ public class ArchiveDeleteAndRestartTest
     public final TestWatcher randomSeedWatcher = ArchiveTests.newWatcher(seed);
 
     @RegisterExtension
-    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
-
-    @RegisterExtension
-    public final ClusterTestWatcher clusterTestWatcher = new ClusterTestWatcher();
+    public final SystemTestWatcher systemTestWatcher = new SystemTestWatcher();
 
     private TestMediaDriver driver;
     private Archive archive;
@@ -92,13 +91,13 @@ public class ArchiveDeleteAndRestartTest
 
         try
         {
-            driver = TestMediaDriver.launch(driverCtx, testWatcher);
+            driver = TestMediaDriver.launch(driverCtx, systemTestWatcher);
             archive = Archive.launch(archiveContext.clone());
         }
         finally
         {
-            clusterTestWatcher.dataCollector().add(driverCtx.aeronDirectory());
-            clusterTestWatcher.dataCollector().add(archiveContext.archiveDir());
+            systemTestWatcher.dataCollector().add(driverCtx.aeronDirectory());
+            systemTestWatcher.dataCollector().add(archiveContext.archiveDir());
         }
         client = Aeron.connect();
     }
@@ -107,8 +106,6 @@ public class ArchiveDeleteAndRestartTest
     public void after()
     {
         CloseHelper.closeAll(client, archive, driver);
-
-        assertEquals(0, clusterTestWatcher.errorCount(), "Errors observed in " + this.getClass().getSimpleName());
     }
 
     @InterruptAfter(10)

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveTest.java
@@ -26,8 +26,10 @@ import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.FrameDescriptor;
 import io.aeron.logbuffer.Header;
-import io.aeron.test.*;
-import io.aeron.test.driver.MediaDriverTestWatcher;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
+import io.aeron.test.Tests;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.*;
 import org.agrona.collections.MutableBoolean;
@@ -82,10 +84,7 @@ public class ArchiveTest
     public final TestWatcher randomSeedWatcher = ArchiveTests.newWatcher(seed);
 
     @RegisterExtension
-    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
-
-    @RegisterExtension
-    public final ClusterTestWatcher clusterTestWatcher = new ClusterTestWatcher();
+    public final SystemTestWatcher systemTestWatcher = new SystemTestWatcher();
 
     private long controlSessionId;
     private String publishUri;
@@ -145,7 +144,7 @@ public class ArchiveTest
             .idleStrategySupplier(YieldingIdleStrategy::new);
         try
         {
-            driver = TestMediaDriver.launch(driverCtx, testWatcher);
+            driver = TestMediaDriver.launch(driverCtx, systemTestWatcher);
 
             if (threadingMode == ThreadingMode.INVOKER)
             {
@@ -156,8 +155,8 @@ public class ArchiveTest
         }
         finally
         {
-            clusterTestWatcher.dataCollector().add(driverCtx.aeronDirectory());
-            clusterTestWatcher.dataCollector().add(archiveContext.archiveDir());
+            systemTestWatcher.dataCollector().add(driverCtx.aeronDirectory());
+            systemTestWatcher.dataCollector().add(archiveContext.archiveDir());
         }
 
         client = Aeron.connect();
@@ -202,8 +201,6 @@ public class ArchiveTest
         {
             CloseHelper.closeAll(client, archive, driver);
         }
-
-        assertEquals(0, clusterTestWatcher.errorCount(), "Errors observed in " + this.getClass().getSimpleName());
     }
 
     @ParameterizedTest

--- a/aeron-system-tests/src/test/java/io/aeron/archive/BasicArchiveTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/BasicArchiveTest.java
@@ -21,8 +21,10 @@ import io.aeron.archive.client.ArchiveException;
 import io.aeron.archive.status.RecordingPos;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
-import io.aeron.test.*;
-import io.aeron.test.driver.MediaDriverTestWatcher;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
+import io.aeron.test.Tests;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.SystemUtil;
@@ -67,10 +69,7 @@ public class BasicArchiveTest
     private AeronArchive aeronArchive;
 
     @RegisterExtension
-    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
-
-    @RegisterExtension
-    public final ClusterTestWatcher clusterTestWatcher = new ClusterTestWatcher();
+    public final SystemTestWatcher systemTestWatcher = new SystemTestWatcher();
 
     private File archiveDir;
 
@@ -99,13 +98,13 @@ public class BasicArchiveTest
 
         try
         {
-            driver = TestMediaDriver.launch(driverCtx, testWatcher);
+            driver = TestMediaDriver.launch(driverCtx, systemTestWatcher);
             archive = Archive.launch(archiveCtx);
         }
         finally
         {
-            clusterTestWatcher.dataCollector().add(driverCtx.aeronDirectory());
-            clusterTestWatcher.dataCollector().add(archiveCtx.archiveDir());
+            systemTestWatcher.dataCollector().add(driverCtx.aeronDirectory());
+            systemTestWatcher.dataCollector().add(archiveCtx.archiveDir());
         }
 
         aeron = Aeron.connect(
@@ -121,7 +120,6 @@ public class BasicArchiveTest
     public void after()
     {
         CloseHelper.closeAll(aeronArchive, aeron, archive, driver);
-        assertEquals(0, clusterTestWatcher.errorCount(), "Errors observed in " + this.getClass().getSimpleName());
     }
 
     @Test

--- a/aeron-system-tests/src/test/java/io/aeron/archive/CatalogWithJumboRecordingsAndGapsTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/CatalogWithJumboRecordingsAndGapsTest.java
@@ -20,8 +20,9 @@ import io.aeron.CommonContext;
 import io.aeron.archive.client.AeronArchive;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
-import io.aeron.test.*;
-import io.aeron.test.driver.MediaDriverTestWatcher;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.collections.MutableInteger;
@@ -77,10 +78,7 @@ class CatalogWithJumboRecordingsAndGapsTest
     private AeronArchive aeronArchive;
 
     @RegisterExtension
-    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
-
-    @RegisterExtension
-    public final ClusterTestWatcher clusterTestWatcher = new ClusterTestWatcher();
+    public final SystemTestWatcher systemTestWatcher = new SystemTestWatcher();
 
     @BeforeEach
     void before()
@@ -137,13 +135,13 @@ class CatalogWithJumboRecordingsAndGapsTest
 
         try
         {
-            mediaDriver = TestMediaDriver.launch(driverCtx, testWatcher);
+            mediaDriver = TestMediaDriver.launch(driverCtx, systemTestWatcher);
             archive = Archive.launch(archiveCtx);
         }
         finally
         {
-            clusterTestWatcher.dataCollector().add(driverCtx.aeronDirectory());
-            clusterTestWatcher.dataCollector().add(archiveCtx.archiveDir());
+            systemTestWatcher.dataCollector().add(driverCtx.aeronDirectory());
+            systemTestWatcher.dataCollector().add(archiveCtx.archiveDir());
         }
 
         aeron = Aeron.connect(
@@ -159,8 +157,6 @@ class CatalogWithJumboRecordingsAndGapsTest
     void after()
     {
         CloseHelper.closeAll(aeronArchive, aeron, archive, mediaDriver);
-
-        assertEquals(0, clusterTestWatcher.errorCount(), "Errors observed in " + this.getClass().getSimpleName());
     }
 
     @Test

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ExtendRecordingTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ExtendRecordingTest.java
@@ -27,8 +27,10 @@ import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.samples.archive.RecordingDescriptor;
 import io.aeron.samples.archive.RecordingDescriptorCollector;
-import io.aeron.test.*;
-import io.aeron.test.driver.MediaDriverTestWatcher;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
+import io.aeron.test.Tests;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.ExpandableArrayBuffer;
@@ -93,10 +95,7 @@ public class ExtendRecordingTest
         (controlSessionId, correlationId, relevantId, code, errorMessage) -> errors.add(errorMessage);
 
     @RegisterExtension
-    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
-
-    @RegisterExtension
-    public final ClusterTestWatcher clusterTestWatcher = new ClusterTestWatcher();
+    public final SystemTestWatcher systemTestWatcher = new SystemTestWatcher();
 
     @BeforeEach
     public void before()
@@ -125,13 +124,13 @@ public class ExtendRecordingTest
 
         try
         {
-            driver = TestMediaDriver.launch(driverCtx, testWatcher);
+            driver = TestMediaDriver.launch(driverCtx, systemTestWatcher);
             archive = Archive.launch(archiveCtx);
         }
         finally
         {
-            clusterTestWatcher.dataCollector().add(driverCtx.aeronDirectory());
-            clusterTestWatcher.dataCollector().add(archiveCtx.archiveDir());
+            systemTestWatcher.dataCollector().add(driverCtx.aeronDirectory());
+            systemTestWatcher.dataCollector().add(archiveCtx.archiveDir());
         }
 
         aeron = Aeron.connect(
@@ -147,8 +146,6 @@ public class ExtendRecordingTest
     public void after()
     {
         CloseHelper.closeAll(aeronArchive, aeron, archive, driver);
-
-        assertEquals(0, clusterTestWatcher.errorCount(), "Errors observed in " + this.getClass().getSimpleName());
     }
 
     @Test

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ManageRecordingHistoryTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ManageRecordingHistoryTest.java
@@ -26,8 +26,9 @@ import io.aeron.archive.status.RecordingPos;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.LogBufferDescriptor;
-import io.aeron.test.*;
-import io.aeron.test.driver.MediaDriverTestWatcher;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.SystemUtil;
@@ -65,10 +66,7 @@ public class ManageRecordingHistoryTest
     private AeronArchive aeronArchive;
 
     @RegisterExtension
-    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
-
-    @RegisterExtension
-    public final ClusterTestWatcher clusterTestWatcher = new ClusterTestWatcher();
+    public final SystemTestWatcher systemTestWatcher = new SystemTestWatcher();
 
     @BeforeEach
     public void before()
@@ -91,13 +89,13 @@ public class ManageRecordingHistoryTest
 
         try
         {
-            driver = TestMediaDriver.launch(driverCtx, testWatcher);
+            driver = TestMediaDriver.launch(driverCtx, systemTestWatcher);
             archive = Archive.launch(archiveCtx);
         }
         finally
         {
-            clusterTestWatcher.dataCollector().add(driverCtx.aeronDirectory());
-            clusterTestWatcher.dataCollector().add(archiveCtx.archiveDir());
+            systemTestWatcher.dataCollector().add(driverCtx.aeronDirectory());
+            systemTestWatcher.dataCollector().add(archiveCtx.archiveDir());
         }
 
         aeron = Aeron.connect();
@@ -111,8 +109,6 @@ public class ManageRecordingHistoryTest
     public void after()
     {
         CloseHelper.closeAll(aeronArchive, aeron, archive, driver);
-
-        assertEquals(0, clusterTestWatcher.errorCount(), "Errors observed in " + this.getClass().getSimpleName());
     }
 
     @Test

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ReplicateRecordingTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ReplicateRecordingTest.java
@@ -22,8 +22,10 @@ import io.aeron.archive.codecs.RecordingSignal;
 import io.aeron.archive.status.RecordingPos;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
-import io.aeron.test.*;
-import io.aeron.test.driver.MediaDriverTestWatcher;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
+import io.aeron.test.Tests;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.SystemUtil;
@@ -81,10 +83,7 @@ public class ReplicateRecordingTest
     private AeronArchive dstAeronArchive;
 
     @RegisterExtension
-    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
-
-    @RegisterExtension
-    public final ClusterTestWatcher clusterTestWatcher = new ClusterTestWatcher();
+    public final SystemTestWatcher systemTestWatcher = new SystemTestWatcher();
 
 
     @BeforeEach
@@ -135,17 +134,17 @@ public class ReplicateRecordingTest
 
         try
         {
-            srcDriver = TestMediaDriver.launch(srcContext, testWatcher);
+            srcDriver = TestMediaDriver.launch(srcContext, systemTestWatcher);
             srcArchive = Archive.launch(srcArchiveCtx);
-            dstDriver = TestMediaDriver.launch(dstContext, testWatcher);
+            dstDriver = TestMediaDriver.launch(dstContext, systemTestWatcher);
             dstArchive = Archive.launch(dstArchiveCtx);
         }
         finally
         {
-            clusterTestWatcher.dataCollector().add(srcContext.aeronDirectory());
-            clusterTestWatcher.dataCollector().add(dstContext.aeronDirectory());
-            clusterTestWatcher.dataCollector().add(dstArchiveCtx.archiveDir());
-            clusterTestWatcher.dataCollector().add(srcArchiveCtx.archiveDir());
+            systemTestWatcher.dataCollector().add(srcContext.aeronDirectory());
+            systemTestWatcher.dataCollector().add(dstContext.aeronDirectory());
+            systemTestWatcher.dataCollector().add(dstArchiveCtx.archiveDir());
+            systemTestWatcher.dataCollector().add(srcArchiveCtx.archiveDir());
         }
 
         srcAeron = Aeron.connect(
@@ -183,8 +182,6 @@ public class ReplicateRecordingTest
             dstArchive,
             dstDriver,
             srcDriver);
-
-        assertEquals(0, clusterTestWatcher.errorCount(), "Errors observed in " + this.getClass().getSimpleName());
     }
 
     @Test

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/AppointedLeaderTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/AppointedLeaderTest.java
@@ -16,12 +16,11 @@
 package io.aeron.cluster;
 
 import io.aeron.cluster.service.Cluster;
-import io.aeron.test.ClusterTestWatcher;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.cluster.TestCluster;
 import io.aeron.test.cluster.TestNode;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -34,23 +33,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class AppointedLeaderTest
 {
     @RegisterExtension
-    public final ClusterTestWatcher clusterTestWatcher = new ClusterTestWatcher();
+    public final SystemTestWatcher systemTestWatcher = new SystemTestWatcher();
 
     private static final int LEADER_ID = 1;
-
-    @AfterEach
-    void tearDown()
-    {
-        assertEquals(
-            0, clusterTestWatcher.errorCount(), "Errors observed in cluster test");
-    }
 
     @Test
     @InterruptAfter(20)
     public void shouldConnectAndSendKeepAlive()
     {
         final TestCluster cluster = aCluster().withStaticNodes(3).withAppointedLeader(LEADER_ID).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
         assertEquals(LEADER_ID, leader.index());
@@ -65,7 +57,7 @@ public class AppointedLeaderTest
     public void shouldEchoMessagesViaService()
     {
         final TestCluster cluster = aCluster().withStaticNodes(3).withAppointedLeader(LEADER_ID).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
         assertEquals(LEADER_ID, leader.index());

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterBackupTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterBackupTest.java
@@ -16,14 +16,13 @@
 package io.aeron.cluster;
 
 import io.aeron.cluster.client.AeronCluster;
-import io.aeron.test.ClusterTestWatcher;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.SlowTest;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.cluster.TestBackupNode;
 import io.aeron.test.cluster.TestCluster;
 import io.aeron.test.cluster.TestNode;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -38,21 +37,14 @@ import static org.junit.jupiter.api.Assertions.*;
 public class ClusterBackupTest
 {
     @RegisterExtension
-    final ClusterTestWatcher clusterTestWatcher = new ClusterTestWatcher();
-
-    @AfterEach
-    void tearDown()
-    {
-        assertEquals(
-            0, clusterTestWatcher.errorCount(), "Errors observed in cluster test");
-    }
+    final SystemTestWatcher systemTestWatcher = new SystemTestWatcher();
 
     @Test
     @InterruptAfter(30)
     public void shouldBackupClusterNoSnapshotsAndEmptyLog()
     {
         final TestCluster cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         cluster.awaitLeader();
         cluster.startClusterBackupNode(true);
@@ -73,7 +65,7 @@ public class ClusterBackupTest
     public void shouldBackupClusterNoSnapshotsAndNonEmptyLog()
     {
         final TestCluster cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
 
@@ -103,7 +95,7 @@ public class ClusterBackupTest
     public void shouldBackupClusterNoSnapshotsAndThenSendMessages()
     {
         final TestCluster cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
         cluster.startClusterBackupNode(true);
@@ -133,7 +125,7 @@ public class ClusterBackupTest
     public void shouldBackupClusterWithSnapshot()
     {
         final TestCluster cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
 
@@ -166,7 +158,7 @@ public class ClusterBackupTest
     public void shouldBackupClusterAfterCleanShutdown()
     {
         final TestCluster cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
 
@@ -203,7 +195,7 @@ public class ClusterBackupTest
     public void shouldBackupClusterWithSnapshotAndNonEmptyLog()
     {
         final TestCluster cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
 
@@ -243,7 +235,7 @@ public class ClusterBackupTest
     public void shouldBackupClusterWithSnapshotThenSend()
     {
         final TestCluster cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
 
@@ -283,7 +275,7 @@ public class ClusterBackupTest
     public void shouldBeAbleToGetTimeOfNextBackupQuery()
     {
         final TestCluster cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         cluster.awaitLeader();
         final TestBackupNode backupNode = cluster.startClusterBackupNode(true);
@@ -299,7 +291,7 @@ public class ClusterBackupTest
     public void shouldBackupClusterNoSnapshotsAndNonEmptyLogWithReQuery()
     {
         final TestCluster cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
 
@@ -337,7 +329,7 @@ public class ClusterBackupTest
     public void shouldBackupClusterNoSnapshotsAndNonEmptyLogAfterFailure()
     {
         final TestCluster cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leaderOne = cluster.awaitLeader();
 
@@ -369,7 +361,7 @@ public class ClusterBackupTest
     public void shouldBackupClusterNoSnapshotsAndNonEmptyLogWithFailure()
     {
         final TestCluster cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leaderOne = cluster.awaitLeader();
 

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterNetworkTopologyTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterNetworkTopologyTest.java
@@ -76,7 +76,7 @@ public class ClusterNetworkTopologyTest
     private static final List<String> INTERNAL_HOSTNAMES = Arrays.asList("10.42.1.10", "10.42.1.11", "10.42.1.12");
 
     @RegisterExtension
-    public final ClusterTestWatcher clusterTestWatcher = new ClusterTestWatcher();
+    public final SystemTestWatcher systemTestWatcher = new SystemTestWatcher();
 
     private File baseDir;
 
@@ -214,12 +214,12 @@ public class ClusterNetworkTopologyTest
     {
         for (int nodeId = 0; nodeId < nodeCount; nodeId++)
         {
-            clusterTestWatcher.dataCollector().add(
+            systemTestWatcher.dataCollector().add(
                 new File(CommonContext.getAeronDirectoryName() + "-" + nodeId + "-driver"));
-            clusterTestWatcher.dataCollector().add(new File(clusterNodeDir(nodeId), ClusterConfig.ARCHIVE_SUB_DIR));
-            clusterTestWatcher.dataCollector().add(new File(clusterNodeDir(nodeId), ClusterConfig.CLUSTER_SUB_DIR));
-            clusterTestWatcher.dataCollector().add(new File(clusterNodeDir(nodeId), "event.log"));
-            clusterTestWatcher.dataCollector().add(new File(clusterNodeDir(nodeId), "command.out"));
+            systemTestWatcher.dataCollector().add(new File(clusterNodeDir(nodeId), ClusterConfig.ARCHIVE_SUB_DIR));
+            systemTestWatcher.dataCollector().add(new File(clusterNodeDir(nodeId), ClusterConfig.CLUSTER_SUB_DIR));
+            systemTestWatcher.dataCollector().add(new File(clusterNodeDir(nodeId), "event.log"));
+            systemTestWatcher.dataCollector().add(new File(clusterNodeDir(nodeId), "command.out"));
         }
     }
 

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
@@ -23,7 +23,6 @@ import io.aeron.test.cluster.TestCluster;
 import io.aeron.test.cluster.TestNode;
 import org.agrona.collections.Hashing;
 import org.agrona.collections.MutableInteger;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -35,7 +34,7 @@ import java.util.zip.CRC32;
 import static io.aeron.cluster.service.Cluster.Role.FOLLOWER;
 import static io.aeron.cluster.service.Cluster.Role.LEADER;
 import static io.aeron.logbuffer.FrameDescriptor.computeMaxMessageLength;
-import static io.aeron.test.ClusterTestWatcher.UNKNOWN_HOST_FILTER;
+import static io.aeron.test.SystemTestWatcher.UNKNOWN_HOST_FILTER;
 import static io.aeron.test.Tests.awaitAvailableWindow;
 import static io.aeron.test.cluster.ClusterTests.*;
 import static io.aeron.test.cluster.TestCluster.*;
@@ -50,22 +49,16 @@ import static org.junit.jupiter.api.Assertions.*;
 public class ClusterTest
 {
     @RegisterExtension
-    public final ClusterTestWatcher clusterTestWatcher = new ClusterTestWatcher();
+    public final SystemTestWatcher systemTestWatcher = new SystemTestWatcher();
 
     private TestCluster cluster = null;
-
-    @AfterEach
-    void tearDown()
-    {
-        assertEquals(0, clusterTestWatcher.errorCount(), "Errors observed in cluster test");
-    }
 
     @Test
     @InterruptAfter(30)
     public void shouldStopFollowerAndRestartFollower()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         cluster.awaitLeader();
         TestNode follower = cluster.followers().get(0);
@@ -84,7 +77,7 @@ public class ClusterTest
     public void shouldNotifyClientOfNewLeader()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
 
@@ -100,7 +93,7 @@ public class ClusterTest
     public void shouldStopLeaderAndFollowersThenRestartAllWithSnapshot()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
 
@@ -120,7 +113,7 @@ public class ClusterTest
     public void shouldShutdownClusterAndRestartWithSnapshots()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
 
@@ -148,7 +141,7 @@ public class ClusterTest
     public void shouldAbortClusterAndRestart()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
 
@@ -178,7 +171,7 @@ public class ClusterTest
     public void shouldAbortClusterOnTerminationTimeout()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
         final List<TestNode> followers = cluster.followers();
@@ -210,7 +203,7 @@ public class ClusterTest
     public void shouldEchoMessages()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         cluster.awaitLeader();
         cluster.connectClient();
@@ -227,7 +220,7 @@ public class ClusterTest
     public void shouldHandleLeaderFailOverWhenNameIsNotResolvable()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster).ignoreErrorsMatching(UNKNOWN_HOST_FILTER);
+        systemTestWatcher.cluster(cluster).ignoreErrorsMatching(UNKNOWN_HOST_FILTER);
 
         final TestNode originalLeader = cluster.awaitLeader();
         cluster.connectClient();
@@ -255,7 +248,7 @@ public class ClusterTest
         final int initiallyUnresolvableNodeId = 1;
 
         cluster = aCluster().withStaticNodes(3).withInvalidNameResolution(initiallyUnresolvableNodeId).start();
-        clusterTestWatcher.cluster(cluster).ignoreErrorsMatching(UNKNOWN_HOST_FILTER);
+        systemTestWatcher.cluster(cluster).ignoreErrorsMatching(UNKNOWN_HOST_FILTER);
 
         cluster.awaitLeader();
         cluster.connectClient();
@@ -277,7 +270,7 @@ public class ClusterTest
     public void shouldHandleClusterStartWhereMostNamesBecomeResolvableDuringElection()
     {
         cluster = aCluster().withStaticNodes(3).withInvalidNameResolution(0).withInvalidNameResolution(2).start();
-        clusterTestWatcher.cluster(cluster).ignoreErrorsMatching(UNKNOWN_HOST_FILTER);
+        systemTestWatcher.cluster(cluster).ignoreErrorsMatching(UNKNOWN_HOST_FILTER);
 
         awaitElectionState(cluster.node(1), ElectionState.CANVASS);
 
@@ -300,7 +293,7 @@ public class ClusterTest
     public void shouldEchoMessagesThenContinueOnNewLeader()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode originalLeader = cluster.awaitLeader();
         cluster.connectClient();
@@ -334,7 +327,7 @@ public class ClusterTest
     public void shouldStopLeaderAndRestartAsFollower()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode originalLeader = cluster.awaitLeader();
 
@@ -352,7 +345,7 @@ public class ClusterTest
     public void shouldStopLeaderAndRestartAsFollowerWithSendingAfter()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode originalLeader = cluster.awaitLeader();
 
@@ -375,7 +368,7 @@ public class ClusterTest
     public void shouldStopLeaderAndRestartAsFollowerWithSendingAfterThenStopLeader()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode originalLeader = cluster.awaitLeader();
 
@@ -403,7 +396,7 @@ public class ClusterTest
     public void shouldAcceptMessagesAfterSingleNodeCleanRestart()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         cluster.awaitLeader();
         TestNode follower = cluster.followers().get(0);
@@ -428,7 +421,7 @@ public class ClusterTest
     public void shouldReplaySnapshotTakenWhileDown()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
         final List<TestNode> followers = cluster.followers();
@@ -461,7 +454,7 @@ public class ClusterTest
     public void shouldTolerateMultipleLeaderFailures()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode firstLeader = cluster.awaitLeader();
         cluster.stopNode(firstLeader);
@@ -488,7 +481,7 @@ public class ClusterTest
     public void shouldRecoverAfterTwoLeadersNodesFailAndComeBackUpAtSameTime()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode firstLeader = cluster.awaitLeader();
 
@@ -522,7 +515,7 @@ public class ClusterTest
     public void shouldAcceptMessagesAfterTwoNodeCleanRestart()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         cluster.awaitLeader();
         final List<TestNode> followers = cluster.followers();
@@ -556,7 +549,7 @@ public class ClusterTest
     public void shouldRecoverWithUncommittedMessagesAfterRestartWhenNewCommitPosExceedsPreviousAppendedPos()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
         final List<TestNode> followers = cluster.followers();
@@ -610,7 +603,7 @@ public class ClusterTest
     public void shouldRecoverWithUncommittedMessagesAfterRestartWhenNewCommitPosIsLessThanPreviousAppendedPos()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
         final List<TestNode> followers = cluster.followers();
@@ -653,7 +646,7 @@ public class ClusterTest
     public void shouldCallOnRoleChangeOnBecomingLeader()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leaderOne = cluster.awaitLeader();
         final List<TestNode> followers = cluster.followers();
@@ -681,7 +674,7 @@ public class ClusterTest
     public void shouldLoseLeadershipWhenNoActiveQuorumOfFollowers()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
         final TestNode.TestService service = leader.service();
@@ -710,7 +703,7 @@ public class ClusterTest
     public void shouldTerminateLeaderWhenServiceStops()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
         cluster.connectClient();
@@ -731,7 +724,7 @@ public class ClusterTest
     public void shouldEnterElectionWhenRecordingStopsOnLeader()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
         cluster.connectClient();
@@ -757,7 +750,7 @@ public class ClusterTest
     public void shouldRecoverFollowerWhenRecordingStops()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         cluster.awaitLeader();
 
@@ -787,7 +780,7 @@ public class ClusterTest
     public void shouldCloseClientOnTimeout()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
 
@@ -813,7 +806,7 @@ public class ClusterTest
     public void shouldRecoverWhileMessagesContinue() throws InterruptedException
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final MutableInteger messageCounter = new MutableInteger();
         final TestNode leader = cluster.awaitLeader();
@@ -858,7 +851,7 @@ public class ClusterTest
     public void shouldCatchupFromEmptyLog()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         cluster.awaitLeader();
         final List<TestNode> followers = cluster.followers();
@@ -881,7 +874,7 @@ public class ClusterTest
     public void shouldCatchupFromEmptyLogThenSnapshotAfterShutdownAndFollowerCleanStart()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
         final List<TestNode> followers = cluster.followers(2);
@@ -927,7 +920,7 @@ public class ClusterTest
     public void shouldCatchUpTwoFreshNodesAfterRestart()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
         final List<TestNode> followers = cluster.followers();
@@ -963,7 +956,7 @@ public class ClusterTest
     public void shouldReplayMultipleSnapshotsWithEmptyFollowerLog()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
 
@@ -1031,7 +1024,7 @@ public class ClusterTest
     public void shouldRecoverQuicklyAfterKillingFollowersThenRestartingOne()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
         final List<TestNode> followers = cluster.followers();
@@ -1061,7 +1054,7 @@ public class ClusterTest
     public void shouldRecoverWhenLeaderHasAppendedMoreThanFollower()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
         final List<TestNode> followers = cluster.followers();
@@ -1091,7 +1084,7 @@ public class ClusterTest
     public void shouldRecoverWhenFollowerIsMultipleTermsBehind()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode originalLeader = cluster.awaitLeader();
 
@@ -1129,7 +1122,7 @@ public class ClusterTest
     public void shouldRecoverWhenFollowerArrivesPartWayThroughTerm()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         cluster.awaitLeader();
         final TestNode followerOne = cluster.followers().get(0);
@@ -1156,7 +1149,7 @@ public class ClusterTest
     public void shouldRecoverWhenFollowerArrivePartWayThroughTermAfterMissingElection()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
         final List<TestNode> followers = cluster.followers();
@@ -1196,7 +1189,7 @@ public class ClusterTest
     void shouldRecoverWhenLastSnapshotIsMarkedInvalid()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader0 = cluster.awaitLeader();
 
@@ -1240,7 +1233,7 @@ public class ClusterTest
     void shouldRecoverWhenLastSnapshotForShutdownIsMarkedInvalid()
     {
         cluster = aCluster().withStaticNodes(1).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         TestNode leader = cluster.awaitLeader();
 
@@ -1272,7 +1265,7 @@ public class ClusterTest
     void shouldHandleMultipleElections()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader0 = cluster.awaitLeader();
 
@@ -1312,7 +1305,7 @@ public class ClusterTest
     void shouldRecoverWhenLastSnapshotIsInvalidBetweenTwoElections()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader0 = cluster.awaitLeader();
 
@@ -1364,7 +1357,7 @@ public class ClusterTest
     void shouldRecoverWhenLastTwosSnapshotsAreInvalidAfterElection()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader0 = cluster.awaitLeader();
 
@@ -1455,7 +1448,7 @@ public class ClusterTest
             .withServiceSupplier(
                 (i) -> new TestNode.TestService[]{ new TestNode.TestService(), new TestNode.ChecksumService() })
             .start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
         for (int i = 0; i < 3; i++)
@@ -1552,7 +1545,7 @@ public class ClusterTest
     private void shouldCatchUpAfterFollowerMissesMessage(final String message)
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         cluster.awaitLeader();
         TestNode follower = cluster.followers().get(0);

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterToolTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterToolTest.java
@@ -15,13 +15,12 @@
  */
 package io.aeron.cluster;
 
-import io.aeron.test.ClusterTestWatcher;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.SlowTest;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.cluster.TestCluster;
 import io.aeron.test.cluster.TestNode;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -49,21 +48,14 @@ import static org.junit.jupiter.api.Assertions.*;
 class ClusterToolTest
 {
     @RegisterExtension
-    final ClusterTestWatcher clusterTestWatcher = new ClusterTestWatcher();
-
-    @AfterEach
-    void tearDown()
-    {
-        assertEquals(
-            0, clusterTestWatcher.errorCount(), "Errors observed in cluster test");
-    }
+    final SystemTestWatcher systemTestWatcher = new SystemTestWatcher();
 
     @Test
     @InterruptAfter(30)
     void shouldHandleSnapshotOnLeaderOnly()
     {
         final TestCluster cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
         final long initialSnapshotCount = leader.consensusModule().context().snapshotCounter().get();
@@ -97,7 +89,7 @@ class ClusterToolTest
     void shouldNotSnapshotWhenSuspendedOnly()
     {
         final TestCluster cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
         final long initialSnapshotCount = leader.consensusModule().context().snapshotCounter().get();
@@ -127,7 +119,7 @@ class ClusterToolTest
     void shouldSuspendAndResume()
     {
         final TestCluster cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
         final CapturingPrintStream capturingPrintStream = new CapturingPrintStream();

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/DynamicMembershipTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/DynamicMembershipTest.java
@@ -15,13 +15,12 @@
  */
 package io.aeron.cluster;
 
-import io.aeron.test.ClusterTestWatcher;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.SlowTest;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.cluster.TestCluster;
 import io.aeron.test.cluster.TestNode;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,21 +37,14 @@ public class DynamicMembershipTest
     private TestCluster cluster = null;
 
     @RegisterExtension
-    final ClusterTestWatcher clusterTestWatcher = new ClusterTestWatcher();
-
-    @AfterEach
-    void tearDown()
-    {
-        assertEquals(
-            0, clusterTestWatcher.errorCount(), "Errors observed in cluster test");
-    }
+    final SystemTestWatcher systemTestWatcher = new SystemTestWatcher();
 
     @Test
     @InterruptAfter(30)
     public void shouldQueryClusterMembers(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
         final ClusterMembership clusterMembership = leader.clusterMembership();
@@ -67,7 +59,7 @@ public class DynamicMembershipTest
     public void shouldDynamicallyJoinClusterOfThreeNoSnapshots(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
         final TestNode dynamicMember = cluster.startDynamicNode(3, true);
@@ -86,7 +78,7 @@ public class DynamicMembershipTest
     public void shouldDynamicallyJoinClusterOfThreeNoSnapshotsThenSend(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
         final TestNode dynamicMember = cluster.startDynamicNode(3, true);
@@ -107,7 +99,7 @@ public class DynamicMembershipTest
     public void shouldDynamicallyJoinClusterOfThreeNoSnapshotsWithCatchup(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
 
@@ -127,7 +119,7 @@ public class DynamicMembershipTest
     public void shouldDynamicallyJoinClusterOfThreeWithEmptySnapshot(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
 
@@ -147,7 +139,7 @@ public class DynamicMembershipTest
     public void shouldDynamicallyJoinClusterOfThreeWithSnapshot(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
 
@@ -173,7 +165,7 @@ public class DynamicMembershipTest
     public void shouldDynamicallyJoinClusterOfThreeWithSnapshotThenSend(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
 
@@ -207,7 +199,7 @@ public class DynamicMembershipTest
     public void shouldRemoveFollower(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
         final TestNode follower = cluster.followers().get(0);
@@ -227,7 +219,7 @@ public class DynamicMembershipTest
     public void shouldRemoveLeader(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode initialLeader = cluster.awaitLeader();
 
@@ -249,7 +241,7 @@ public class DynamicMembershipTest
     public void shouldRemoveLeaderAfterDynamicNodeJoined(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode initialLeader = cluster.awaitLeader();
         final TestNode dynamicMember = cluster.startDynamicNode(3, true);
@@ -275,7 +267,7 @@ public class DynamicMembershipTest
     public void shouldRemoveLeaderAfterDynamicNodeJoinedThenRestartCluster(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode initialLeader = cluster.awaitLeader();
         final TestNode dynamicMember = cluster.startDynamicNode(3, true);
@@ -316,7 +308,7 @@ public class DynamicMembershipTest
     public void shouldJoinDynamicNodeToSingleStaticLeader(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(1).withDynamicNodes(1).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode initialLeader = cluster.awaitLeader();
         final TestNode dynamicMember = cluster.startDynamicNode(1, true);
@@ -330,7 +322,7 @@ public class DynamicMembershipTest
     public void shouldDynamicallyJoinClusterOfThreeNoSnapshotsAndRestartDynamicNode(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
         final TestNode dynamicMember = cluster.startDynamicNode(3, true);

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/MultiClusteredServicesTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/MultiClusteredServicesTest.java
@@ -29,7 +29,6 @@ import io.aeron.test.driver.RedirectingNameResolver;
 import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,13 +38,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 @ExtendWith(InterruptingTestCallback.class)
 public class MultiClusteredServicesTest
 {
     @RegisterExtension
-    public final ClusterTestWatcher clusterTestWatcher = new ClusterTestWatcher();
+    public final SystemTestWatcher systemTestWatcher = new SystemTestWatcher();
 
     final AtomicLong serviceAMessageCount = new AtomicLong(0);
     final AtomicLong serviceBMessageCount = new AtomicLong(0);
@@ -54,12 +51,6 @@ public class MultiClusteredServicesTest
     @BeforeEach
     void setUp()
     {
-    }
-
-    @AfterEach
-    void tearDown()
-    {
-        assertEquals(0, clusterTestWatcher.errorCount(), "Errors observed in " + this.getClass().getSimpleName());
     }
 
     final class ServiceA extends TestNode.TestService
@@ -120,9 +111,9 @@ public class MultiClusteredServicesTest
                 }
                 finally
                 {
-                    clusterTestWatcher.dataCollector().add(context.mediaDriverCtx.aeronDirectory());
-                    clusterTestWatcher.dataCollector().add(context.archiveCtx.archiveDir());
-                    clusterTestWatcher.dataCollector().add(context.consensusModuleCtx.clusterDir());
+                    systemTestWatcher.dataCollector().add(context.mediaDriverCtx.aeronDirectory());
+                    systemTestWatcher.dataCollector().add(context.archiveCtx.archiveDir());
+                    systemTestWatcher.dataCollector().add(context.consensusModuleCtx.clusterDir());
                 }
             });
 
@@ -136,7 +127,7 @@ public class MultiClusteredServicesTest
                 }
                 finally
                 {
-                    clusterTestWatcher.dataCollector().add(context.serviceContainerCtx.clusterDir());
+                    systemTestWatcher.dataCollector().add(context.serviceContainerCtx.clusterDir());
                 }
             });
 

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/MultiModuleSharedDriverTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/MultiModuleSharedDriverTest.java
@@ -35,7 +35,6 @@ import org.agrona.DirectBuffer;
 import org.agrona.ExpandableArrayBuffer;
 import org.agrona.SystemUtil;
 import org.agrona.collections.MutableReference;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -49,18 +48,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class MultiModuleSharedDriverTest
 {
     @RegisterExtension
-    public final ClusterTestWatcher clusterTestWatcher = new ClusterTestWatcher();
+    public final SystemTestWatcher systemTestWatcher = new SystemTestWatcher();
 
 
     @BeforeEach
     void setUp()
     {
-    }
-
-    @AfterEach
-    void tearDown()
-    {
-        assertEquals(0, clusterTestWatcher.errorCount(), "Errors observed in " + this.getClass().getSimpleName());
     }
 
     @SuppressWarnings("methodlength")
@@ -152,15 +145,15 @@ public class MultiModuleSharedDriverTest
             }
             finally
             {
-                clusterTestWatcher.dataCollector().add(moduleCtx0.clusterDir());
-                clusterTestWatcher.dataCollector().add(moduleCtx1.clusterDir());
+                systemTestWatcher.dataCollector().add(moduleCtx0.clusterDir());
+                systemTestWatcher.dataCollector().add(moduleCtx1.clusterDir());
                 CloseHelper.closeAll(client0, client1, consensusModule0, consensusModule1, container0, container1);
             }
         }
         finally
         {
-            clusterTestWatcher.dataCollector().add(driverCtx.aeronDirectory());
-            clusterTestWatcher.dataCollector().add(archiveCtx.archiveDir());
+            systemTestWatcher.dataCollector().add(driverCtx.aeronDirectory());
+            systemTestWatcher.dataCollector().add(archiveCtx.archiveDir());
         }
     }
 
@@ -168,8 +161,8 @@ public class MultiModuleSharedDriverTest
     @InterruptAfter(30)
     public void shouldSupportTwoMultiNodeClusters()
     {
-        try (MultiClusterNode node0 = new MultiClusterNode(0, clusterTestWatcher.dataCollector());
-            MultiClusterNode node1 = new MultiClusterNode(1, clusterTestWatcher.dataCollector()))
+        try (MultiClusterNode node0 = new MultiClusterNode(0, systemTestWatcher.dataCollector());
+            MultiClusterNode node1 = new MultiClusterNode(1, systemTestWatcher.dataCollector()))
         {
             final MutableReference<String> egress = new MutableReference<>();
             final EgressListener egressListener = (clusterSessionId, timestamp, buffer, offset, length, header) ->

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/MultiNodeTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/MultiNodeTest.java
@@ -17,12 +17,11 @@ package io.aeron.cluster;
 
 import io.aeron.cluster.client.AeronCluster;
 import io.aeron.cluster.service.Cluster;
-import io.aeron.test.ClusterTestWatcher;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.cluster.TestCluster;
 import io.aeron.test.cluster.TestNode;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -36,14 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class MultiNodeTest
 {
     @RegisterExtension
-    final ClusterTestWatcher clusterTestWatcher = new ClusterTestWatcher();
-
-    @AfterEach
-    void tearDown()
-    {
-        assertEquals(
-            0, clusterTestWatcher.errorCount(), "Errors observed in cluster test");
-    }
+    final SystemTestWatcher systemTestWatcher = new SystemTestWatcher();
 
     @Test
     @InterruptAfter(20)
@@ -52,7 +44,7 @@ public class MultiNodeTest
         final int appointedLeaderIndex = 1;
 
         final TestCluster cluster = aCluster().withStaticNodes(3).withAppointedLeader(appointedLeaderIndex).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
 
@@ -69,7 +61,7 @@ public class MultiNodeTest
         final int appointedLeaderIndex = 1;
 
         final TestCluster cluster = aCluster().withStaticNodes(3).withAppointedLeader(appointedLeaderIndex).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
 
@@ -96,7 +88,7 @@ public class MultiNodeTest
         final int appointedLeaderIndex = 1;
 
         final TestCluster cluster = aCluster().withStaticNodes(3).withAppointedLeader(appointedLeaderIndex).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
 
@@ -134,7 +126,7 @@ public class MultiNodeTest
             .egressChannel("aeron:udp?term-length=64k|endpoint=localhost:" + responsePort);
 
         final TestCluster cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final int numMessages = 10;
         cluster.connectClient(clientCtx);

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ServiceIpcIngressTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ServiceIpcIngressTest.java
@@ -15,38 +15,29 @@
  */
 package io.aeron.cluster;
 
-import io.aeron.test.ClusterTestWatcher;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.cluster.ClusterTests;
 import io.aeron.test.cluster.TestCluster;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static io.aeron.test.cluster.TestCluster.aCluster;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(InterruptingTestCallback.class)
 public class ServiceIpcIngressTest
 {
     @RegisterExtension
-    final ClusterTestWatcher clusterTestWatcher = new ClusterTestWatcher();
-
-    @AfterEach
-    void tearDown()
-    {
-        assertEquals(
-            0, clusterTestWatcher.errorCount(), "Errors observed in cluster test");
-    }
+    final SystemTestWatcher systemTestWatcher = new SystemTestWatcher();
 
     @Test
     @InterruptAfter(20)
     public void shouldEchoIpcMessages()
     {
         final TestCluster cluster = aCluster().withStaticNodes(3).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         cluster.awaitLeader();
         cluster.connectClient();

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/SingleNodeTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/SingleNodeTest.java
@@ -16,12 +16,11 @@
 package io.aeron.cluster;
 
 import io.aeron.cluster.service.Cluster;
-import io.aeron.test.ClusterTestWatcher;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.cluster.TestCluster;
 import io.aeron.test.cluster.TestNode;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -36,21 +35,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class SingleNodeTest
 {
     @RegisterExtension
-    final ClusterTestWatcher clusterTestWatcher = new ClusterTestWatcher();
-
-    @AfterEach
-    void tearDown()
-    {
-        assertEquals(
-            0, clusterTestWatcher.errorCount(), "Errors observed in cluster test");
-    }
+    final SystemTestWatcher systemTestWatcher = new SystemTestWatcher();
 
     @Test
     @InterruptAfter(20)
     public void shouldStartCluster()
     {
         final TestCluster cluster = aCluster().withStaticNodes(1).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
 
@@ -67,7 +59,7 @@ public class SingleNodeTest
         try
         {
             final TestCluster cluster = aCluster().withStaticNodes(1).start();
-            clusterTestWatcher.cluster(cluster);
+            systemTestWatcher.cluster(cluster);
 
             final TestNode leader = cluster.awaitLeader();
 
@@ -90,7 +82,7 @@ public class SingleNodeTest
     public void shouldReplayLog()
     {
         final TestCluster cluster = aCluster().withStaticNodes(1).start();
-        clusterTestWatcher.cluster(cluster);
+        systemTestWatcher.cluster(cluster);
 
         final TestNode leader = cluster.awaitLeader();
 

--- a/aeron-system-tests/src/test/java/io/aeron/driver/DriverNameResolverTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/driver/DriverNameResolverTest.java
@@ -17,11 +17,7 @@ package io.aeron.driver;
 
 import io.aeron.*;
 import io.aeron.logbuffer.LogBufferDescriptor;
-import io.aeron.test.InterruptAfter;
-import io.aeron.test.InterruptingTestCallback;
-import io.aeron.test.SlowTest;
-import io.aeron.test.Tests;
-import io.aeron.test.driver.MediaDriverTestWatcher;
+import io.aeron.test.*;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.collections.MutableBoolean;
@@ -52,7 +48,7 @@ public class DriverNameResolverTest
     private final Map<String, Aeron> clients = new TreeMap<>();
 
     @RegisterExtension
-    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
+    public final SystemTestWatcher testWatcher = new SystemTestWatcher();
 
     @AfterEach
     public void after()

--- a/aeron-test-support/src/main/java/io/aeron/test/MediaDriverTestUtil.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/MediaDriverTestUtil.java
@@ -13,14 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.aeron.test.driver;
+package io.aeron.test;
 
-import io.aeron.test.IgnoreStdErr;
+import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.IoUtil;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.extension.TestWatcher;
 
 import java.io.File;
 import java.io.IOException;
@@ -29,7 +27,7 @@ import java.nio.file.Files;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-public class MediaDriverTestWatcher implements TestWatcher, DriverOutputConsumer, AfterTestExecutionCallback
+class MediaDriverTestUtil
 {
     private final Map<String, ProcessDetails> outputFilesByAeronDirectoryName = new LinkedHashMap<>();
 


### PR DESCRIPTION
- Rename to SystemTestWatcher.
- Have the SystemTestWatcher automatically check for errors instead of being called a teardown method.