### PR TITLE
[C++ Wrapper] Add an AsyncDestination type definition to Subscription.h

### DIFF
--- a/aeron-client/src/main/cpp_wrapper/Subscription.h
+++ b/aeron-client/src/main/cpp_wrapper/Subscription.h
@@ -37,6 +37,7 @@ namespace aeron
 {
 
 using namespace aeron::concurrent::logbuffer;
+using AsyncDestination = aeron_async_destination_t;
 
 class AsyncAddSubscription
 {


### PR DESCRIPTION
Add an AsyncDestination type definition to Subscription.h, similar to how it is done in Publication.h.

If the AsyncDestination type definition is not added to Subscription.h, you will encounter errors when referencing Subscription.h alone