### PR TITLE
Prevent commit position move in leader log replication

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -2602,6 +2602,11 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler
         return 0;
     }
 
+    long queryQuorumPosition()
+    {
+        return quorumPosition(activeMembers, rankedPositions);
+    }
+
     int updateLeaderPosition(final long nowNs, final long position)
     {
         thisMember.logPosition(position).timeOfLastAppendPositionNs(nowNs);


### PR DESCRIPTION
Instead of waiting in LEADER_LOG_REPLICATION state for followers to replicate their logs, move directly through to the LEADER_REPLAY state and allow the leader to initialise.  Followers that are multiple terms behind will continue replicate and catch up.  This avoids changing the commit position until after LEADER_REPLAY is complete.  Keep the replication timeout deadline moving forward when newLeadershipTerm events are received as commit position events won't come out while the leader is replaying.  This prevents the replication from timing out during a long LEADER_REPLAY.