### PR TITLE
Add missing <mutex> header

### DIFF
--- a/aeron-client/src/main/cpp_wrapper/Subscription.h
+++ b/aeron-client/src/main/cpp_wrapper/Subscription.h
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <iostream>
 #include <memory>
+#include <mutex>
 #include <iterator>
 #include <stdexcept>
 


### PR DESCRIPTION
This fixes undefined references to `std::recursive_mutex` for client code that includes the C++ wrapper headers.