### PR TITLE
Fix use of sendmmsg()

### DIFF
--- a/aeron-driver/src/main/c/agent/aeron_driver_agent.c
+++ b/aeron-driver/src/main/c/agent/aeron_driver_agent.c
@@ -1470,7 +1470,7 @@ static const char *dissect_cmd_in(int64_t cmd_id, const void *message, size_t le
             snprintf(
                 buffer,
                 sizeof(buffer) - 1,
-                "streamId=%d clientId=%" PRId64 " correlationId=%" PRId64 " channel=%*.s",
+                "streamId=%d clientId=%" PRId64 " correlationId=%" PRId64 " channel=%.*s",
                 command->stream_id,
                 command->correlated.client_id,
                 command->correlated.correlation_id,


### PR DESCRIPTION
`aeron_udp_channel_transport_sendv()` calls `sendmmsg()` under the hood. `sendmmsg()` [manpage](https://manpages.ubuntu.com/manpages/focal/en/man2/send.2freebsd.html) says:

> [EISCONN]          A destination address was specified and the socket is already connected.

We're using `exasock` accellerated TCP stack, which takes it quite literally and returns an error even if specified destination address matches the connected address of the socket. Linux must be more relaxed about it and the old code works fine.

