### PR TITLE
MDC short send fix

### DIFF
--- a/aeron-driver/src/main/c/media/aeron_udp_destination_tracker.c
+++ b/aeron-driver/src/main/c/media/aeron_udp_destination_tracker.c
@@ -109,7 +109,7 @@ int aeron_udp_destination_tracker_send(
     int result = (int)iov_length;
     int to_be_removed = 0;
 
-    *bytes_sent = 0;
+    *bytes_sent = iov->iov_len;
 
     int starting_index = tracker->round_robin_index++;
     if (starting_index >= length)

--- a/aeron-system-tests/src/test/java/io/aeron/SpySimulatedConnectionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/SpySimulatedConnectionTest.java
@@ -38,7 +38,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.*;
@@ -280,7 +279,7 @@ class SpySimulatedConnectionTest
 
     @Test
     @InterruptAfter(10)
-    void shouldNotHaveShortSendsWithMDCPublication() throws Exception
+    void shouldNotHaveShortSendsWithMDCPublication()
     {
         launch();
 
@@ -292,20 +291,7 @@ class SpySimulatedConnectionTest
         Tests.awaitConnected(spy);
         Tests.awaitConnected(publication);
 
-        Thread.sleep(500);
-
-        final AtomicInteger shortSendsCounterId = new AtomicInteger(0);
-        driver.counters().forEach((counterId, typeId, keyBuffer, label) ->
-        {
-            if (AeronCounters.DRIVER_SYSTEM_COUNTER_TYPE_ID == typeId &&
-                SystemCounterDescriptor.SHORT_SENDS.id() == keyBuffer.getInt(0))
-            {
-                shortSendsCounterId.set(counterId);
-            }
-        });
-
-        assertNotEquals(0, shortSendsCounterId);
-        assertEquals(0, driver.counters().getCounterValue(shortSendsCounterId.get()));
+        assertEquals(0, driver.counters().getCounterValue(SystemCounterDescriptor.SHORT_SENDS.id()));
     }
 
     private void waitUntilFullConnectivity()

--- a/aeron-system-tests/src/test/java/io/aeron/SpySimulatedConnectionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/SpySimulatedConnectionTest.java
@@ -294,7 +294,7 @@ class SpySimulatedConnectionTest
 
         Thread.sleep(500);
 
-        AtomicInteger shortSendsCounterId = new AtomicInteger(0);
+        final AtomicInteger shortSendsCounterId = new AtomicInteger(0);
         driver.counters().forEach((counterId, typeId, keyBuffer, label) ->
         {
             if (AeronCounters.DRIVER_SYSTEM_COUNTER_TYPE_ID == typeId &&

--- a/aeron-system-tests/src/test/java/io/aeron/SpySimulatedConnectionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/SpySimulatedConnectionTest.java
@@ -295,7 +295,8 @@ class SpySimulatedConnectionTest
         Thread.sleep(500);
 
         AtomicInteger shortSendsCounterId = new AtomicInteger(0);
-        driver.counters().forEach((counterId, typeId, keyBuffer, label) -> {
+        driver.counters().forEach((counterId, typeId, keyBuffer, label) ->
+        {
             if (AeronCounters.DRIVER_SYSTEM_COUNTER_TYPE_ID == typeId &&
                 SystemCounterDescriptor.SHORT_SENDS.id() == keyBuffer.getInt(0))
             {


### PR DESCRIPTION
The Java media driver sets the initial result ('bytes sent' effectively) to the number of bytes to be sent in the two implementations of `MultiSndDestination#send()`.  The first commit here does the same for the equivalent function in the C media driver.  The second commit is a new system test that fails when run against the C media driver before the fix.