### PR TITLE
Allow followers that have replication logs to start replay concurrently with leader replay

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -2614,7 +2614,7 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler
         if (commitPosition > this.commitPosition.getWeak() ||
             nowNs >= (timeOfLastLogUpdateNs + leaderHeartbeatIntervalNs))
         {
-            sendCommitPosition(commitPosition);
+            publishCommitPosition(commitPosition);
 
             this.commitPosition.setOrdered(commitPosition);
             timeOfLastLogUpdateNs = nowNs;
@@ -2631,7 +2631,7 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler
         return 0;
     }
 
-    void sendCommitPosition(final long commitPosition)
+    void publishCommitPosition(final long commitPosition)
     {
         for (final ClusterMember member : activeMembers)
         {

--- a/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
@@ -579,7 +579,7 @@ class Election
     {
         int workCount = 0;
 
-        if (hasLastUpdateExpired(nowNs, ctx.electionStatusIntervalNs()))
+        if (hasUpdateIntervalExpired(nowNs, ctx.electionStatusIntervalNs()))
         {
             timeOfLastUpdateNs = nowNs;
             for (final ClusterMember member : clusterMembers)
@@ -1035,7 +1035,7 @@ class Election
     {
         int workCount = 0;
 
-        if (hasLastUpdateExpired(nowNs, ctx.leaderHeartbeatIntervalNs()))
+        if (hasUpdateIntervalExpired(nowNs, ctx.leaderHeartbeatIntervalNs()))
         {
             timeOfLastUpdateNs = nowNs;
             publishNewLeadershipTerm(ctx.clusterClock().timeUnit().convert(nowNs, TimeUnit.NANOSECONDS));
@@ -1055,7 +1055,7 @@ class Election
         {
             timeOfLastCommitPositionUpdateNs = nowNs;
             lastPublishedCommitPosition = quorumPosition;
-            consensusModuleAgent.sendCommitPosition(quorumPosition);
+            consensusModuleAgent.publishCommitPosition(quorumPosition);
             workCount++;
         }
 
@@ -1108,7 +1108,7 @@ class Election
     {
         final long position = logReplication.position();
         if (position > appendPosition ||
-            (position == appendPosition && hasLastUpdateExpired(nowNs, ctx.leaderHeartbeatIntervalNs())))
+            (position == appendPosition && hasUpdateIntervalExpired(nowNs, ctx.leaderHeartbeatIntervalNs())))
         {
             if (consensusPublisher.appendPosition(
                 leaderMember.publication(), leadershipTermId, position, thisMember.id()))
@@ -1352,7 +1352,7 @@ class Election
         }
     }
 
-    private boolean hasLastUpdateExpired(final long nowNs, final long intervalNs)
+    private boolean hasUpdateIntervalExpired(final long nowNs, final long intervalNs)
     {
         return hasIntervalExpired(nowNs, timeOfLastUpdateNs, intervalNs);
     }


### PR DESCRIPTION
Emit the commitPosition events during LEADER_LOG_REPLICATION and LEADER_REPLAY, but don't update the commitPosition counter.  Wait for replay to handle that.