### PR TITLE
[Java] fix ClientConductor concurrent bug

### DIFF
--- a/aeron-client/src/main/java/io/aeron/ClientConductor.java
+++ b/aeron-client/src/main/java/io/aeron/ClientConductor.java
@@ -236,7 +236,8 @@ final class ClientConductor implements Agent
                 subscription.internalClose(NULL_VALUE);
                 resourceByRegIdMap.remove(correlationId);
             }
-        } finally
+        }
+        finally
         {
             clientLock.unlock();
         }

--- a/aeron-client/src/main/java/io/aeron/ClientConductor.java
+++ b/aeron-client/src/main/java/io/aeron/ClientConductor.java
@@ -428,7 +428,8 @@ final class ClientConductor implements Agent
                 }
             }
         }
-        finally {
+        finally
+        {
             clientLock.unlock();
         }
     }


### PR DESCRIPTION
`java.lang.IndexOutOfBoundsException: Index 1 out of bounds for length 1
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:100) ~[?:?]
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:106) ~[?:?]
	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:302) ~[?:?]
	at java.base/java.util.Objects.checkIndex(Objects.java:385) ~[?:?]
	at java.base/java.util.ArrayList.get(ArrayList.java:427) ~[?:?]
	at io.aeron.ClientConductor.checkLingeringResources(ClientConductor.java:1655) ~[aeron-client-1.46.8.jar!/:1.46.8]
	at io.aeron.ClientConductor.checkTimeouts(ClientConductor.java:1565) ~[aeron-client-1.46.8.jar!/:1.46.8]
	at io.aeron.ClientConductor.service(ClientConductor.java:1470) ~[aeron-client-1.46.8.jar!/:1.46.8]
	at io.aeron.ClientConductor.awaitResponse(ClientConductor.java:1529) ~[aeron-client-1.46.8.jar!/:1.46.8]
	at io.aeron.ClientConductor.addExclusivePublication(ClientConductor.java:473) ~[aeron-client-1.46.8.jar!/:1.46.8]
	at io.aeron.Aeron.addExclusivePublication(Aeron.java:294) ~[aeron-client-1.46.8.jar!/:1.46.8]
	at io.aeron.archive.client.AeronArchive.connect(AeronArchive.java:245) ~[aeron-archive-1.46.8.jar!/:1.46.8]
	at io.aeron.cluster.service.ClusteredServiceAgent.loadSnapshot(ClusteredServiceAgent.java:892) ~[aeron-cluster-1.46.8.jar!/:1.46.8]
	at io.aeron.cluster.service.ClusteredServiceAgent.recoverState(ClusteredServiceAgent.java:754) ~[aeron-cluster-1.46.8.jar!/:1.46.8]
	at io.aeron.cluster.service.ClusteredServiceAgent.onStart(ClusteredServiceAgent.java:182) ~[aeron-cluster-1.46.8.jar!/:1.46.8]
	at org.agrona.concurrent.AgentRunner.run(AgentRunner.java:150) ~[agrona-1.23.1.jar!/:1.23.1]
	at java.base/java.lang.Thread.run(Thread.java:1584) [?:?]`