### PR TITLE
[Java] Extend ELECTION_STATE_CHANGE logging event with the extra information.

### DIFF
--- a/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventDissector.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventDissector.java
@@ -96,17 +96,17 @@ final class ArchiveEventDissector
         final int offset,
         final StringBuilder builder)
     {
-        int relativeOffset = dissectLogHeader(CONTEXT, eventCode, buffer, offset, builder);
+        int encodedLength = dissectLogHeader(CONTEXT, eventCode, buffer, offset, builder);
 
-        HEADER_DECODER.wrap(buffer, offset + relativeOffset);
-        relativeOffset += MessageHeaderDecoder.ENCODED_LENGTH;
+        HEADER_DECODER.wrap(buffer, offset + encodedLength);
+        encodedLength += MessageHeaderDecoder.ENCODED_LENGTH;
 
         switch (eventCode)
         {
             case CMD_IN_CONNECT:
                 CONNECT_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + relativeOffset,
+                    offset + encodedLength,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendConnect(builder);
@@ -115,7 +115,7 @@ final class ArchiveEventDissector
             case CMD_IN_CLOSE_SESSION:
                 CLOSE_SESSION_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + relativeOffset,
+                    offset + encodedLength,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendCloseSession(builder);
@@ -124,7 +124,7 @@ final class ArchiveEventDissector
             case CMD_IN_START_RECORDING:
                 START_RECORDING_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + relativeOffset,
+                    offset + encodedLength,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendStartRecording(builder);
@@ -133,7 +133,7 @@ final class ArchiveEventDissector
             case CMD_IN_STOP_RECORDING:
                 STOP_RECORDING_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + relativeOffset,
+                    offset + encodedLength,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendStopRecording(builder);
@@ -142,7 +142,7 @@ final class ArchiveEventDissector
             case CMD_IN_REPLAY:
                 REPLAY_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + relativeOffset,
+                    offset + encodedLength,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendReplay(builder);
@@ -151,7 +151,7 @@ final class ArchiveEventDissector
             case CMD_IN_STOP_REPLAY:
                 STOP_REPLAY_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + relativeOffset,
+                    offset + encodedLength,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendStopReplay(builder);
@@ -160,7 +160,7 @@ final class ArchiveEventDissector
             case CMD_IN_LIST_RECORDINGS:
                 LIST_RECORDINGS_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + relativeOffset,
+                    offset + encodedLength,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendListRecordings(builder);
@@ -169,7 +169,7 @@ final class ArchiveEventDissector
             case CMD_IN_LIST_RECORDINGS_FOR_URI:
                 LIST_RECORDINGS_FOR_URI_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + relativeOffset,
+                    offset + encodedLength,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendListRecordingsForUri(builder);
@@ -178,7 +178,7 @@ final class ArchiveEventDissector
             case CMD_IN_LIST_RECORDING:
                 LIST_RECORDING_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + relativeOffset,
+                    offset + encodedLength,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendListRecording(builder);
@@ -187,7 +187,7 @@ final class ArchiveEventDissector
             case CMD_IN_EXTEND_RECORDING:
                 EXTEND_RECORDING_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + relativeOffset,
+                    offset + encodedLength,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendExtendRecording(builder);
@@ -196,7 +196,7 @@ final class ArchiveEventDissector
             case CMD_IN_RECORDING_POSITION:
                 RECORDING_POSITION_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + relativeOffset,
+                    offset + encodedLength,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendRecordingPosition(builder);
@@ -205,7 +205,7 @@ final class ArchiveEventDissector
             case CMD_IN_TRUNCATE_RECORDING:
                 TRUNCATE_RECORDING_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + relativeOffset,
+                    offset + encodedLength,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendTruncateRecording(builder);
@@ -214,7 +214,7 @@ final class ArchiveEventDissector
             case CMD_IN_STOP_RECORDING_SUBSCRIPTION:
                 STOP_RECORDING_SUBSCRIPTION_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + relativeOffset,
+                    offset + encodedLength,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendStopRecordingSubscription(builder);
@@ -223,7 +223,7 @@ final class ArchiveEventDissector
             case CMD_IN_STOP_POSITION:
                 STOP_POSITION_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + relativeOffset,
+                    offset + encodedLength,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendStopPosition(builder);
@@ -232,7 +232,7 @@ final class ArchiveEventDissector
             case CMD_IN_FIND_LAST_MATCHING_RECORD:
                 FIND_LAST_MATCHING_RECORDING_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + relativeOffset,
+                    offset + encodedLength,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendFindLastMatchingRecord(builder);
@@ -241,7 +241,7 @@ final class ArchiveEventDissector
             case CMD_IN_LIST_RECORDING_SUBSCRIPTIONS:
                 LIST_RECORDING_SUBSCRIPTIONS_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + relativeOffset,
+                    offset + encodedLength,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendListRecordingSubscriptions(builder);
@@ -250,7 +250,7 @@ final class ArchiveEventDissector
             case CMD_IN_START_BOUNDED_REPLAY:
                 BOUNDED_REPLAY_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + relativeOffset,
+                    offset + encodedLength,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendStartBoundedReplay(builder);
@@ -259,7 +259,7 @@ final class ArchiveEventDissector
             case CMD_IN_STOP_ALL_REPLAYS:
                 STOP_ALL_REPLAYS_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + relativeOffset,
+                    offset + encodedLength,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendStopAllReplays(builder);
@@ -268,7 +268,7 @@ final class ArchiveEventDissector
             case CMD_IN_REPLICATE:
                 REPLICATE_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + relativeOffset,
+                    offset + encodedLength,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendReplicate(builder);
@@ -277,7 +277,7 @@ final class ArchiveEventDissector
             case CMD_IN_STOP_REPLICATION:
                 STOP_REPLICATION_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + relativeOffset,
+                    offset + encodedLength,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendStopReplication(builder);
@@ -286,7 +286,7 @@ final class ArchiveEventDissector
             case CMD_IN_START_POSITION:
                 START_POSITION_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + relativeOffset,
+                    offset + encodedLength,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendStartPosition(builder);
@@ -295,7 +295,7 @@ final class ArchiveEventDissector
             case CMD_IN_DETACH_SEGMENTS:
                 DETACH_SEGMENTS_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + relativeOffset,
+                    offset + encodedLength,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendDetachSegments(builder);
@@ -304,7 +304,7 @@ final class ArchiveEventDissector
             case CMD_IN_DELETE_DETACHED_SEGMENTS:
                 DELETE_DETACHED_SEGMENTS_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + relativeOffset,
+                    offset + encodedLength,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendDeleteDetachedSegments(builder);
@@ -313,7 +313,7 @@ final class ArchiveEventDissector
             case CMD_IN_PURGE_SEGMENTS:
                 PURGE_SEGMENTS_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + relativeOffset,
+                    offset + encodedLength,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendPurgeSegments(builder);
@@ -322,7 +322,7 @@ final class ArchiveEventDissector
             case CMD_IN_ATTACH_SEGMENTS:
                 ATTACH_SEGMENTS_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + relativeOffset,
+                    offset + encodedLength,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendAttachSegments(builder);
@@ -331,7 +331,7 @@ final class ArchiveEventDissector
             case CMD_IN_MIGRATE_SEGMENTS:
                 MIGRATE_SEGMENTS_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + relativeOffset,
+                    offset + encodedLength,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendMigrateSegments(builder);
@@ -340,7 +340,7 @@ final class ArchiveEventDissector
             case CMD_IN_AUTH_CONNECT:
                 AUTH_CONNECT_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + relativeOffset,
+                    offset + encodedLength,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendAuthConnect(builder);
@@ -349,7 +349,7 @@ final class ArchiveEventDissector
             case CMD_IN_KEEP_ALIVE:
                 KEEP_ALIVE_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + relativeOffset,
+                    offset + encodedLength,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendKeepAlive(builder);
@@ -358,7 +358,7 @@ final class ArchiveEventDissector
             case CMD_IN_TAGGED_REPLICATE:
                 TAGGED_REPLICATE_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + relativeOffset,
+                    offset + encodedLength,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendTaggedReplicate(builder);
@@ -367,7 +367,7 @@ final class ArchiveEventDissector
             case CMD_IN_START_RECORDING2:
                 START_RECORDING_REQUEST2_DECODER.wrap(
                     buffer,
-                    offset + relativeOffset,
+                    offset + encodedLength,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendStartRecording2(builder);
@@ -376,7 +376,7 @@ final class ArchiveEventDissector
             case CMD_IN_EXTEND_RECORDING2:
                 EXTEND_RECORDING_REQUEST2_DECODER.wrap(
                     buffer,
-                    offset + relativeOffset,
+                    offset + encodedLength,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendExtendRecording2(builder);
@@ -385,7 +385,7 @@ final class ArchiveEventDissector
             case CMD_IN_STOP_RECORDING_BY_IDENTITY:
                 STOP_RECORDING_BY_IDENTITY_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + relativeOffset,
+                    offset + encodedLength,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendStopRecordingByIdentity(builder);
@@ -394,7 +394,7 @@ final class ArchiveEventDissector
             case CMD_IN_PURGE_RECORDING:
                 PURGE_RECORDING_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + relativeOffset,
+                    offset + encodedLength,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendPurgeRecording(builder);
@@ -403,7 +403,7 @@ final class ArchiveEventDissector
             case CMD_IN_REPLICATE2:
                 REPLICATE_REQUEST2_DECODER.wrap(
                     buffer,
-                    offset + relativeOffset,
+                    offset + encodedLength,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendReplicate2(builder);
@@ -416,14 +416,14 @@ final class ArchiveEventDissector
 
     static void dissectControlResponse(final MutableDirectBuffer buffer, final int offset, final StringBuilder builder)
     {
-        int relativeOffset = dissectLogHeader(CONTEXT, CMD_OUT_RESPONSE, buffer, offset, builder);
+        int encodedLength = dissectLogHeader(CONTEXT, CMD_OUT_RESPONSE, buffer, offset, builder);
 
-        HEADER_DECODER.wrap(buffer, offset + relativeOffset);
-        relativeOffset += MessageHeaderDecoder.ENCODED_LENGTH;
+        HEADER_DECODER.wrap(buffer, offset + encodedLength);
+        encodedLength += MessageHeaderDecoder.ENCODED_LENGTH;
 
         CONTROL_RESPONSE_DECODER.wrap(
             buffer,
-            offset + relativeOffset,
+            offset + encodedLength,
             HEADER_DECODER.blockLength(),
             HEADER_DECODER.version());
 

--- a/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventEncoder.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventEncoder.java
@@ -37,21 +37,12 @@ final class ArchiveEventEncoder
         final E to,
         final long id)
     {
-        int relativeOffset = encodeLogHeader(encodingBuffer, offset, captureLength, length);
+        int encodedLength = encodeLogHeader(encodingBuffer, offset, captureLength, length);
 
-        encodingBuffer.putLong(offset + relativeOffset, id, LITTLE_ENDIAN);
-        relativeOffset += SIZE_OF_LONG;
+        encodingBuffer.putLong(offset + encodedLength, id, LITTLE_ENDIAN);
+        encodedLength += SIZE_OF_LONG;
 
-        encodingBuffer.putInt(offset + relativeOffset, captureLength - (SIZE_OF_LONG + SIZE_OF_INT), LITTLE_ENDIAN);
-        relativeOffset += SIZE_OF_INT;
-
-        final String fromName = null == from ? "null" : from.name();
-        final String toName = null == to ? "null" : to.name();
-        relativeOffset += encodingBuffer.putStringWithoutLengthAscii(offset + relativeOffset, fromName);
-        relativeOffset += encodingBuffer.putStringWithoutLengthAscii(offset + relativeOffset, STATE_SEPARATOR);
-        relativeOffset += encodingBuffer.putStringWithoutLengthAscii(offset + relativeOffset, toName);
-
-        return relativeOffset;
+        return encodeTrailingStateChange(encodingBuffer, offset, encodedLength, captureLength, from, to);
     }
 
     static <E extends Enum<E>> int sessionStateChangeLength(final E from, final E to)
@@ -68,15 +59,15 @@ final class ArchiveEventEncoder
         final long recordingId,
         final String errorMessage)
     {
-        int relativeOffset = encodeLogHeader(encodingBuffer, offset, captureLength, length);
+        int encodedLength = encodeLogHeader(encodingBuffer, offset, captureLength, length);
 
-        encodingBuffer.putLong(offset + relativeOffset, sessionId, LITTLE_ENDIAN);
-        relativeOffset += SIZE_OF_LONG;
+        encodingBuffer.putLong(offset + encodedLength, sessionId, LITTLE_ENDIAN);
+        encodedLength += SIZE_OF_LONG;
 
-        encodingBuffer.putLong(offset + relativeOffset, recordingId, LITTLE_ENDIAN);
-        relativeOffset += SIZE_OF_LONG;
+        encodingBuffer.putLong(offset + encodedLength, recordingId, LITTLE_ENDIAN);
+        encodedLength += SIZE_OF_LONG;
 
-        encodeTrailingString(encodingBuffer, offset + relativeOffset, captureLength - (SIZE_OF_INT * 2), errorMessage);
+        encodeTrailingString(encodingBuffer, offset + encodedLength, captureLength - (SIZE_OF_INT * 2), errorMessage);
     }
 
     static void encodeCatalogResize(
@@ -87,11 +78,11 @@ final class ArchiveEventEncoder
         final long catalogLength,
         final long newCatalogLength)
     {
-        int relativeOffset = encodeLogHeader(encodingBuffer, offset, captureLength, length);
+        int encodedLength = encodeLogHeader(encodingBuffer, offset, captureLength, length);
 
-        encodingBuffer.putLong(offset + relativeOffset, catalogLength, LITTLE_ENDIAN);
-        relativeOffset += SIZE_OF_LONG;
+        encodingBuffer.putLong(offset + encodedLength, catalogLength, LITTLE_ENDIAN);
+        encodedLength += SIZE_OF_LONG;
 
-        encodingBuffer.putLong(offset + relativeOffset, newCatalogLength, LITTLE_ENDIAN);
+        encodingBuffer.putLong(offset + encodedLength, newCatalogLength, LITTLE_ENDIAN);
     }
 }

--- a/aeron-agent/src/main/java/io/aeron/agent/ClusterEventCode.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ClusterEventCode.java
@@ -19,6 +19,7 @@ import org.agrona.MutableDirectBuffer;
 
 import java.util.Arrays;
 
+import static io.aeron.agent.ClusterEventDissector.dissectElectionStateChange;
 import static io.aeron.agent.ClusterEventDissector.dissectNewLeadershipTerm;
 
 /**
@@ -29,7 +30,8 @@ public enum ClusterEventCode implements EventCode
     /**
      * State change events within a cluster election.
      */
-    ELECTION_STATE_CHANGE(1, ClusterEventDissector::dissectStateChange),
+    ELECTION_STATE_CHANGE(1,
+        (eventCode, buffer, offset, builder) -> dissectElectionStateChange(buffer, offset, builder)),
 
     /**
      * A new term of leadership is to begin for an elected cluster member.

--- a/aeron-agent/src/main/java/io/aeron/agent/ClusterEventDissector.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ClusterEventDissector.java
@@ -17,6 +17,7 @@ package io.aeron.agent;
 
 import org.agrona.MutableDirectBuffer;
 
+import static io.aeron.agent.ClusterEventCode.ELECTION_STATE_CHANGE;
 import static io.aeron.agent.ClusterEventCode.NEW_LEADERSHIP_TERM;
 import static io.aeron.agent.CommonEventDissector.dissectLogHeader;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
@@ -101,6 +102,42 @@ final class ClusterEventDissector
         builder.append(": memberId=").append(memberId);
         builder.append(' ');
         buffer.getStringAscii(absoluteOffset, builder);
+    }
+
+    static void dissectElectionStateChange(
+        final MutableDirectBuffer buffer,
+        final int offset,
+        final StringBuilder builder)
+    {
+        int absoluteOffset = offset;
+        absoluteOffset += dissectLogHeader(CONTEXT, ELECTION_STATE_CHANGE, buffer, absoluteOffset, builder);
+
+        final int memberId = buffer.getInt(absoluteOffset, LITTLE_ENDIAN);
+        absoluteOffset += SIZE_OF_INT;
+        final int leaderId = buffer.getInt(absoluteOffset, LITTLE_ENDIAN);
+        absoluteOffset += SIZE_OF_INT;
+        final long candidateTermId = buffer.getLong(absoluteOffset, LITTLE_ENDIAN);
+        absoluteOffset += SIZE_OF_LONG;
+        final long leadershipTermId = buffer.getLong(absoluteOffset, LITTLE_ENDIAN);
+        absoluteOffset += SIZE_OF_LONG;
+        final long logPosition = buffer.getLong(absoluteOffset, LITTLE_ENDIAN);
+        absoluteOffset += SIZE_OF_LONG;
+        final long logLeadershipTermId = buffer.getLong(absoluteOffset, LITTLE_ENDIAN);
+        absoluteOffset += SIZE_OF_LONG;
+        final long appendPosition = buffer.getLong(absoluteOffset, LITTLE_ENDIAN);
+        absoluteOffset += SIZE_OF_LONG;
+        final long catchupPosition = buffer.getLong(absoluteOffset, LITTLE_ENDIAN);
+        absoluteOffset += SIZE_OF_LONG;
+
+        builder.append(": memberId=").append(memberId).append(' ');
+        buffer.getStringAscii(absoluteOffset, builder);
+        builder.append(" leaderId=").append(leaderId);
+        builder.append(" candidateTermId=").append(candidateTermId);
+        builder.append(" leadershipTermId=").append(leadershipTermId);
+        builder.append(" logPosition=").append(logPosition);
+        builder.append(" logLeadershipTermId=").append(logLeadershipTermId);
+        builder.append(" appendPosition=").append(appendPosition);
+        builder.append(" catchupPosition=").append(catchupPosition);
     }
 
     static void dissectCanvassPosition(

--- a/aeron-agent/src/main/java/io/aeron/agent/ClusterInterceptor.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ClusterInterceptor.java
@@ -17,7 +17,8 @@ package io.aeron.agent;
 
 import net.bytebuddy.asm.Advice;
 
-import static io.aeron.agent.ClusterEventCode.*;
+import static io.aeron.agent.ClusterEventCode.ROLE_CHANGE;
+import static io.aeron.agent.ClusterEventCode.STATE_CHANGE;
 import static io.aeron.agent.ClusterEventLogger.LOGGER;
 
 class ClusterInterceptor
@@ -25,9 +26,29 @@ class ClusterInterceptor
     static class ElectionStateChange
     {
         @Advice.OnMethodEnter
-        static <E extends Enum<E>> void stateChange(final E oldState, final E newState, final int memberId)
+        static <E extends Enum<E>> void stateChange(
+            final E oldState,
+            final E newState,
+            final int memberId,
+            final int leaderId,
+            final long candidateTermId,
+            final long leadershipTermId,
+            final long logPosition,
+            final long logLeadershipTermId,
+            final long appendPosition,
+            final long catchupPosition)
         {
-            LOGGER.logStateChange(ELECTION_STATE_CHANGE, oldState, newState, memberId);
+            LOGGER.logElectionStateChange(
+                oldState,
+                newState,
+                memberId,
+                leaderId,
+                candidateTermId,
+                leadershipTermId,
+                logPosition,
+                logLeadershipTermId,
+                appendPosition,
+                catchupPosition);
         }
     }
 

--- a/aeron-agent/src/main/java/io/aeron/agent/CommonEventDissector.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/CommonEventDissector.java
@@ -54,16 +54,16 @@ final class CommonEventDissector
         final int offset,
         final StringBuilder builder)
     {
-        int relativeOffset = 0;
+        int encodedLength = 0;
 
-        final int captureLength = buffer.getInt(offset + relativeOffset, LITTLE_ENDIAN);
-        relativeOffset += SIZE_OF_INT;
+        final int captureLength = buffer.getInt(offset + encodedLength, LITTLE_ENDIAN);
+        encodedLength += SIZE_OF_INT;
 
-        final int bufferLength = buffer.getInt(offset + relativeOffset, LITTLE_ENDIAN);
-        relativeOffset += SIZE_OF_INT;
+        final int bufferLength = buffer.getInt(offset + encodedLength, LITTLE_ENDIAN);
+        encodedLength += SIZE_OF_INT;
 
-        final long timestampNs = buffer.getLong(offset + relativeOffset, LITTLE_ENDIAN);
-        relativeOffset += SIZE_OF_LONG;
+        final long timestampNs = buffer.getLong(offset + encodedLength, LITTLE_ENDIAN);
+        encodedLength += SIZE_OF_LONG;
 
         builder
             .append('[')
@@ -78,32 +78,32 @@ final class CommonEventDissector
             .append(bufferLength)
             .append(']');
 
-        return relativeOffset;
+        return encodedLength;
     }
 
     static int dissectSocketAddress(final MutableDirectBuffer buffer, final int offset, final StringBuilder builder)
     {
-        int relativeOffset = 0;
-        final int port = buffer.getInt(offset + relativeOffset, LITTLE_ENDIAN);
-        relativeOffset += SIZE_OF_INT;
+        int encodedLength = 0;
+        final int port = buffer.getInt(offset + encodedLength, LITTLE_ENDIAN);
+        encodedLength += SIZE_OF_INT;
 
-        relativeOffset += dissectInetAddress(buffer, offset + relativeOffset, builder);
+        encodedLength += dissectInetAddress(buffer, offset + encodedLength, builder);
 
         builder.append(':').append(port);
 
-        return relativeOffset;
+        return encodedLength;
     }
 
     static int dissectInetAddress(final MutableDirectBuffer buffer, final int offset, final StringBuilder builder)
     {
-        int relativeOffset = 0;
+        int encodedLength = 0;
 
-        final int addressLength = buffer.getInt(offset + relativeOffset);
-        relativeOffset += SIZE_OF_INT;
+        final int addressLength = buffer.getInt(offset + encodedLength);
+        encodedLength += SIZE_OF_INT;
 
         if (4 == addressLength)
         {
-            final int i = offset + relativeOffset;
+            final int i = offset + encodedLength;
             builder
                 .append(buffer.getByte(i) & 0xFF)
                 .append('.')
@@ -115,7 +115,7 @@ final class CommonEventDissector
         }
         else if (16 == addressLength)
         {
-            final int i = offset + relativeOffset;
+            final int i = offset + encodedLength;
             builder
                 .append('[')
                 .append(toHexString(((buffer.getByte(i) << 8) & 0xFF00) | buffer.getByte(i + 1) & 0xFF))
@@ -140,8 +140,8 @@ final class CommonEventDissector
             builder.append("unknown-address");
         }
 
-        relativeOffset += addressLength;
+        encodedLength += addressLength;
 
-        return relativeOffset;
+        return encodedLength;
     }
 }

--- a/aeron-agent/src/main/java/io/aeron/agent/DriverEventDissector.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DriverEventDissector.java
@@ -68,15 +68,15 @@ final class DriverEventDissector
         final int offset,
         final StringBuilder builder)
     {
-        int relativeOffset = dissectLogHeader(CONTEXT, eventCode, buffer, offset, builder);
+        int encodedLength = dissectLogHeader(CONTEXT, eventCode, buffer, offset, builder);
 
         builder.append(": ");
 
-        relativeOffset += dissectSocketAddress(buffer, offset + relativeOffset, builder);
+        encodedLength += dissectSocketAddress(buffer, offset + encodedLength, builder);
 
         builder.append(" ");
 
-        final int frameOffset = offset + relativeOffset;
+        final int frameOffset = offset + encodedLength;
         final int frameType = frameType(buffer, frameOffset);
         switch (frameType)
         {
@@ -120,53 +120,53 @@ final class DriverEventDissector
     static void dissectCommand(
         final DriverEventCode code, final MutableDirectBuffer buffer, final int offset, final StringBuilder builder)
     {
-        final int relativeOffset = dissectLogHeader(CONTEXT, code, buffer, offset, builder);
+        final int encodedLength = dissectLogHeader(CONTEXT, code, buffer, offset, builder);
         builder.append(": ");
 
         switch (code)
         {
             case CMD_IN_ADD_PUBLICATION:
             case CMD_IN_ADD_EXCLUSIVE_PUBLICATION:
-                PUB_MSG.wrap(buffer, offset + relativeOffset);
+                PUB_MSG.wrap(buffer, offset + encodedLength);
                 dissectPublication(builder);
                 break;
 
             case CMD_IN_ADD_SUBSCRIPTION:
-                SUB_MSG.wrap(buffer, offset + relativeOffset);
+                SUB_MSG.wrap(buffer, offset + encodedLength);
                 dissectSubscription(builder);
                 break;
 
             case CMD_IN_REMOVE_PUBLICATION:
             case CMD_IN_REMOVE_SUBSCRIPTION:
             case CMD_IN_REMOVE_COUNTER:
-                REMOVE_MSG.wrap(buffer, offset + relativeOffset);
+                REMOVE_MSG.wrap(buffer, offset + encodedLength);
                 dissectRemoveEvent(builder);
                 break;
 
             case CMD_OUT_PUBLICATION_READY:
             case CMD_OUT_EXCLUSIVE_PUBLICATION_READY:
-                PUB_READY.wrap(buffer, offset + relativeOffset);
+                PUB_READY.wrap(buffer, offset + encodedLength);
                 dissectPublicationReady(builder);
                 break;
 
             case CMD_OUT_AVAILABLE_IMAGE:
-                IMAGE_READY.wrap(buffer, offset + relativeOffset);
+                IMAGE_READY.wrap(buffer, offset + encodedLength);
                 dissectImageReady(builder);
                 break;
 
             case CMD_OUT_ON_OPERATION_SUCCESS:
-                OPERATION_SUCCEEDED.wrap(buffer, offset + relativeOffset);
+                OPERATION_SUCCEEDED.wrap(buffer, offset + encodedLength);
                 dissectOperationSuccess(builder);
                 break;
 
             case CMD_IN_KEEPALIVE_CLIENT:
             case CMD_IN_CLIENT_CLOSE:
-                CORRELATED_MSG.wrap(buffer, offset + relativeOffset);
+                CORRELATED_MSG.wrap(buffer, offset + encodedLength);
                 dissectCorrelationEvent(builder);
                 break;
 
             case CMD_OUT_ON_UNAVAILABLE_IMAGE:
-                IMAGE_MSG.wrap(buffer, offset + relativeOffset);
+                IMAGE_MSG.wrap(buffer, offset + encodedLength);
                 dissectImage(builder);
                 break;
 
@@ -174,38 +174,38 @@ final class DriverEventDissector
             case CMD_IN_REMOVE_DESTINATION:
             case CMD_IN_ADD_RCV_DESTINATION:
             case CMD_IN_REMOVE_RCV_DESTINATION:
-                DESTINATION_MSG.wrap(buffer, offset + relativeOffset);
+                DESTINATION_MSG.wrap(buffer, offset + encodedLength);
                 dissectDestination(builder);
                 break;
 
             case CMD_OUT_ERROR:
-                ERROR_MSG.wrap(buffer, offset + relativeOffset);
+                ERROR_MSG.wrap(buffer, offset + encodedLength);
                 dissectError(builder);
                 break;
 
             case CMD_IN_ADD_COUNTER:
-                COUNTER_MSG.wrap(buffer, offset + relativeOffset);
+                COUNTER_MSG.wrap(buffer, offset + encodedLength);
                 dissectCounter(builder);
                 break;
 
             case CMD_OUT_SUBSCRIPTION_READY:
-                SUBSCRIPTION_READY.wrap(buffer, offset + relativeOffset);
+                SUBSCRIPTION_READY.wrap(buffer, offset + encodedLength);
                 dissectSubscriptionReady(builder);
                 break;
 
             case CMD_OUT_COUNTER_READY:
             case CMD_OUT_ON_UNAVAILABLE_COUNTER:
-                COUNTER_UPDATE.wrap(buffer, offset + relativeOffset);
+                COUNTER_UPDATE.wrap(buffer, offset + encodedLength);
                 dissectCounterUpdate(builder);
                 break;
 
             case CMD_OUT_ON_CLIENT_TIMEOUT:
-                CLIENT_TIMEOUT.wrap(buffer, offset + relativeOffset);
+                CLIENT_TIMEOUT.wrap(buffer, offset + encodedLength);
                 dissectClientTimeout(builder);
                 break;
 
             case CMD_IN_TERMINATE_DRIVER:
-                TERMINATE_DRIVER.wrap(buffer, offset + relativeOffset);
+                TERMINATE_DRIVER.wrap(buffer, offset + encodedLength);
                 dissectTerminateDriver(builder);
                 break;
 
@@ -218,8 +218,8 @@ final class DriverEventDissector
     static void dissectString(
         final DriverEventCode code, final MutableDirectBuffer buffer, final int offset, final StringBuilder builder)
     {
-        final int relativeOffset = dissectLogHeader(CONTEXT, code, buffer, offset, builder);
-        builder.append(": ").append(buffer.getStringAscii(offset + relativeOffset, LITTLE_ENDIAN));
+        final int encodedLength = dissectLogHeader(CONTEXT, code, buffer, offset, builder);
+        builder.append(": ").append(buffer.getStringAscii(offset + encodedLength, LITTLE_ENDIAN));
     }
 
     static void dissectRemovePublicationCleanup(

--- a/aeron-agent/src/main/java/io/aeron/agent/DriverEventEncoder.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DriverEventEncoder.java
@@ -46,13 +46,13 @@ final class DriverEventEncoder
         final int srcOffset,
         final InetSocketAddress dstAddress)
     {
-        int relativeOffset = encodeLogHeader(encodingBuffer, offset, captureLength, length);
+        int encodedLength = encodeLogHeader(encodingBuffer, offset, captureLength, length);
 
-        final int encodedSocketLength = encodeSocketAddress(encodingBuffer, offset + relativeOffset, dstAddress);
-        relativeOffset += encodedSocketLength;
+        final int encodedSocketLength = encodeSocketAddress(encodingBuffer, offset + encodedLength, dstAddress);
+        encodedLength += encodedSocketLength;
 
         final int bufferCaptureLength = captureLength - encodedSocketLength;
-        encodingBuffer.putBytes(offset + relativeOffset, srcBuffer, srcOffset, bufferCaptureLength);
+        encodingBuffer.putBytes(offset + encodedLength, srcBuffer, srcOffset, bufferCaptureLength);
     }
 
     static void encode(
@@ -64,13 +64,13 @@ final class DriverEventEncoder
         final int srcOffset,
         final InetSocketAddress dstAddress)
     {
-        int relativeOffset = encodeLogHeader(encodingBuffer, offset, captureLength, length);
+        int encodedLength = encodeLogHeader(encodingBuffer, offset, captureLength, length);
 
-        final int encodedSocketLength = encodeSocketAddress(encodingBuffer, offset + relativeOffset, dstAddress);
-        relativeOffset += encodedSocketLength;
+        final int encodedSocketLength = encodeSocketAddress(encodingBuffer, offset + encodedLength, dstAddress);
+        encodedLength += encodedSocketLength;
 
         final int bufferCaptureLength = captureLength - encodedSocketLength;
-        encodingBuffer.putBytes(offset + relativeOffset, srcBuffer, srcOffset, bufferCaptureLength);
+        encodingBuffer.putBytes(offset + encodedLength, srcBuffer, srcOffset, bufferCaptureLength);
     }
 
     static void encode(
@@ -82,13 +82,13 @@ final class DriverEventEncoder
         final int srcOffset,
         final InetAddress dstAddress)
     {
-        int relativeOffset = encodeLogHeader(encodingBuffer, offset, captureLength, length);
+        int encodedLength = encodeLogHeader(encodingBuffer, offset, captureLength, length);
 
-        final int encodedInetAddressLength = encodeInetAddress(encodingBuffer, offset + relativeOffset, dstAddress);
-        relativeOffset += encodedInetAddressLength;
+        final int encodedInetAddressLength = encodeInetAddress(encodingBuffer, offset + encodedLength, dstAddress);
+        encodedLength += encodedInetAddressLength;
 
         final int bufferCaptureLength = captureLength - encodedInetAddressLength;
-        encodingBuffer.putBytes(offset + relativeOffset, srcBuffer, srcOffset, bufferCaptureLength);
+        encodingBuffer.putBytes(offset + encodedLength, srcBuffer, srcOffset, bufferCaptureLength);
     }
 
     static void encode(
@@ -98,8 +98,8 @@ final class DriverEventEncoder
         final int length,
         final String value)
     {
-        final int relativeOffset = encodeLogHeader(encodingBuffer, offset, captureLength, length);
-        encodeTrailingString(encodingBuffer, offset + relativeOffset, captureLength, value);
+        final int encodedLength = encodeLogHeader(encodingBuffer, offset, captureLength, length);
+        encodeTrailingString(encodingBuffer, offset + encodedLength, captureLength, value);
     }
 
     static void encode(
@@ -109,8 +109,8 @@ final class DriverEventEncoder
         final int length,
         final InetSocketAddress address)
     {
-        final int relativeOffset = encodeLogHeader(encodingBuffer, offset, captureLength, length);
-        encodeSocketAddress(encodingBuffer, offset + relativeOffset, address);
+        final int encodedLength = encodeLogHeader(encodingBuffer, offset, captureLength, length);
+        encodeSocketAddress(encodingBuffer, offset + encodedLength, address);
     }
 
     static void encodePublicationRemoval(
@@ -122,15 +122,15 @@ final class DriverEventEncoder
         final int sessionId,
         final int streamId)
     {
-        int relativeOffset = encodeLogHeader(encodingBuffer, offset, captureLength, length);
+        int encodedLength = encodeLogHeader(encodingBuffer, offset, captureLength, length);
 
-        encodingBuffer.putInt(offset + relativeOffset, sessionId, LITTLE_ENDIAN);
-        relativeOffset += SIZE_OF_INT;
+        encodingBuffer.putInt(offset + encodedLength, sessionId, LITTLE_ENDIAN);
+        encodedLength += SIZE_OF_INT;
 
-        encodingBuffer.putInt(offset + relativeOffset, streamId, LITTLE_ENDIAN);
-        relativeOffset += SIZE_OF_INT;
+        encodingBuffer.putInt(offset + encodedLength, streamId, LITTLE_ENDIAN);
+        encodedLength += SIZE_OF_INT;
 
-        encodeTrailingString(encodingBuffer, offset + relativeOffset, captureLength - SIZE_OF_INT * 2, channel);
+        encodeTrailingString(encodingBuffer, offset + encodedLength, captureLength - SIZE_OF_INT * 2, channel);
     }
 
     static void encodeSubscriptionRemoval(
@@ -142,16 +142,16 @@ final class DriverEventEncoder
         final int streamId,
         final long id)
     {
-        int relativeOffset = encodeLogHeader(encodingBuffer, offset, captureLength, length);
+        int encodedLength = encodeLogHeader(encodingBuffer, offset, captureLength, length);
 
-        encodingBuffer.putInt(offset + relativeOffset, streamId, LITTLE_ENDIAN);
-        relativeOffset += SIZE_OF_INT;
+        encodingBuffer.putInt(offset + encodedLength, streamId, LITTLE_ENDIAN);
+        encodedLength += SIZE_OF_INT;
 
-        encodingBuffer.putLong(offset + relativeOffset, id, LITTLE_ENDIAN);
-        relativeOffset += SIZE_OF_LONG;
+        encodingBuffer.putLong(offset + encodedLength, id, LITTLE_ENDIAN);
+        encodedLength += SIZE_OF_LONG;
 
         encodeTrailingString(
-            encodingBuffer, offset + relativeOffset, captureLength - SIZE_OF_INT - SIZE_OF_LONG, channel);
+            encodingBuffer, offset + encodedLength, captureLength - SIZE_OF_INT - SIZE_OF_LONG, channel);
     }
 
     static void encodeImageRemoval(
@@ -164,19 +164,19 @@ final class DriverEventEncoder
         final int streamId,
         final long id)
     {
-        int relativeOffset = encodeLogHeader(encodingBuffer, offset, captureLength, length);
+        int encodedLength = encodeLogHeader(encodingBuffer, offset, captureLength, length);
 
-        encodingBuffer.putInt(offset + relativeOffset, sessionId, LITTLE_ENDIAN);
-        relativeOffset += SIZE_OF_INT;
+        encodingBuffer.putInt(offset + encodedLength, sessionId, LITTLE_ENDIAN);
+        encodedLength += SIZE_OF_INT;
 
-        encodingBuffer.putInt(offset + relativeOffset, streamId, LITTLE_ENDIAN);
-        relativeOffset += SIZE_OF_INT;
+        encodingBuffer.putInt(offset + encodedLength, streamId, LITTLE_ENDIAN);
+        encodedLength += SIZE_OF_INT;
 
-        encodingBuffer.putLong(offset + relativeOffset, id, LITTLE_ENDIAN);
-        relativeOffset += SIZE_OF_LONG;
+        encodingBuffer.putLong(offset + encodedLength, id, LITTLE_ENDIAN);
+        encodedLength += SIZE_OF_LONG;
 
         encodeTrailingString(
-            encodingBuffer, offset + relativeOffset, captureLength - SIZE_OF_INT * 2 - SIZE_OF_LONG, channel);
+            encodingBuffer, offset + encodedLength, captureLength - SIZE_OF_INT * 2 - SIZE_OF_LONG, channel);
     }
 
     static <E extends Enum<E>> int untetheredSubscriptionStateChangeLength(final E from, final E to)
@@ -195,25 +195,18 @@ final class DriverEventEncoder
         final int streamId,
         final int sessionId)
     {
-        int relativeOffset = encodeLogHeader(encodingBuffer, offset, captureLength, length);
+        int encodedLength = encodeLogHeader(encodingBuffer, offset, captureLength, length);
 
-        encodingBuffer.putLong(offset + relativeOffset, subscriptionId, LITTLE_ENDIAN);
-        relativeOffset += SIZE_OF_LONG;
+        encodingBuffer.putLong(offset + encodedLength, subscriptionId, LITTLE_ENDIAN);
+        encodedLength += SIZE_OF_LONG;
 
-        encodingBuffer.putInt(offset + relativeOffset, streamId, LITTLE_ENDIAN);
-        relativeOffset += SIZE_OF_INT;
+        encodingBuffer.putInt(offset + encodedLength, streamId, LITTLE_ENDIAN);
+        encodedLength += SIZE_OF_INT;
 
-        encodingBuffer.putInt(offset + relativeOffset, sessionId, LITTLE_ENDIAN);
-        relativeOffset += SIZE_OF_INT;
+        encodingBuffer.putInt(offset + encodedLength, sessionId, LITTLE_ENDIAN);
+        encodedLength += SIZE_OF_INT;
 
-        encodingBuffer.putInt(offset + relativeOffset, captureLength - (SIZE_OF_LONG + 3 * SIZE_OF_INT), LITTLE_ENDIAN);
-        relativeOffset += SIZE_OF_INT;
-
-        final String fromName = null == from ? "null" : from.name();
-        final String toName = null == to ? "null" : to.name();
-        relativeOffset += encodingBuffer.putStringWithoutLengthAscii(offset + relativeOffset, fromName);
-        relativeOffset += encodingBuffer.putStringWithoutLengthAscii(offset + relativeOffset, STATE_SEPARATOR);
-        encodingBuffer.putStringWithoutLengthAscii(offset + relativeOffset, toName);
+        encodeTrailingStateChange(encodingBuffer, offset, encodedLength, captureLength, from, to);
     }
 
     static void encodeFlowControlReceiver(
@@ -227,22 +220,22 @@ final class DriverEventEncoder
         final String channel,
         final int receiverCount)
     {
-        int relativeOffset = encodeLogHeader(encodingBuffer, offset, captureLength, length);
+        int encodedLength = encodeLogHeader(encodingBuffer, offset, captureLength, length);
 
-        encodingBuffer.putInt(offset + relativeOffset, receiverCount, LITTLE_ENDIAN);
-        relativeOffset += SIZE_OF_INT;
+        encodingBuffer.putInt(offset + encodedLength, receiverCount, LITTLE_ENDIAN);
+        encodedLength += SIZE_OF_INT;
 
-        encodingBuffer.putLong(offset + relativeOffset, receiverId, LITTLE_ENDIAN);
-        relativeOffset += SIZE_OF_LONG;
+        encodingBuffer.putLong(offset + encodedLength, receiverId, LITTLE_ENDIAN);
+        encodedLength += SIZE_OF_LONG;
 
-        encodingBuffer.putInt(offset + relativeOffset, sessionId, LITTLE_ENDIAN);
-        relativeOffset += SIZE_OF_INT;
+        encodingBuffer.putInt(offset + encodedLength, sessionId, LITTLE_ENDIAN);
+        encodedLength += SIZE_OF_INT;
 
-        encodingBuffer.putInt(offset + relativeOffset, streamId, LITTLE_ENDIAN);
-        relativeOffset += SIZE_OF_INT;
+        encodingBuffer.putInt(offset + encodedLength, streamId, LITTLE_ENDIAN);
+        encodedLength += SIZE_OF_INT;
 
         encodeTrailingString(
-            encodingBuffer, offset + relativeOffset, captureLength - SIZE_OF_INT * 3 - SIZE_OF_LONG, channel);
+            encodingBuffer, offset + encodedLength, captureLength - SIZE_OF_INT * 3 - SIZE_OF_LONG, channel);
     }
 
     static void encodeResolve(
@@ -254,11 +247,11 @@ final class DriverEventEncoder
         final String hostName,
         final InetAddress inetAddress)
     {
-        int relativeOffset = encodeLogHeader(encodingBuffer, offset, captureLength, length);
-        relativeOffset += encodeTrailingString(
-            encodingBuffer, offset + relativeOffset, SIZE_OF_INT + MAX_HOST_NAME_LENGTH, resolverName);
-        relativeOffset += encodeTrailingString(
-            encodingBuffer, offset + relativeOffset, SIZE_OF_INT + MAX_HOST_NAME_LENGTH, hostName);
-        encodeInetAddress(encodingBuffer, offset + relativeOffset, inetAddress);
+        int encodedLength = encodeLogHeader(encodingBuffer, offset, captureLength, length);
+        encodedLength += encodeTrailingString(
+            encodingBuffer, offset + encodedLength, SIZE_OF_INT + MAX_HOST_NAME_LENGTH, resolverName);
+        encodedLength += encodeTrailingString(
+            encodingBuffer, offset + encodedLength, SIZE_OF_INT + MAX_HOST_NAME_LENGTH, hostName);
+        encodeInetAddress(encodingBuffer, offset + encodedLength, inetAddress);
     }
 }

--- a/aeron-agent/src/test/java/io/aeron/agent/ClusterEventLoggerTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ClusterEventLoggerTest.java
@@ -19,11 +19,13 @@ import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.ringbuffer.ManyToOneRingBuffer;
 import org.junit.jupiter.api.Test;
 
+import java.time.temporal.ChronoUnit;
 import java.util.concurrent.TimeUnit;
 
 import static io.aeron.agent.AgentTests.verifyLogHeader;
-import static io.aeron.agent.ClusterEventCode.NEW_LEADERSHIP_TERM;
-import static io.aeron.agent.ClusterEventCode.STATE_CHANGE;
+import static io.aeron.agent.ClusterEventCode.*;
+import static io.aeron.agent.ClusterEventEncoder.electionStateChangeLength;
+import static io.aeron.agent.ClusterEventEncoder.newLeaderShipTermLength;
 import static io.aeron.agent.CommonEventEncoder.LOG_HEADER_LENGTH;
 import static io.aeron.agent.CommonEventEncoder.STATE_SEPARATOR;
 import static io.aeron.agent.EventConfiguration.MAX_EVENT_LENGTH;
@@ -58,7 +60,7 @@ class ClusterEventLoggerTest
         final long timestamp = 2;
         final int leaderMemberId = 0;
         final int logSessionId = 3;
-        final int captureLength = SIZE_OF_LONG * 9 + SIZE_OF_INT * 3;
+        final int captureLength = newLeaderShipTermLength();
         final boolean isStartup = true;
         final long termBaseLogPosition = 982734;
         final long leaderRecordingId = 76434;
@@ -78,31 +80,31 @@ class ClusterEventLoggerTest
             isStartup);
 
         verifyLogHeader(logBuffer, offset, NEW_LEADERSHIP_TERM.toEventCodeId(), captureLength, captureLength);
-        int relativeOffset = LOG_HEADER_LENGTH;
-        assertEquals(logLeadershipTermId, logBuffer.getLong(encodedMsgOffset(offset + relativeOffset), LITTLE_ENDIAN));
-        relativeOffset += SIZE_OF_LONG;
-        assertEquals(nextLeadershipTermId, logBuffer.getLong(encodedMsgOffset(offset + relativeOffset), LITTLE_ENDIAN));
-        relativeOffset += SIZE_OF_LONG;
+        int index = encodedMsgOffset(offset) + LOG_HEADER_LENGTH;
+        assertEquals(logLeadershipTermId, logBuffer.getLong(index, LITTLE_ENDIAN));
+        index += SIZE_OF_LONG;
+        assertEquals(nextLeadershipTermId, logBuffer.getLong(index, LITTLE_ENDIAN));
+        index += SIZE_OF_LONG;
         assertEquals(
-            nextTermBaseLogPosition, logBuffer.getLong(encodedMsgOffset(offset + relativeOffset), LITTLE_ENDIAN));
-        relativeOffset += SIZE_OF_LONG;
-        assertEquals(nextLogPosition, logBuffer.getLong(encodedMsgOffset(offset + relativeOffset), LITTLE_ENDIAN));
-        relativeOffset += SIZE_OF_LONG;
-        assertEquals(leadershipTermId, logBuffer.getLong(encodedMsgOffset(offset + relativeOffset), LITTLE_ENDIAN));
-        relativeOffset += SIZE_OF_LONG;
-        assertEquals(termBaseLogPosition, logBuffer.getLong(encodedMsgOffset(offset + relativeOffset), LITTLE_ENDIAN));
-        relativeOffset += SIZE_OF_LONG;
-        assertEquals(logPosition, logBuffer.getLong(encodedMsgOffset(offset + relativeOffset), LITTLE_ENDIAN));
-        relativeOffset += SIZE_OF_LONG;
-        assertEquals(leaderRecordingId, logBuffer.getLong(encodedMsgOffset(offset + relativeOffset), LITTLE_ENDIAN));
-        relativeOffset += SIZE_OF_LONG;
-        assertEquals(timestamp, logBuffer.getLong(encodedMsgOffset(offset + relativeOffset), LITTLE_ENDIAN));
-        relativeOffset += SIZE_OF_LONG;
-        assertEquals(leaderMemberId, logBuffer.getInt(encodedMsgOffset(offset + relativeOffset), LITTLE_ENDIAN));
-        relativeOffset += SIZE_OF_INT;
-        assertEquals(logSessionId, logBuffer.getInt(encodedMsgOffset(offset + relativeOffset), LITTLE_ENDIAN));
-        relativeOffset += SIZE_OF_INT;
-        assertEquals(isStartup, 1 == logBuffer.getInt(encodedMsgOffset(offset + relativeOffset), LITTLE_ENDIAN));
+            nextTermBaseLogPosition, logBuffer.getLong(index, LITTLE_ENDIAN));
+        index += SIZE_OF_LONG;
+        assertEquals(nextLogPosition, logBuffer.getLong(index, LITTLE_ENDIAN));
+        index += SIZE_OF_LONG;
+        assertEquals(leadershipTermId, logBuffer.getLong(index, LITTLE_ENDIAN));
+        index += SIZE_OF_LONG;
+        assertEquals(termBaseLogPosition, logBuffer.getLong(index, LITTLE_ENDIAN));
+        index += SIZE_OF_LONG;
+        assertEquals(logPosition, logBuffer.getLong(index, LITTLE_ENDIAN));
+        index += SIZE_OF_LONG;
+        assertEquals(leaderRecordingId, logBuffer.getLong(index, LITTLE_ENDIAN));
+        index += SIZE_OF_LONG;
+        assertEquals(timestamp, logBuffer.getLong(index, LITTLE_ENDIAN));
+        index += SIZE_OF_LONG;
+        assertEquals(leaderMemberId, logBuffer.getInt(index, LITTLE_ENDIAN));
+        index += SIZE_OF_INT;
+        assertEquals(logSessionId, logBuffer.getInt(index, LITTLE_ENDIAN));
+        index += SIZE_OF_INT;
+        assertEquals(isStartup, 1 == logBuffer.getInt(index, LITTLE_ENDIAN));
     }
 
     @Test
@@ -119,7 +121,58 @@ class ClusterEventLoggerTest
         logger.logStateChange(STATE_CHANGE, from, to, memberId);
 
         verifyLogHeader(logBuffer, offset, STATE_CHANGE.toEventCodeId(), captureLength, captureLength);
-        assertEquals(memberId, logBuffer.getInt(encodedMsgOffset(offset + LOG_HEADER_LENGTH), LITTLE_ENDIAN));
-        assertEquals(payload, logBuffer.getStringAscii(encodedMsgOffset(offset + LOG_HEADER_LENGTH + SIZE_OF_INT)));
+        final int index = encodedMsgOffset(offset) + LOG_HEADER_LENGTH;
+        assertEquals(memberId, logBuffer.getInt(index, LITTLE_ENDIAN));
+        assertEquals(payload, logBuffer.getStringAscii(index + SIZE_OF_INT));
+    }
+
+    @Test
+    void logElectionStateChange()
+    {
+        final int offset = ALIGNMENT * 4;
+        logBuffer.putLong(CAPACITY + TAIL_POSITION_OFFSET, offset);
+        final ChronoUnit from = ChronoUnit.ERAS;
+        final ChronoUnit to = null;
+        final int memberId = 18;
+        final int leaderId = -1;
+        final long candidateTermId = 29L;
+        final long leadershipTermId = 0L;
+        final long logPosition = 100L;
+        final long logLeadershipTermId = -9L;
+        final long appendPosition = 16 * 1024L;
+        final long catchupPosition = 8192L;
+        final int length = electionStateChangeLength(from, to);
+
+        logger.logElectionStateChange(
+            from,
+            to,
+            memberId,
+            leaderId,
+            candidateTermId,
+            leadershipTermId,
+            logPosition,
+            logLeadershipTermId,
+            appendPosition,
+            catchupPosition);
+
+        verifyLogHeader(logBuffer, offset, ELECTION_STATE_CHANGE.toEventCodeId(), length, length);
+        int index = encodedMsgOffset(offset) + LOG_HEADER_LENGTH;
+        assertEquals(memberId, logBuffer.getInt(index, LITTLE_ENDIAN));
+        index += SIZE_OF_INT;
+        assertEquals(leaderId, logBuffer.getInt(index, LITTLE_ENDIAN));
+        index += SIZE_OF_INT;
+        assertEquals(candidateTermId, logBuffer.getLong(index, LITTLE_ENDIAN));
+        index += SIZE_OF_LONG;
+        assertEquals(leadershipTermId, logBuffer.getLong(index, LITTLE_ENDIAN));
+        index += SIZE_OF_LONG;
+        assertEquals(logPosition, logBuffer.getLong(index, LITTLE_ENDIAN));
+        index += SIZE_OF_LONG;
+        assertEquals(logLeadershipTermId, logBuffer.getLong(index, LITTLE_ENDIAN));
+        index += SIZE_OF_LONG;
+        assertEquals(appendPosition, logBuffer.getLong(index, LITTLE_ENDIAN));
+        index += SIZE_OF_LONG;
+        assertEquals(catchupPosition, logBuffer.getLong(index, LITTLE_ENDIAN));
+        index += SIZE_OF_LONG;
+        assertEquals(from.name() + STATE_SEPARATOR + "null", logBuffer.getStringAscii(index));
     }
 }

--- a/aeron-agent/src/test/java/io/aeron/agent/ClusterLoggingAgentTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ClusterLoggingAgentTest.java
@@ -51,6 +51,7 @@ import static io.aeron.agent.EventConfiguration.EVENT_READER_FRAME_LIMIT;
 import static io.aeron.agent.EventConfiguration.EVENT_RING_BUFFER;
 import static java.util.Collections.synchronizedSet;
 import static org.agrona.BitUtil.SIZE_OF_INT;
+import static org.agrona.BitUtil.SIZE_OF_LONG;
 import static org.mockito.Mockito.mock;
 
 @ExtendWith(InterruptingTestCallback.class)
@@ -188,13 +189,13 @@ public class ClusterLoggingAgentTest
 
         public void onMessage(final int msgTypeId, final MutableDirectBuffer buffer, final int index, final int length)
         {
-            final int offset = LOG_HEADER_LENGTH + index + SIZE_OF_INT;
             final ClusterEventCode eventCode = fromEventCodeId(msgTypeId);
 
             switch (eventCode)
             {
                 case ROLE_CHANGE:
                 {
+                    final int offset = index + LOG_HEADER_LENGTH + SIZE_OF_INT;
                     final String roleChange = buffer.getStringAscii(offset);
                     if (roleChange.contains("LEADER"))
                     {
@@ -205,6 +206,7 @@ public class ClusterLoggingAgentTest
 
                 case STATE_CHANGE:
                 {
+                    final int offset = index + LOG_HEADER_LENGTH + SIZE_OF_INT;
                     final String stateChange = buffer.getStringAscii(offset);
                     if (stateChange.contains("ACTIVE"))
                     {
@@ -215,6 +217,7 @@ public class ClusterLoggingAgentTest
 
                 case ELECTION_STATE_CHANGE:
                 {
+                    final int offset = index + LOG_HEADER_LENGTH + 2 * SIZE_OF_INT + 6 * SIZE_OF_LONG;
                     final String stateChange = buffer.getStringAscii(offset);
                     if (stateChange.contains("CLOSED"))
                     {

--- a/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
@@ -15,7 +15,10 @@
  */
 package io.aeron.cluster;
 
-import io.aeron.*;
+import io.aeron.ChannelUriStringBuilder;
+import io.aeron.CommonContext;
+import io.aeron.Image;
+import io.aeron.Subscription;
 import io.aeron.archive.codecs.RecordingSignal;
 import io.aeron.cluster.client.ClusterEvent;
 import io.aeron.cluster.client.ClusterException;
@@ -1121,7 +1124,17 @@ class Election
     {
         if (newState != state)
         {
-            stateChange(state, newState, thisMember.id());
+            stateChange(
+                state,
+                newState,
+                thisMember.id(),
+                null != leaderMember ? leaderMember.id() : -1,
+                candidateTermId,
+                leadershipTermId,
+                logPosition,
+                logLeadershipTermId,
+                appendPosition,
+                catchupPosition);
 
             if (CANVASS == state)
             {
@@ -1305,11 +1318,21 @@ class Election
         return (nowNs - timeOfLastUpdateNs) >= intervalNs;
     }
 
-    void stateChange(final ElectionState oldState, final ElectionState newState, final int memberId)
+    void stateChange(
+        final ElectionState oldState,
+        final ElectionState newState,
+        final int memberId,
+        final int leaderId,
+        final long candidateTermId,
+        final long leadershipTermId,
+        final long logPosition,
+        final long logLeadershipTermId,
+        final long appendPosition,
+        final long catchupPosition)
     {
         /*
         System.out.println("Election: memberId=" + memberId + " " + oldState + " -> " + newState +
-            " leaderId=" + (null != leaderMember ? leaderMember.id() : -1) +
+            " leaderId=" + leaderId +
             " candidateTermId=" + candidateTermId +
             " leadershipTermId=" + leadershipTermId +
             " logPosition=" + logPosition +


### PR DESCRIPTION
This PR adds extra information to the existing `ELECTION_STATE_CHANGE` logging event to match the output of the `Election.stateChange` method.

I decided against adding a new `ELECTION_STATE_CHANGE_FULL` event as that would make implementation and configuration more complex and confusing. In particular the event would have to be enabled explicitly even if `all` is used to show all cluster events but since `all` includes `ELECTION_STATE_CHANGE` we would end up with duplicate information unless the latter is disabled. So in order to have a clean but full cluster event log one would have to do something like this:
```
aeron.event.cluster.log=all,ELECTION_STATE_CHANGE_FULL
aeron.event.cluster.log.disable=ELECTION_STATE_CHANGE
```
The current approach retains the simplicity:
```
aeron.event.cluster.log=all
```
Also going second event route would mean having two pointcuts and two methods in the `Election` class.