### PR TITLE
Prevent message gaps in cluster sessions

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusterSession.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusterSession.java
@@ -24,6 +24,7 @@ import io.aeron.cluster.codecs.EventCode;
 import io.aeron.exceptions.AeronException;
 import io.aeron.exceptions.RegistrationException;
 import io.aeron.logbuffer.BufferClaim;
+import io.aeron.logbuffer.Header;
 import org.agrona.*;
 import org.agrona.collections.ArrayUtil;
 import org.agrona.concurrent.errors.DistinctErrorLog;
@@ -55,6 +56,7 @@ final class ClusterSession implements ClusterClientSession
     private long openedLogPosition = AeronArchive.NULL_POSITION;
     private long closedLogPosition = AeronArchive.NULL_POSITION;
     private transient long timeOfLastActivityNs;
+    private transient long ingressImageCorrelationId = Aeron.NULL_VALUE;
     private long responsePublicationId = Aeron.NULL_VALUE;
     private final int responseStreamId;
     private final String responseChannel;
@@ -417,6 +419,24 @@ final class ClusterSession implements ClusterClientSession
         return requestInput;
     }
 
+    void linkIngressImage(final Header header)
+    {
+        if (Aeron.NULL_VALUE == ingressImageCorrelationId)
+        {
+            ingressImageCorrelationId = ((Image)header.context()).correlationId();
+        }
+    }
+
+    void unlinkIngressImage()
+    {
+        ingressImageCorrelationId = Aeron.NULL_VALUE;
+    }
+
+    long ingressImageCorrelationId()
+    {
+        return ingressImageCorrelationId;
+    }
+
     static void checkEncodedPrincipalLength(final byte[] encodedPrincipal)
     {
         if (null != encodedPrincipal && encodedPrincipal.length > MAX_ENCODED_PRINCIPAL_LENGTH)
@@ -435,6 +455,7 @@ final class ClusterSession implements ClusterClientSession
             ", openedLogPosition=" + openedLogPosition +
             ", closedLogPosition=" + closedLogPosition +
             ", timeOfLastActivityNs=" + timeOfLastActivityNs +
+            ", ingressImageCorrelationId=" + ingressImageCorrelationId +
             ", responseStreamId=" + responseStreamId +
             ", responseChannel='" + responseChannel + '\'' +
             ", responsePublicationId=" + responsePublicationId +

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -3598,10 +3598,7 @@ final class ConsensusModuleAgent
             return; // don't subscribe to ingress if follower and multicast ingress
         }
 
-        if (!ingressUri.containsKey(REJOIN_PARAM_NAME))
-        {
-            ingressUri.put(REJOIN_PARAM_NAME, "false");
-        }
+        ingressUri.put(REJOIN_PARAM_NAME, "false");
 
         final Subscription subscription = aeron.addSubscription(
             ingressUri.toString(), ctx.ingressStreamId(), null, this::onUnavailableIngressImage);

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -3580,6 +3580,11 @@ final class ConsensusModuleAgent
             return; // don't subscribe to ingress if follower and multicast ingress
         }
 
+        if (!ingressUri.containsKey(REJOIN_PARAM_NAME))
+        {
+            ingressUri.put(REJOIN_PARAM_NAME, "false");
+        }
+
         final Subscription subscription = aeron.addSubscription(
             ingressUri.toString(), ctx.ingressStreamId(), null, this::onUnavailableIngressImage);
 

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -658,7 +658,8 @@ final class ConsensusModuleAgent
         final int responseStreamId,
         final int version,
         final String responseChannel,
-        final byte[] encodedCredentials)
+        final byte[] encodedCredentials,
+        final Header header)
     {
         final long clusterSessionId = Cluster.Role.LEADER == role ? nextSessionId++ : NULL_VALUE;
         final ClusterSession session = new ClusterSession(
@@ -688,6 +689,7 @@ final class ConsensusModuleAgent
             }
             else
             {
+                session.linkIngressImage(header);
                 authenticator.onConnectRequest(session.id(), encodedCredentials, NANOSECONDS.toMillis(nowNs));
                 pendingUserSessions.add(session);
             }
@@ -791,13 +793,14 @@ final class ConsensusModuleAgent
         return ControlledFragmentHandler.Action.CONTINUE;
     }
 
-    void onSessionKeepAlive(final long leadershipTermId, final long clusterSessionId)
+    void onSessionKeepAlive(final long leadershipTermId, final long clusterSessionId, final Header header)
     {
         if (leadershipTermId == this.leadershipTermId && Cluster.Role.LEADER == role)
         {
             final ClusterSession session = sessionByIdMap.get(clusterSessionId);
             if (null != session && session.state() == ClusterSession.State.OPEN)
             {
+                session.linkIngressImage(header);
                 session.timeOfLastActivityNs(clusterClock.timeNanos());
             }
         }
@@ -1341,7 +1344,9 @@ final class ConsensusModuleAgent
             clearSessionsAfter(logPosition);
             for (int i = 0, size = sessions.size(); i < size; i++)
             {
-                sessions.get(i).disconnect(aeron, ctx.countedErrorHandler());
+                final ClusterSession session = sessions.get(i);
+                session.unlinkIngressImage();
+                session.disconnect(aeron, ctx.countedErrorHandler());
             }
 
             commitPosition.setRelease(logPosition);
@@ -3448,6 +3453,19 @@ final class ConsensusModuleAgent
 
     private void onUnavailableIngressImage(final Image image)
     {
+        if (Cluster.Role.LEADER == role && ConsensusModule.State.ACTIVE == state)
+        {
+            for (int i = 0, size = sessions.size(); i < size; i++)
+            {
+                final ClusterSession session = sessions.get(i);
+
+                if (session.ingressImageCorrelationId() == image.correlationId() && session.isOpen())
+                {
+                    session.closing(CloseReason.TIMEOUT);
+                }
+            }
+        }
+
         final boolean isIpc = image.subscription().channel().startsWith(IPC_CHANNEL);
         ingressAdapter.freeSessionBuffer(image.sessionId(), isIpc);
     }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/IngressAdapter.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/IngressAdapter.java
@@ -124,7 +124,8 @@ class IngressAdapter implements AutoCloseable
                     connectRequestDecoder.responseStreamId(),
                     connectRequestDecoder.version(),
                     responseChannel,
-                    credentials);
+                    credentials,
+                    header);
                 break;
             }
 
@@ -152,7 +153,8 @@ class IngressAdapter implements AutoCloseable
 
                 consensusModuleAgent.onSessionKeepAlive(
                     sessionKeepAliveDecoder.leadershipTermId(),
-                    sessionKeepAliveDecoder.clusterSessionId());
+                    sessionKeepAliveDecoder.clusterSessionId(),
+                    header);
                 break;
             }
 

--- a/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
@@ -1474,7 +1474,7 @@ public final class AeronCluster implements AutoCloseable
             }
 
             final ChannelUri egressChannelUri = ChannelUri.parse(egressChannel);
-            if (egressChannelUri.isUdp() && !egressChannelUri.containsKey(REJOIN_PARAM_NAME))
+            if (egressChannelUri.isUdp())
             {
                 egressChannelUri.put(REJOIN_PARAM_NAME, "false");
                 egressChannel = egressChannelUri.toString();

--- a/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
@@ -38,6 +38,7 @@ import java.lang.invoke.VarHandle;
 import java.util.concurrent.TimeUnit;
 
 import static io.aeron.Aeron.NULL_VALUE;
+import static io.aeron.CommonContext.REJOIN_PARAM_NAME;
 import static org.agrona.SystemUtil.getDurationInNanos;
 
 /**
@@ -1470,6 +1471,13 @@ public final class AeronCluster implements AutoCloseable
             if (Strings.isEmpty(egressChannel))
             {
                 throw new ConfigurationException("egressChannel must be specified");
+            }
+
+            final ChannelUri egressChannelUri = ChannelUri.parse(egressChannel);
+            if (egressChannelUri.isUdp() && !egressChannelUri.containsKey(REJOIN_PARAM_NAME))
+            {
+                egressChannelUri.put(REJOIN_PARAM_NAME, "false");
+                egressChannel = egressChannelUri.toString();
             }
         }
 

--- a/aeron-cluster/src/main/resources/cluster/aeron-cluster-codecs.xml
+++ b/aeron-cluster/src/main/resources/cluster/aeron-cluster-codecs.xml
@@ -91,6 +91,7 @@
         - Followers can respond with a REDIRECT code and a list of member endpoint destinations in the
           detail that will have the leader first.
         - If a change of leader occurs mid-session then a new-leader-event will be sent from the new leader.
+          Ideally, a client should send a session-keep-alive message as the first message to the new leader.
 
     2. Ingress/Egress Messages - Session Messages which make up application protocol.
         - Messages are sent to a clustered service with a SessionMessageHeader followed by an application payload.

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterSessionReliabilityTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterSessionReliabilityTest.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2025 Adaptive Financial Consulting Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.cluster;
+
+import io.aeron.ChannelUri;
+import io.aeron.cluster.client.AeronCluster;
+import io.aeron.cluster.codecs.CloseReason;
+import io.aeron.cluster.service.ClientSession;
+import io.aeron.driver.SendChannelEndpointSupplier;
+import io.aeron.driver.ext.DebugSendChannelEndpoint;
+import io.aeron.driver.ext.LossGenerator;
+import io.aeron.logbuffer.Header;
+import io.aeron.test.EventLogExtension;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
+import io.aeron.test.Tests;
+import io.aeron.test.cluster.TestCluster;
+import io.aeron.test.cluster.TestNode;
+import io.aeron.test.driver.TestMediaDriver;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.collections.Long2LongHashMap;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.IntFunction;
+
+import static io.aeron.CommonContext.ENDPOINT_PARAM_NAME;
+import static io.aeron.test.cluster.TestCluster.aCluster;
+import static org.agrona.BitUtil.SIZE_OF_LONG;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith({ EventLogExtension.class, InterruptingTestCallback.class })
+class ClusterSessionReliabilityTest
+{
+    @RegisterExtension
+    final SystemTestWatcher systemTestWatcher = new SystemTestWatcher();
+
+    @Test
+    @InterruptAfter(10)
+    void sessionShouldGetClosedWhenIngressImageGoesUnavailableToPreventSilentMessageLoss()
+    {
+        sessionShouldGetClosedWhenIngressImageGoesUnavailableToPreventSilentMessageLoss(false, false);
+    }
+
+    @Test
+    @InterruptAfter(10)
+    void sessionShouldGetClosedWhenMulticastIngressImageGoesUnavailableToPreventSilentMessageLoss()
+    {
+        sessionShouldGetClosedWhenIngressImageGoesUnavailableToPreventSilentMessageLoss(true, false);
+    }
+
+    @Test
+    @InterruptAfter(20)
+    void sessionShouldGetClosedWhenIngressImageGoesUnavailableAfterFailoverToPreventSilentMessageLoss()
+    {
+        sessionShouldGetClosedWhenIngressImageGoesUnavailableToPreventSilentMessageLoss(false, true);
+    }
+
+    @Test
+    @InterruptAfter(20)
+    void sessionShouldGetClosedWhenMulticastIngressImageGoesUnavailableAfterFailoverToPreventSilentMessageLoss()
+    {
+        sessionShouldGetClosedWhenIngressImageGoesUnavailableToPreventSilentMessageLoss(true, true);
+    }
+
+    private void sessionShouldGetClosedWhenIngressImageGoesUnavailableToPreventSilentMessageLoss(
+        final boolean multicastIngress,
+        final boolean withFailover)
+    {
+        TestMediaDriver.notSupportedOnCMediaDriver("uses custom channel endpoint suppliers for simulating loss");
+
+        final AtomicLong outOfSequenceCount = new AtomicLong();
+        final IntFunction<TestNode.TestService[]> serviceSupplier =
+            (index) -> new TestNode.TestService[]
+            {
+                new SequenceCheckingService(index, outOfSequenceCount)
+            };
+        String ingressChannel = "aeron:udp?term-length=128k|alias=ingress";
+        if (multicastIngress)
+        {
+            ingressChannel += "|endpoint=239.192.11.87:20123|interface=127.0.0.1";
+        }
+        final long imageLivenessTimeoutNs = TimeUnit.MILLISECONDS.toNanos(1000);
+        final long sessionTimeoutNs = TimeUnit.MILLISECONDS.toNanos(4000);
+        final TestCluster cluster = aCluster()
+            .withStaticNodes(3)
+            .withServiceSupplier(serviceSupplier)
+            .withIngressChannel(ingressChannel)
+            .withImageLivenessTimeoutNs(imageLivenessTimeoutNs)
+            .withSessionTimeoutNs(sessionTimeoutNs)
+            .start();
+        systemTestWatcher.cluster(cluster);
+
+        TestNode leader = cluster.awaitLeader();
+
+        final PortLossGenerator clientSendLossGenerator = new PortLossGenerator();
+        cluster.clientSendChannelEndpointSupplier(sendChannelEndpointSupplier(clientSendLossGenerator));
+        final AeronCluster client = cluster.connectClient();
+
+        if (withFailover)
+        {
+            leader.gracefulClose();
+
+            cluster.awaitNewLeadershipEvent(1);
+
+            final int previousLeaderIndex = leader.index();
+            leader = cluster.awaitLeader();
+            assertNotEquals(previousLeaderIndex, leader.index());
+        }
+
+        final SequenceCheckingService leaderService = (SequenceCheckingService)leader.service();
+
+        cluster.shouldErrorOnClientClose(false);
+
+        final MutableDirectBuffer buffer = new UnsafeBuffer(new byte[SIZE_OF_LONG]);
+        long sequence = 0;
+        boolean lossRequested = false;
+        long now = System.nanoTime();
+        long nextMessageAt = now;
+        final long deadline = now + sessionTimeoutNs + TimeUnit.SECONDS.toNanos(1);
+        while (true)
+        {
+            now = System.nanoTime();
+
+            if (now - deadline >= 0)
+            {
+                break;
+            }
+
+            if (now - nextMessageAt >= 0)
+            {
+                buffer.putLong(0, sequence);
+                if (client.offer(buffer, 0, buffer.capacity()) > 0)
+                {
+                    sequence++;
+                    nextMessageAt += TimeUnit.MILLISECONDS.toNanos(10);
+                }
+            }
+
+            client.pollEgress();
+
+            if (client.isClosed())
+            {
+                break;
+            }
+
+            if (!lossRequested && leaderService.messageCount() >= 5)
+            {
+                clientSendLossGenerator.startDropping(
+                    endpointPort(client.ingressPublication().channel()),
+                    imageLivenessTimeoutNs + TimeUnit.MILLISECONDS.toNanos(200));
+                lossRequested = true;
+            }
+
+            Tests.sleep(1);
+        }
+
+        assertTrue(lossRequested);
+        assertEquals(0, outOfSequenceCount.get());
+        assertTrue(client.isClosed());
+    }
+
+    private int endpointPort(final String channel)
+    {
+        final ChannelUri uri = ChannelUri.parse(channel);
+        final String endpoint = uri.get(ENDPOINT_PARAM_NAME);
+        return Integer.parseInt(endpoint.substring(endpoint.indexOf(':') + 1));
+    }
+
+    private static SendChannelEndpointSupplier sendChannelEndpointSupplier(final LossGenerator lossGenerator)
+    {
+        return (udpChannel, statusIndicator, context) ->
+        new DebugSendChannelEndpoint(udpChannel, statusIndicator, context, lossGenerator, lossGenerator);
+    }
+
+    private static class SequenceCheckingService extends TestNode.TestService
+    {
+        private final Long2LongHashMap nextSequenceBySessionId = new Long2LongHashMap(-1);
+        private final AtomicLong outOfSequenceCount;
+
+        SequenceCheckingService(final int index, final AtomicLong outOfSequenceCount)
+        {
+            this.outOfSequenceCount = outOfSequenceCount;
+            index(index);
+        }
+
+        public void onSessionMessage(
+            final ClientSession session,
+            final long timestamp,
+            final DirectBuffer buffer,
+            final int offset,
+            final int length,
+            final Header header)
+        {
+            final long sessionId = session.id();
+            final long sequence = buffer.getLong(offset);
+            final long expectedSequence = nextSequenceBySessionId.get(sessionId);
+            if (sequence != expectedSequence)
+            {
+                System.out.println("expected sequence " + expectedSequence + ", but got " + sequence);
+                outOfSequenceCount.incrementAndGet();
+            }
+            nextSequenceBySessionId.put(sessionId, sequence + 1);
+            messageCount.incrementAndGet();
+        }
+
+        public void onSessionOpen(final ClientSession session, final long timestamp)
+        {
+            super.onSessionOpen(session, timestamp);
+            nextSequenceBySessionId.put(session.id(), 0);
+        }
+
+        public void onSessionClose(final ClientSession session, final long timestamp, final CloseReason closeReason)
+        {
+            super.onSessionClose(session, timestamp, closeReason);
+            nextSequenceBySessionId.remove(session.id());
+        }
+    }
+
+    private static final class PortLossGenerator implements LossGenerator
+    {
+        private int port;
+        private long dropUntil;
+        private volatile boolean drop;
+
+        public void startDropping(final int port, final long durationNs)
+        {
+            this.port = port;
+            dropUntil = System.nanoTime() + durationNs;
+            drop = true;
+        }
+
+        public boolean shouldDropFrame(final InetSocketAddress address, final UnsafeBuffer buffer, final int length)
+        {
+            if (drop && port == address.getPort())
+            {
+                if (System.nanoTime() - dropUntil < 0)
+                {
+                    return true;
+                }
+                else
+                {
+                    drop = false;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterSessionReliabilityTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterSessionReliabilityTest.java
@@ -128,6 +128,11 @@ class ClusterSessionReliabilityTest
             final int previousLeaderIndex = leader.index();
             leader = cluster.awaitLeader();
             assertNotEquals(previousLeaderIndex, leader.index());
+
+            while (!client.sendKeepAlive())
+            {
+                Tests.yieldingIdle("failed to send keep-alive");
+            }
         }
 
         final SequenceCheckingService leaderService = (SequenceCheckingService)leader.service();

--- a/aeron-test-support/src/main/java/io/aeron/test/driver/PortLossGenerator.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/driver/PortLossGenerator.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 Adaptive Financial Consulting Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.test.driver;
+
+import io.aeron.driver.ext.LossGenerator;
+import org.agrona.concurrent.UnsafeBuffer;
+
+import java.net.InetSocketAddress;
+
+public class PortLossGenerator implements LossGenerator
+{
+    private int port;
+    private long dropUntil;
+    private volatile boolean drop;
+
+    public void startDropping(final int port, final long durationNs)
+    {
+        this.port = port;
+        dropUntil = System.nanoTime() + durationNs;
+        drop = true;
+    }
+
+    public boolean shouldDropFrame(final InetSocketAddress address, final UnsafeBuffer buffer, final int length)
+    {
+        if (drop && port == address.getPort())
+        {
+            if (System.nanoTime() - dropUntil < 0)
+            {
+                return true;
+            }
+            else
+            {
+                drop = false;
+            }
+        }
+
+        return false;
+    }
+}

--- a/aeron-test-support/src/main/java/io/aeron/test/driver/StreamIdLossGenerator.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/driver/StreamIdLossGenerator.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 Adaptive Financial Consulting Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.test.driver;
+
+import io.aeron.driver.ext.LossGenerator;
+import org.agrona.concurrent.UnsafeBuffer;
+
+import java.net.InetSocketAddress;
+
+public class StreamIdLossGenerator implements LossGenerator
+{
+    private int streamId;
+    private long dropUntil;
+    private volatile boolean drop;
+
+    public void startDropping(final int streamId, final long durationNs)
+    {
+        this.streamId = streamId;
+        dropUntil = System.nanoTime() + durationNs;
+        drop = true;
+    }
+
+    public boolean shouldDropFrame(
+        final InetSocketAddress address,
+        final UnsafeBuffer buffer,
+        final int streamId,
+        final int sessionId,
+        final int termId,
+        final int termOffset,
+        final int length)
+    {
+        if (drop && streamId == this.streamId)
+        {
+            if (System.nanoTime() - dropUntil < 0)
+            {
+                return true;
+            }
+            else
+            {
+                drop = false;
+            }
+        }
+
+        return false;
+    }
+
+    public boolean shouldDropFrame(final InetSocketAddress address, final UnsafeBuffer buffer, final int length)
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
It's possible that after some transient network issue where an image goes unavailable and then available again, a leader will process ingress messages with a gap, and similarly it's possible that a client will process egress messages with a gap. This silent message loss could lead to issues in application protocols which do not expect gaps, so we want to prevent that. This should be very unlikely with the default settings though.

The commits:

- fix the issue on the cluster side for ingress,
- add an optimization to close a session when image goes unavailable without waiting for the session timeout,
- fix the issue on the client side for egress.

A breaking change if someone would run an old client and a new one on the same driver with the same channel, because different rejoin settings are conflicting.