### PR TITLE
File page aligned mark files.

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/Archive.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Archive.java
@@ -1254,7 +1254,7 @@ public final class Archive implements AutoCloseable
                             .aeronDirectoryName(aeronDirectoryName)
                             .epochClock(epochClock)
                             .nanoClock(nanoClock)
-                            .errorHandler(RethrowingErrorHandler.INSTANCE)
+                            .errorHandler(errorHandler)
                             .driverAgentInvoker(mediaDriverAgentInvoker)
                             .useConductorAgentInvoker(true)
                             .subscriberErrorHandler(RethrowingErrorHandler.INSTANCE)

--- a/aeron-archive/src/main/java/io/aeron/archive/Archive.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Archive.java
@@ -2456,7 +2456,7 @@ public final class Archive implements AutoCloseable
          * @see Configuration#SEGMENT_FILE_LENGTH_PROP_NAME
          */
         @Config
-        int segmentFileLength()
+        public int segmentFileLength()
         {
             return segmentFileLength;
         }
@@ -2488,7 +2488,7 @@ public final class Archive implements AutoCloseable
          * @see Configuration#FILE_SYNC_LEVEL_PROP_NAME
          */
         @Config
-        int fileSyncLevel()
+        public int fileSyncLevel()
         {
             return fileSyncLevel;
         }
@@ -2525,7 +2525,7 @@ public final class Archive implements AutoCloseable
          * @see Configuration#CATALOG_FILE_SYNC_LEVEL_PROP_NAME
          */
         @Config
-        int catalogFileSyncLevel()
+        public int catalogFileSyncLevel()
         {
             return catalogFileSyncLevel;
         }
@@ -2554,7 +2554,7 @@ public final class Archive implements AutoCloseable
          *
          * @return the {@link AgentInvoker} that should be used for the Media Driver if running in a lightweight mode.
          */
-        AgentInvoker mediaDriverAgentInvoker()
+        public AgentInvoker mediaDriverAgentInvoker()
         {
             return mediaDriverAgentInvoker;
         }

--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveMarkFile.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveMarkFile.java
@@ -444,14 +444,14 @@ public class ArchiveMarkFile implements AutoCloseable
         }
 
         final int filePageSize;
-        if (null == ctx.aeron())
+        if (null != ctx.aeron())
         {
-            filePageSize = CommonContext.driverFilePageSize(
-                new File(ctx.aeronDirectoryName()), ctx.epochClock(), new CommonContext().driverTimeoutMs());
+            filePageSize = ctx.aeron().context().filePageSize();
         }
         else
         {
-            filePageSize = ctx.aeron().context().filePageSize();
+            filePageSize = CommonContext.driverFilePageSize(
+                new File(ctx.aeronDirectoryName()), ctx.epochClock(), new CommonContext().driverTimeoutMs());
         }
         return BitUtil.align(HEADER_LENGTH + ctx.errorBufferLength(), 0 != filePageSize ? filePageSize : PAGE_MIN_SIZE);
     }

--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveMarkFile.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveMarkFile.java
@@ -118,56 +118,51 @@ public class ArchiveMarkFile implements AutoCloseable
 
         if (file.exists())
         {
-            final int headerOffset = headerOffset(file);
-
-            final MarkFile markFile = new MarkFile(
+            final int currentHeaderOffset = headerOffset(file);
+            final MarkFile existingMarkFile = new MarkFile(
                 file,
                 true,
-                headerOffset + MarkFileHeaderDecoder.versionEncodingOffset(),
-                headerOffset + MarkFileHeaderDecoder.activityTimestampEncodingOffset(),
+                currentHeaderOffset + MarkFileHeaderDecoder.versionEncodingOffset(),
+                currentHeaderOffset + MarkFileHeaderDecoder.activityTimestampEncodingOffset(),
                 totalFileLength,
                 timeoutMs,
                 epochClock,
                 (version) -> validateVersion(file, version),
                 null);
 
-            final UnsafeBuffer buffer = markFile.buffer();
+            final UnsafeBuffer existingBuffer = existingMarkFile.buffer();
 
-            if (buffer.capacity() != totalFileLength)
+            if (0 != currentHeaderOffset)
             {
-                throw new ArchiveException(
-                    "ArchiveMarkFile capacity=" + buffer.capacity() + " < expectedCapacity=" + totalFileLength);
-            }
-
-            if (0 != headerOffset)
-            {
-                headerDecoder.wrapAndApplyHeader(buffer, 0, messageHeaderDecoder);
+                headerDecoder.wrapAndApplyHeader(existingBuffer, 0, messageHeaderDecoder);
             }
             else
             {
-                headerDecoder.wrap(buffer, 0, MarkFileHeaderDecoder.BLOCK_LENGTH, MarkFileHeaderDecoder.SCHEMA_VERSION);
+                headerDecoder.wrap(
+                    existingBuffer, 0, MarkFileHeaderDecoder.BLOCK_LENGTH, MarkFileHeaderDecoder.SCHEMA_VERSION);
             }
 
             final int existingErrorBufferLength = headerDecoder.errorBufferLength();
             if (existingErrorBufferLength > 0)
             {
                 final UnsafeBuffer existingErrorBuffer = new UnsafeBuffer(
-                    buffer, headerDecoder.headerLength(), existingErrorBufferLength);
+                    existingBuffer, headerDecoder.headerLength(), existingErrorBufferLength);
 
                 saveExistingErrors(file, existingErrorBuffer, CommonContext.fallbackLogger());
                 existingErrorBuffer.setMemory(0, existingErrorBufferLength, (byte)0);
             }
 
-            if (0 != headerOffset)
+            if (0 != currentHeaderOffset)
             {
-                this.markFile = markFile;
-                this.buffer = buffer;
+                markFile = existingMarkFile;
+                buffer = existingBuffer;
             }
             else
             {
                 headerDecoder.wrap(EMPTY_BUFFER, 0, 0, 0);
-                CloseHelper.close(markFile);
-                this.markFile = new MarkFile(
+                CloseHelper.close(existingMarkFile);
+
+                markFile = new MarkFile(
                     file,
                     false,
                     HEADER_OFFSET + MarkFileHeaderDecoder.versionEncodingOffset(),
@@ -177,8 +172,8 @@ public class ArchiveMarkFile implements AutoCloseable
                     epochClock,
                     null,
                     null);
-                this.buffer = this.markFile.buffer();
-                this.buffer.setMemory(0, this.buffer.capacity(), (byte)0);
+                buffer = markFile.buffer();
+                buffer.setMemory(0, buffer.capacity(), (byte)0);
             }
         }
         else

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveMarkFileTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveMarkFileTest.java
@@ -47,6 +47,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 
+import static io.aeron.logbuffer.LogBufferDescriptor.PAGE_MIN_SIZE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -75,7 +76,9 @@ class ArchiveMarkFileTest
         assertFalse(markFile.exists());
 
         final Aeron aeron = mock(Aeron.class);
-        when(aeron.context()).thenReturn(mock(Aeron.Context.class));
+        final Aeron.Context aeronCtx = mock(Aeron.Context.class);
+        when(aeronCtx.filePageSize()).thenReturn(PAGE_MIN_SIZE);
+        when(aeron.context()).thenReturn(aeronCtx);
 
         final Archive.Context context = TestContexts.localhostArchive()
             .archiveDir(archiveDir)
@@ -132,7 +135,11 @@ class ArchiveMarkFileTest
         final File archiveMarkFile = new File(markFileDir, ArchiveMarkFile.FILENAME);
 
         final Aeron aeron = mock(Aeron.class);
-        when(aeron.context()).thenReturn(new Aeron.Context().useConductorAgentInvoker(false));
+        final Aeron.Context aeronCtx = mock(Aeron.Context.class);
+        when(aeronCtx.aeronDirectoryName()).thenReturn("/dev/shm/aeron");
+        when(aeronCtx.filePageSize()).thenReturn(PAGE_MIN_SIZE);
+        when(aeronCtx.useConductorAgentInvoker()).thenReturn(false);
+        when(aeron.context()).thenReturn(aeronCtx);
 
         final MediaDriver.Context driverContext = new MediaDriver.Context()
             .aeronDirectoryName(aeronDir.getAbsolutePath())
@@ -264,7 +271,9 @@ class ArchiveMarkFileTest
         }
 
         final Aeron aeron = mock(Aeron.class);
-        when(aeron.context()).thenReturn(mock(Aeron.Context.class));
+        final Aeron.Context aeronCtx = mock(Aeron.Context.class);
+        when(aeronCtx.filePageSize()).thenReturn(PAGE_MIN_SIZE);
+        when(aeron.context()).thenReturn(aeronCtx);
 
         final Archive.Context context = new Archive.Context()
             .archiveDir(new File(tempDir, "archive"))
@@ -334,7 +343,9 @@ class ArchiveMarkFileTest
         }
 
         final Aeron aeron = mock(Aeron.class);
-        when(aeron.context()).thenReturn(mock(Aeron.Context.class));
+        final Aeron.Context aeronCtx = mock(Aeron.Context.class);
+        when(aeronCtx.filePageSize()).thenReturn(PAGE_MIN_SIZE);
+        when(aeron.context()).thenReturn(aeronCtx);
 
         final Archive.Context context = new Archive.Context()
             .archiveDir(new File(tempDir, "archive/a/long/path/to"))
@@ -492,7 +503,7 @@ class ArchiveMarkFileTest
         final Archive.Context context = new Archive.Context();
         final Aeron aeron = mock(Aeron.class);
         final Aeron.Context aeronContext = mock(Aeron.Context.class);
-        when(aeronContext.filePageSize()).thenReturn(0);
+        when(aeronContext.filePageSize()).thenReturn(PAGE_MIN_SIZE);
         when(aeronContext.aeronDirectory()).thenReturn(aeronDir.toFile());
         when(aeronContext.aeronDirectoryName()).thenReturn(aeronDir.toString());
         when(aeron.context()).thenReturn(aeronContext);

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveMarkFileTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveMarkFileTest.java
@@ -16,6 +16,7 @@
 package io.aeron.archive;
 
 import io.aeron.Aeron;
+import io.aeron.CommonContext;
 import io.aeron.archive.client.AeronArchive;
 import io.aeron.archive.client.ArchiveException;
 import io.aeron.archive.codecs.mark.MarkFileHeaderDecoder;
@@ -24,6 +25,7 @@ import io.aeron.archive.codecs.mark.MessageHeaderDecoder;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.test.TestContexts;
+import org.agrona.BitUtil;
 import org.agrona.IoUtil;
 import org.agrona.MarkFile;
 import org.agrona.SemanticVersion;
@@ -47,8 +49,17 @@ import java.nio.file.StandardOpenOption;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class ArchiveMarkFileTest
 {
@@ -57,17 +68,19 @@ class ArchiveMarkFileTest
     @Test
     void shouldUseMarkFileDirectory(final @TempDir File tempDir)
     {
-        final File aeronDir = new File(tempDir, "aeron");
         final File archiveDir = new File(tempDir, "archive_dir");
         final File markFileDir = new File(tempDir, "mark-file-home");
         final File markFile = new File(markFileDir, ArchiveMarkFile.FILENAME);
         assertTrue(markFileDir.mkdirs());
         assertFalse(markFile.exists());
 
+        final Aeron aeron = mock(Aeron.class);
+        when(aeron.context()).thenReturn(mock(Aeron.Context.class));
+
         final Archive.Context context = TestContexts.localhostArchive()
             .archiveDir(archiveDir)
             .markFileDir(markFileDir)
-            .aeronDirectoryName(aeronDir.getAbsolutePath());
+            .aeron(aeron);
         shouldEncodeMarkFileFromArchiveContext(context);
 
         assertTrue(markFile.exists());
@@ -92,8 +105,8 @@ class ArchiveMarkFileTest
             .epochClock(SystemEpochClock.INSTANCE)
             .threadingMode(ArchiveThreadingMode.SHARED);
 
-        try (MediaDriver driver = MediaDriver.launch(driverContext.clone());
-            Archive archive = Archive.launch(archiveContext.clone()))
+        try (MediaDriver ignored = MediaDriver.launch(driverContext.clone());
+            Archive ignored1 = Archive.launch(archiveContext.clone()))
         {
             assertTrue(new File(markFileDir, ArchiveMarkFile.FILENAME).exists());
             assertTrue(new File(archiveDir, ArchiveMarkFile.LINK_FILENAME).exists());
@@ -101,8 +114,8 @@ class ArchiveMarkFileTest
         }
 
         archiveContext.markFileDir(null);
-        try (MediaDriver driver = MediaDriver.launch(driverContext.clone());
-            Archive archive = Archive.launch(archiveContext.clone()))
+        try (MediaDriver ignored = MediaDriver.launch(driverContext.clone());
+            Archive ignored1 = Archive.launch(archiveContext.clone()))
         {
             assertTrue(new File(archiveDir, ArchiveMarkFile.FILENAME).exists());
             assertFalse(new File(archiveDir, ArchiveMarkFile.LINK_FILENAME).exists());
@@ -132,7 +145,7 @@ class ArchiveMarkFileTest
             .epochClock(SystemEpochClock.INSTANCE)
             .aeron(aeron);
 
-        // Force an error on startup by attempting to start an archive without a media driver.
+        // Force an error on startup by attempting to use invalid Aeron client
         try (Archive ignored = Archive.launch(archiveContext.clone()))
         {
             fail("Expected archive to timeout as no media driver is running.");
@@ -250,10 +263,13 @@ class ArchiveMarkFileTest
             assertEquals(Aeron.NULL_VALUE, archiveMarkFile.archiveId());
         }
 
+        final Aeron aeron = mock(Aeron.class);
+        when(aeron.context()).thenReturn(mock(Aeron.Context.class));
+
         final Archive.Context context = new Archive.Context()
             .archiveDir(new File(tempDir, "archive"))
             .markFileDir(file.getParent().toFile())
-            .aeronDirectoryName(aeronDirectory);
+            .aeron(aeron);
         shouldEncodeMarkFileFromArchiveContext(context);
     }
 
@@ -317,10 +333,13 @@ class ArchiveMarkFileTest
             assertEquals(Aeron.NULL_VALUE, archiveMarkFile.archiveId());
         }
 
+        final Aeron aeron = mock(Aeron.class);
+        when(aeron.context()).thenReturn(mock(Aeron.Context.class));
+
         final Archive.Context context = new Archive.Context()
             .archiveDir(new File(tempDir, "archive/a/long/path/to"))
             .markFileDir(file.getParent().toFile())
-            .aeronDirectoryName(aeronDirectory)
+            .aeron(aeron)
             .errorBufferLength(errorBufferLength);
         shouldEncodeMarkFileFromArchiveContext(context);
     }
@@ -424,6 +443,103 @@ class ArchiveMarkFileTest
 
         archiveMarkFile.signalReady();
         assertTrue(archiveMarkFile.isClosed());
+    }
+
+    @Test
+    void shouldAlignMarkFileLengthToFilePageSizeFromAeronClient(final @TempDir Path tempDir) throws IOException
+    {
+        final Path aeronDir = tempDir.resolve("aeron");
+        final Path archiveDir = tempDir.resolve("archive");
+        final Path markFileDir = tempDir.resolve("mark");
+        Files.createDirectories(aeronDir);
+        Files.createDirectories(archiveDir);
+        Files.createDirectories(markFileDir);
+
+        final Archive.Context context = new Archive.Context();
+        final Aeron aeron = mock(Aeron.class);
+        final Aeron.Context aeronContext = mock(Aeron.Context.class);
+        final int filePageSize = 16 * 1024;
+        when(aeronContext.filePageSize()).thenReturn(filePageSize);
+        when(aeronContext.aeronDirectory()).thenReturn(aeronDir.toFile());
+        when(aeronContext.aeronDirectoryName()).thenReturn(aeronDir.toString());
+        when(aeron.context()).thenReturn(aeronContext);
+        context
+            .aeron(aeron)
+            .archiveDir(archiveDir.toFile())
+            .markFileDir(markFileDir.toFile())
+            .epochClock(SystemEpochClock.INSTANCE);
+
+        try (ArchiveMarkFile archiveMarkFile = new ArchiveMarkFile(context))
+        {
+            assertEquals(
+                BitUtil.align(ArchiveMarkFile.HEADER_LENGTH + context.errorBufferLength(), filePageSize),
+                archiveMarkFile.buffer().capacity());
+        }
+
+        verify(aeronContext).filePageSize();
+    }
+
+    @Test
+    void shouldAlignMarkFileLengthTo4KIfAeronClientReturnsZero(final @TempDir Path tempDir) throws IOException
+    {
+        final Path aeronDir = tempDir.resolve("aeron");
+        final Path archiveDir = tempDir.resolve("archive");
+        final Path markFileDir = tempDir.resolve("mark");
+        Files.createDirectories(aeronDir);
+        Files.createDirectories(archiveDir);
+        Files.createDirectories(markFileDir);
+
+        final Archive.Context context = new Archive.Context();
+        final Aeron aeron = mock(Aeron.class);
+        final Aeron.Context aeronContext = mock(Aeron.Context.class);
+        when(aeronContext.filePageSize()).thenReturn(0);
+        when(aeronContext.aeronDirectory()).thenReturn(aeronDir.toFile());
+        when(aeronContext.aeronDirectoryName()).thenReturn(aeronDir.toString());
+        when(aeron.context()).thenReturn(aeronContext);
+        context
+            .aeron(aeron)
+            .archiveDir(archiveDir.toFile())
+            .markFileDir(markFileDir.toFile())
+            .epochClock(SystemEpochClock.INSTANCE)
+            .errorBufferLength(1111111);
+
+        try (ArchiveMarkFile archiveMarkFile = new ArchiveMarkFile(context))
+        {
+            assertEquals(
+                BitUtil.align(ArchiveMarkFile.HEADER_LENGTH + context.errorBufferLength(), 4096),
+                archiveMarkFile.buffer().capacity());
+        }
+
+        verify(aeronContext).filePageSize();
+    }
+
+
+    @Test
+    @SuppressWarnings("try")
+    void shouldAlignMarkFileLengthToFilePageSizeFromMediaDriver(final @TempDir Path tempDir) throws IOException
+    {
+        final Path archiveDir = tempDir.resolve("archive");
+        Files.createDirectories(archiveDir);
+
+        final int filePageSize = 2 * 1024 * 1024;
+        final MediaDriver.Context mediaDriverContext = new MediaDriver.Context()
+            .aeronDirectoryName(CommonContext.generateRandomDirName())
+            .threadingMode(ThreadingMode.SHARED)
+            .filePageSize(filePageSize);
+
+        final Archive.Context context = new Archive.Context();
+        context
+            .aeronDirectoryName(mediaDriverContext.aeronDirectoryName())
+            .markFileDir(new File(mediaDriverContext.aeronDirectoryName()))
+            .archiveDir(archiveDir.toFile())
+            .epochClock(SystemEpochClock.INSTANCE)
+            .errorBufferLength(1234567);
+
+        try (MediaDriver ignored = MediaDriver.launch(mediaDriverContext);
+            ArchiveMarkFile archiveMarkFile = new ArchiveMarkFile(context))
+        {
+            assertEquals(filePageSize, archiveMarkFile.buffer().capacity());
+        }
     }
 
     private static void shouldEncodeMarkFileFromArchiveContext(final Archive.Context ctx)

--- a/aeron-client/src/main/c/aeron_cnc.c
+++ b/aeron-client/src/main/c/aeron_cnc.c
@@ -123,6 +123,7 @@ int aeron_cnc_constants(aeron_cnc_t *aeron_cnc, aeron_cnc_constants_t *constants
     constants->client_liveness_timeout = aeron_cnc->metadata->client_liveness_timeout;
     constants->start_timestamp = aeron_cnc->metadata->start_timestamp;
     constants->pid = aeron_cnc->metadata->pid;
+    constants->file_page_size = aeron_cnc->metadata->file_page_size;
 
     return 0;
 }

--- a/aeron-client/src/main/c/aeron_cnc_file_descriptor.h
+++ b/aeron-client/src/main/c/aeron_cnc_file_descriptor.h
@@ -54,7 +54,7 @@ typedef enum aeron_cnc_load_result_stct
 }
 aeron_cnc_load_result_t;
 
-#define AERON_CNC_VERSION_AND_META_DATA_LENGTH (AERON_ALIGN(sizeof(aeron_cnc_metadata_t), AERON_CACHE_LINE_LENGTH * 2u))
+#define AERON_CNC_VERSION_AND_META_DATA_LENGTH UINT32_C(AERON_CACHE_LINE_LENGTH * 2)
 
 inline uint8_t *aeron_cnc_to_driver_buffer(aeron_cnc_metadata_t *metadata)
 {

--- a/aeron-client/src/main/c/aeron_cnc_file_descriptor.h
+++ b/aeron-client/src/main/c/aeron_cnc_file_descriptor.h
@@ -23,6 +23,7 @@
 #include "util/aeron_fileutil.h"
 
 #define AERON_CNC_FILE "cnc.dat"
+#define AERON_CNC_VERSION (aeron_semantic_version_compose(0, 2, 0))
 
 #pragma pack(push)
 #pragma pack(4)
@@ -37,6 +38,7 @@ typedef struct aeron_cnc_metadata_stct
     int64_t client_liveness_timeout;
     int64_t start_timestamp;
     int64_t pid;
+    int32_t file_page_size;
 }
 aeron_cnc_metadata_t;
 #pragma pack(pop)
@@ -116,7 +118,5 @@ aeron_cnc_load_result_t aeron_cnc_map_file_and_load_metadata(
     const char *dir, aeron_mapped_file_t *mapped_file, aeron_cnc_metadata_t **metadata);
 
 int aeron_cnc_resolve_filename(const char *directory, char *filename_buffer, size_t filename_buffer_length);
-
-#define AERON_CNC_VERSION (aeron_semantic_version_compose(0, 2, 0))
 
 #endif //AERON_C_CNC_FILE_DESCRIPTOR_H

--- a/aeron-client/src/main/c/aeronc.h
+++ b/aeron-client/src/main/c/aeronc.h
@@ -2523,6 +2523,7 @@ typedef struct aeron_cnc_constants_stct
     int64_t client_liveness_timeout;
     int64_t start_timestamp;
     int64_t pid;
+    int32_t file_page_size;
 }
 aeron_cnc_constants_t;
 #pragma pack(pop)

--- a/aeron-client/src/main/java/io/aeron/Aeron.java
+++ b/aeron-client/src/main/java/io/aeron/Aeron.java
@@ -23,8 +23,25 @@ import io.aeron.exceptions.ConfigurationException;
 import io.aeron.exceptions.DriverTimeoutException;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.version.Versioned;
-import org.agrona.*;
-import org.agrona.concurrent.*;
+import org.agrona.BufferUtil;
+import org.agrona.CloseHelper;
+import org.agrona.DirectBuffer;
+import org.agrona.ErrorHandler;
+import org.agrona.ExpandableArrayBuffer;
+import org.agrona.Strings;
+import org.agrona.concurrent.AgentInvoker;
+import org.agrona.concurrent.AgentRunner;
+import org.agrona.concurrent.AtomicBuffer;
+import org.agrona.concurrent.BusySpinIdleStrategy;
+import org.agrona.concurrent.CountedErrorHandler;
+import org.agrona.concurrent.EpochClock;
+import org.agrona.concurrent.IdleStrategy;
+import org.agrona.concurrent.NanoClock;
+import org.agrona.concurrent.NoOpLock;
+import org.agrona.concurrent.SleepingMillisIdleStrategy;
+import org.agrona.concurrent.SystemEpochClock;
+import org.agrona.concurrent.SystemNanoClock;
+import org.agrona.concurrent.YieldingIdleStrategy;
 import org.agrona.concurrent.broadcast.BroadcastReceiver;
 import org.agrona.concurrent.broadcast.CopyBroadcastReceiver;
 import org.agrona.concurrent.ringbuffer.ManyToOneRingBuffer;
@@ -1027,7 +1044,7 @@ public class Aeron implements AutoCloseable
             }
 
             connectToDriver();
-            filePageSize = CncFileDescriptor.filePageSize(cncMetaDataBuffer);
+            filePageSize = driverFilePageSize(cncMetaDataBuffer);
 
             interServiceTimeoutNs = CncFileDescriptor.clientLivenessTimeoutNs(cncMetaDataBuffer);
             if (interServiceTimeoutNs <= keepAliveIntervalNs)

--- a/aeron-client/src/main/java/io/aeron/Aeron.java
+++ b/aeron-client/src/main/java/io/aeron/Aeron.java
@@ -1771,6 +1771,7 @@ public class Aeron implements AutoCloseable
          * Get file page size from running media driver.
          *
          * @return file page size or zero (if not connected to the media driver).
+         * @since 1.48.0
          */
         public int filePageSize()
         {

--- a/aeron-client/src/main/java/io/aeron/Aeron.java
+++ b/aeron-client/src/main/java/io/aeron/Aeron.java
@@ -1909,7 +1909,7 @@ public class Aeron implements AutoCloseable
         {
             while (true)
             {
-                while (!file.exists() || file.length() < CncFileDescriptor.META_DATA_LENGTH)
+                while (!file.exists() || file.length() < CncFileDescriptor.END_OF_METADATA_OFFSET)
                 {
                     if (clock.time() > deadlineMs)
                     {
@@ -1922,7 +1922,7 @@ public class Aeron implements AutoCloseable
                 try (FileChannel fileChannel = FileChannel.open(file.toPath(), READ, WRITE))
                 {
                     final long fileSize = fileChannel.size();
-                    if (fileSize < CncFileDescriptor.META_DATA_LENGTH)
+                    if (fileSize < CncFileDescriptor.END_OF_METADATA_OFFSET)
                     {
                         if (clock.time() > deadlineMs)
                         {

--- a/aeron-client/src/main/java/io/aeron/CncFileDescriptor.java
+++ b/aeron-client/src/main/java/io/aeron/CncFileDescriptor.java
@@ -155,12 +155,12 @@ public class CncFileDescriptor
     /**
      * Length of the metadata header for the CnC file.
      */
-    public static final int META_DATA_LENGTH = FILE_PAGE_SIZE_FIELD_OFFSET + SIZE_OF_INT;
+    public static final int META_DATA_LENGTH = CACHE_LINE_LENGTH * 2;
 
     /**
      * The offset of the first byte past the metadata header which is aligned on a cache-line boundary.
      */
-    public static final int END_OF_METADATA_OFFSET = align(META_DATA_LENGTH, (CACHE_LINE_LENGTH * 2));
+    public static final int END_OF_METADATA_OFFSET = META_DATA_LENGTH;
 
     /**
      * Compute the length of the cnc file and return it.
@@ -171,7 +171,7 @@ public class CncFileDescriptor
      */
     public static int computeCncFileLength(final int totalLengthOfBuffers, final int alignment)
     {
-        return align(END_OF_METADATA_OFFSET + totalLengthOfBuffers, alignment);
+        return align(META_DATA_LENGTH + totalLengthOfBuffers, alignment);
     }
 
     /**
@@ -328,7 +328,7 @@ public class CncFileDescriptor
      */
     public static UnsafeBuffer createMetaDataBuffer(final ByteBuffer buffer)
     {
-        return new UnsafeBuffer(buffer, 0, END_OF_METADATA_OFFSET);
+        return new UnsafeBuffer(buffer, 0, META_DATA_LENGTH);
     }
 
     /**
@@ -341,7 +341,7 @@ public class CncFileDescriptor
     public static UnsafeBuffer createToDriverBuffer(final ByteBuffer buffer, final DirectBuffer metaDataBuffer)
     {
         return new UnsafeBuffer(
-            buffer, END_OF_METADATA_OFFSET, metaDataBuffer.getInt(TO_DRIVER_BUFFER_LENGTH_FIELD_OFFSET));
+            buffer, META_DATA_LENGTH, metaDataBuffer.getInt(TO_DRIVER_BUFFER_LENGTH_FIELD_OFFSET));
     }
 
     /**
@@ -353,7 +353,7 @@ public class CncFileDescriptor
      */
     public static UnsafeBuffer createToClientsBuffer(final ByteBuffer buffer, final DirectBuffer metaDataBuffer)
     {
-        final int offset = END_OF_METADATA_OFFSET + metaDataBuffer.getInt(TO_DRIVER_BUFFER_LENGTH_FIELD_OFFSET);
+        final int offset = META_DATA_LENGTH + metaDataBuffer.getInt(TO_DRIVER_BUFFER_LENGTH_FIELD_OFFSET);
 
         return new UnsafeBuffer(buffer, offset, metaDataBuffer.getInt(TO_CLIENTS_BUFFER_LENGTH_FIELD_OFFSET));
     }
@@ -367,7 +367,7 @@ public class CncFileDescriptor
      */
     public static UnsafeBuffer createCountersMetaDataBuffer(final ByteBuffer buffer, final DirectBuffer metaDataBuffer)
     {
-        final int offset = END_OF_METADATA_OFFSET +
+        final int offset = META_DATA_LENGTH +
             metaDataBuffer.getInt(TO_DRIVER_BUFFER_LENGTH_FIELD_OFFSET) +
             metaDataBuffer.getInt(TO_CLIENTS_BUFFER_LENGTH_FIELD_OFFSET);
 
@@ -383,7 +383,7 @@ public class CncFileDescriptor
      */
     public static UnsafeBuffer createCountersValuesBuffer(final ByteBuffer buffer, final DirectBuffer metaDataBuffer)
     {
-        final int offset = END_OF_METADATA_OFFSET +
+        final int offset = META_DATA_LENGTH +
             metaDataBuffer.getInt(TO_DRIVER_BUFFER_LENGTH_FIELD_OFFSET) +
             metaDataBuffer.getInt(TO_CLIENTS_BUFFER_LENGTH_FIELD_OFFSET) +
             metaDataBuffer.getInt(COUNTERS_METADATA_BUFFER_LENGTH_FIELD_OFFSET);
@@ -400,7 +400,7 @@ public class CncFileDescriptor
      */
     public static UnsafeBuffer createErrorLogBuffer(final ByteBuffer buffer, final DirectBuffer metaDataBuffer)
     {
-        final int offset = END_OF_METADATA_OFFSET +
+        final int offset = META_DATA_LENGTH +
             metaDataBuffer.getInt(TO_DRIVER_BUFFER_LENGTH_FIELD_OFFSET) +
             metaDataBuffer.getInt(TO_CLIENTS_BUFFER_LENGTH_FIELD_OFFSET) +
             metaDataBuffer.getInt(COUNTERS_METADATA_BUFFER_LENGTH_FIELD_OFFSET) +
@@ -479,7 +479,7 @@ public class CncFileDescriptor
     public static boolean isCncFileLengthSufficient(final DirectBuffer metaDataBuffer, final int cncFileLength)
     {
         final int metadataRequiredLength =
-            END_OF_METADATA_OFFSET +
+            META_DATA_LENGTH +
             metaDataBuffer.getInt(TO_DRIVER_BUFFER_LENGTH_FIELD_OFFSET) +
             metaDataBuffer.getInt(TO_CLIENTS_BUFFER_LENGTH_FIELD_OFFSET) +
             metaDataBuffer.getInt(COUNTERS_METADATA_BUFFER_LENGTH_FIELD_OFFSET) +

--- a/aeron-client/src/main/java/io/aeron/CncFileDescriptor.java
+++ b/aeron-client/src/main/java/io/aeron/CncFileDescriptor.java
@@ -72,6 +72,8 @@ import static org.agrona.BitUtil.*;
  *  |                         Driver PID                            |
  *  |                                                               |
  *  +---------------------------------------------------------------+
+ *  |                        File page size                         |
+ *  +---------------------------------------------------------------+
  * </pre>
  */
 public class CncFileDescriptor
@@ -131,6 +133,11 @@ public class CncFileDescriptor
      */
     public static final int PID_FIELD_OFFSET;
 
+    /**
+     * Offset at which the file page size value for the driver can be found.
+     */
+    public static final int FILE_PAGE_SIZE_FIELD_OFFSET;
+
     static
     {
         CNC_VERSION_FIELD_OFFSET = 0;
@@ -142,12 +149,13 @@ public class CncFileDescriptor
         CLIENT_LIVENESS_TIMEOUT_FIELD_OFFSET = ERROR_LOG_BUFFER_LENGTH_FIELD_OFFSET + SIZE_OF_INT;
         START_TIMESTAMP_FIELD_OFFSET = CLIENT_LIVENESS_TIMEOUT_FIELD_OFFSET + SIZE_OF_LONG;
         PID_FIELD_OFFSET = START_TIMESTAMP_FIELD_OFFSET + SIZE_OF_LONG;
+        FILE_PAGE_SIZE_FIELD_OFFSET = PID_FIELD_OFFSET + SIZE_OF_LONG;
     }
 
     /**
      * Length of the metadata header for the CnC file.
      */
-    public static final int META_DATA_LENGTH = PID_FIELD_OFFSET + SIZE_OF_LONG;
+    public static final int META_DATA_LENGTH = FILE_PAGE_SIZE_FIELD_OFFSET + SIZE_OF_INT;
 
     /**
      * The offset of the first byte past the metadata header which is aligned on a cache-line boundary.
@@ -277,6 +285,7 @@ public class CncFileDescriptor
      * @param errorLogBufferLength        for recording the distinct error log.
      * @param startTimestampMs            epoch at which the driver started.
      * @param pid                         for the process hosting the driver.
+     * @param filePageSize                for alignment of all files.
      */
     public static void fillMetaData(
         final UnsafeBuffer cncMetaDataBuffer,
@@ -287,7 +296,8 @@ public class CncFileDescriptor
         final long clientLivenessTimeoutNs,
         final int errorLogBufferLength,
         final long startTimestampMs,
-        final long pid)
+        final long pid,
+        final int filePageSize)
     {
         cncMetaDataBuffer.putInt(TO_DRIVER_BUFFER_LENGTH_FIELD_OFFSET, toDriverBufferLength);
         cncMetaDataBuffer.putInt(TO_CLIENTS_BUFFER_LENGTH_FIELD_OFFSET, toClientsBufferLength);
@@ -297,6 +307,7 @@ public class CncFileDescriptor
         cncMetaDataBuffer.putLong(CLIENT_LIVENESS_TIMEOUT_FIELD_OFFSET, clientLivenessTimeoutNs);
         cncMetaDataBuffer.putLong(START_TIMESTAMP_FIELD_OFFSET, startTimestampMs);
         cncMetaDataBuffer.putLong(PID_FIELD_OFFSET, pid);
+        cncMetaDataBuffer.putInt(FILE_PAGE_SIZE_FIELD_OFFSET, filePageSize);
     }
 
     /**
@@ -306,7 +317,7 @@ public class CncFileDescriptor
      */
     public static void signalCncReady(final UnsafeBuffer cncMetaDataBuffer)
     {
-        cncMetaDataBuffer.putIntVolatile(cncVersionOffset(0), CNC_VERSION);
+        cncMetaDataBuffer.putIntVolatile(CNC_VERSION_FIELD_OFFSET, CNC_VERSION);
     }
 
     /**
@@ -317,7 +328,7 @@ public class CncFileDescriptor
      */
     public static UnsafeBuffer createMetaDataBuffer(final ByteBuffer buffer)
     {
-        return new UnsafeBuffer(buffer, 0, META_DATA_LENGTH);
+        return new UnsafeBuffer(buffer, 0, END_OF_METADATA_OFFSET);
     }
 
     /**
@@ -329,7 +340,8 @@ public class CncFileDescriptor
      */
     public static UnsafeBuffer createToDriverBuffer(final ByteBuffer buffer, final DirectBuffer metaDataBuffer)
     {
-        return new UnsafeBuffer(buffer, END_OF_METADATA_OFFSET, metaDataBuffer.getInt(toDriverBufferLengthOffset(0)));
+        return new UnsafeBuffer(
+            buffer, END_OF_METADATA_OFFSET, metaDataBuffer.getInt(TO_DRIVER_BUFFER_LENGTH_FIELD_OFFSET));
     }
 
     /**
@@ -341,9 +353,9 @@ public class CncFileDescriptor
      */
     public static UnsafeBuffer createToClientsBuffer(final ByteBuffer buffer, final DirectBuffer metaDataBuffer)
     {
-        final int offset = END_OF_METADATA_OFFSET + metaDataBuffer.getInt(toDriverBufferLengthOffset(0));
+        final int offset = END_OF_METADATA_OFFSET + metaDataBuffer.getInt(TO_DRIVER_BUFFER_LENGTH_FIELD_OFFSET);
 
-        return new UnsafeBuffer(buffer, offset, metaDataBuffer.getInt(toClientsBufferLengthOffset(0)));
+        return new UnsafeBuffer(buffer, offset, metaDataBuffer.getInt(TO_CLIENTS_BUFFER_LENGTH_FIELD_OFFSET));
     }
 
     /**
@@ -356,10 +368,10 @@ public class CncFileDescriptor
     public static UnsafeBuffer createCountersMetaDataBuffer(final ByteBuffer buffer, final DirectBuffer metaDataBuffer)
     {
         final int offset = END_OF_METADATA_OFFSET +
-            metaDataBuffer.getInt(toDriverBufferLengthOffset(0)) +
-            metaDataBuffer.getInt(toClientsBufferLengthOffset(0));
+            metaDataBuffer.getInt(TO_DRIVER_BUFFER_LENGTH_FIELD_OFFSET) +
+            metaDataBuffer.getInt(TO_CLIENTS_BUFFER_LENGTH_FIELD_OFFSET);
 
-        return new UnsafeBuffer(buffer, offset, metaDataBuffer.getInt(countersMetaDataBufferLengthOffset(0)));
+        return new UnsafeBuffer(buffer, offset, metaDataBuffer.getInt(COUNTERS_METADATA_BUFFER_LENGTH_FIELD_OFFSET));
     }
 
     /**
@@ -372,11 +384,11 @@ public class CncFileDescriptor
     public static UnsafeBuffer createCountersValuesBuffer(final ByteBuffer buffer, final DirectBuffer metaDataBuffer)
     {
         final int offset = END_OF_METADATA_OFFSET +
-            metaDataBuffer.getInt(toDriverBufferLengthOffset(0)) +
-            metaDataBuffer.getInt(toClientsBufferLengthOffset(0)) +
-            metaDataBuffer.getInt(countersMetaDataBufferLengthOffset(0));
+            metaDataBuffer.getInt(TO_DRIVER_BUFFER_LENGTH_FIELD_OFFSET) +
+            metaDataBuffer.getInt(TO_CLIENTS_BUFFER_LENGTH_FIELD_OFFSET) +
+            metaDataBuffer.getInt(COUNTERS_METADATA_BUFFER_LENGTH_FIELD_OFFSET);
 
-        return new UnsafeBuffer(buffer, offset, metaDataBuffer.getInt(countersValuesBufferLengthOffset(0)));
+        return new UnsafeBuffer(buffer, offset, metaDataBuffer.getInt(COUNTERS_VALUES_BUFFER_LENGTH_FIELD_OFFSET));
     }
 
     /**
@@ -389,12 +401,12 @@ public class CncFileDescriptor
     public static UnsafeBuffer createErrorLogBuffer(final ByteBuffer buffer, final DirectBuffer metaDataBuffer)
     {
         final int offset = END_OF_METADATA_OFFSET +
-            metaDataBuffer.getInt(toDriverBufferLengthOffset(0)) +
-            metaDataBuffer.getInt(toClientsBufferLengthOffset(0)) +
-            metaDataBuffer.getInt(countersMetaDataBufferLengthOffset(0)) +
-            metaDataBuffer.getInt(countersValuesBufferLengthOffset(0));
+            metaDataBuffer.getInt(TO_DRIVER_BUFFER_LENGTH_FIELD_OFFSET) +
+            metaDataBuffer.getInt(TO_CLIENTS_BUFFER_LENGTH_FIELD_OFFSET) +
+            metaDataBuffer.getInt(COUNTERS_METADATA_BUFFER_LENGTH_FIELD_OFFSET) +
+            metaDataBuffer.getInt(COUNTERS_VALUES_BUFFER_LENGTH_FIELD_OFFSET);
 
-        return new UnsafeBuffer(buffer, offset, metaDataBuffer.getInt(errorLogBufferLengthOffset(0)));
+        return new UnsafeBuffer(buffer, offset, metaDataBuffer.getInt(ERROR_LOG_BUFFER_LENGTH_FIELD_OFFSET));
     }
 
     /**
@@ -405,7 +417,7 @@ public class CncFileDescriptor
      */
     public static long clientLivenessTimeoutNs(final DirectBuffer metaDataBuffer)
     {
-        return metaDataBuffer.getLong(clientLivenessTimeoutOffset(0));
+        return metaDataBuffer.getLong(CLIENT_LIVENESS_TIMEOUT_FIELD_OFFSET);
     }
 
     /**
@@ -416,7 +428,7 @@ public class CncFileDescriptor
      */
     public static long startTimestampMs(final DirectBuffer metaDataBuffer)
     {
-        return metaDataBuffer.getLong(startTimestampOffset(0));
+        return metaDataBuffer.getLong(START_TIMESTAMP_FIELD_OFFSET);
     }
 
     /**
@@ -427,7 +439,18 @@ public class CncFileDescriptor
      */
     public static long pid(final DirectBuffer metaDataBuffer)
     {
-        return metaDataBuffer.getLong(pidOffset(0));
+        return metaDataBuffer.getLong(PID_FIELD_OFFSET);
+    }
+
+    /**
+     * Get the file page size.
+     *
+     * @param metaDataBuffer for the CnC file.
+     * @return the file page size.
+     */
+    public static int filePageSize(final DirectBuffer metaDataBuffer)
+    {
+        return metaDataBuffer.getInt(FILE_PAGE_SIZE_FIELD_OFFSET);
     }
 
     /**

--- a/aeron-client/src/main/java/io/aeron/CommonContext.java
+++ b/aeron-client/src/main/java/io/aeron/CommonContext.java
@@ -1215,6 +1215,7 @@ public class CommonContext implements Cloneable
      * @param clock          to use.
      * @param deadlineMs     for awaiting connection.
      * @return file page size from running media driver.
+     * @since 1.48.0
      */
     public static int driverFilePageSize(final File aeronDirectory, final EpochClock clock, final long deadlineMs)
     {

--- a/aeron-client/src/main/java/io/aeron/CommonContext.java
+++ b/aeron-client/src/main/java/io/aeron/CommonContext.java
@@ -916,7 +916,7 @@ public class CommonContext implements Cloneable
     {
         final File cncFile = new File(aeronDirectory, CncFileDescriptor.CNC_FILE);
 
-        if (cncFile.exists() && cncFile.length() > CncFileDescriptor.END_OF_METADATA_OFFSET)
+        if (cncFile.exists() && cncFile.length() > CncFileDescriptor.META_DATA_LENGTH)
         {
             if (null != logger)
             {
@@ -942,7 +942,7 @@ public class CommonContext implements Cloneable
     {
         final File cncFile = new File(directory, CncFileDescriptor.CNC_FILE);
 
-        if (cncFile.exists() && cncFile.length() > CncFileDescriptor.END_OF_METADATA_OFFSET)
+        if (cncFile.exists() && cncFile.length() > CncFileDescriptor.META_DATA_LENGTH)
         {
             logger.accept("INFO: Aeron CnC file exists: " + cncFile);
 
@@ -1042,7 +1042,7 @@ public class CommonContext implements Cloneable
     {
         final File cncFile = new File(directory, CncFileDescriptor.CNC_FILE);
 
-        if (cncFile.exists() && cncFile.length() > CncFileDescriptor.END_OF_METADATA_OFFSET)
+        if (cncFile.exists() && cncFile.length() > CncFileDescriptor.META_DATA_LENGTH)
         {
             final MappedByteBuffer cncByteBuffer = IoUtil.mapExistingFile(cncFile, "CnC file");
             try
@@ -1251,7 +1251,7 @@ public class CommonContext implements Cloneable
     {
         while (true)
         {
-            while (!cncFile.exists() || cncFile.length() < CncFileDescriptor.END_OF_METADATA_OFFSET)
+            while (!cncFile.exists() || cncFile.length() < CncFileDescriptor.META_DATA_LENGTH)
             {
                 if (clock.time() > deadlineMs)
                 {
@@ -1264,7 +1264,7 @@ public class CommonContext implements Cloneable
             try (FileChannel fileChannel = FileChannel.open(cncFile.toPath(), READ, WRITE))
             {
                 final long fileSize = fileChannel.size();
-                if (fileSize < CncFileDescriptor.END_OF_METADATA_OFFSET)
+                if (fileSize < CncFileDescriptor.META_DATA_LENGTH)
                 {
                     if (clock.time() > deadlineMs)
                     {

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
@@ -1661,12 +1661,15 @@ public final class ConsensusModule implements AutoCloseable
 
             if (null == markFile)
             {
+                final int filePageSize = null != aeron ? aeron.context().filePageSize() :
+                    driverFilePageSize(new File(aeronDirectoryName), epochClock, new CommonContext().driverTimeoutMs());
                 markFile = new ClusterMarkFile(
                     new File(markFileDir, ClusterMarkFile.FILENAME),
                     ClusterComponentType.CONSENSUS_MODULE,
                     errorBufferLength,
                     epochClock,
-                    ClusteredServiceContainer.Configuration.LIVENESS_TIMEOUT_MS);
+                    ClusteredServiceContainer.Configuration.LIVENESS_TIMEOUT_MS,
+                    filePageSize);
             }
 
             MarkFile.ensureMarkFileLink(
@@ -1719,9 +1722,9 @@ public final class ConsensusModule implements AutoCloseable
                     new Aeron.Context()
                         .aeronDirectoryName(aeronDirectoryName)
                         .errorHandler(errorHandler)
+                        .subscriberErrorHandler(RethrowingErrorHandler.INSTANCE)
                         .epochClock(epochClock)
                         .useConductorAgentInvoker(true)
-                        .subscriberErrorHandler(RethrowingErrorHandler.INSTANCE)
                         .awaitingIdleStrategy(YieldingIdleStrategy.INSTANCE)
                         .clientLock(NoOpLock.INSTANCE)
                         .clientName(agentRoleName));
@@ -1757,7 +1760,7 @@ public final class ConsensusModule implements AutoCloseable
                 throw new ClusterException("Aeron client must use a RethrowingErrorHandler");
             }
 
-            if (null == aeron.conductorAgentInvoker())
+            if (!aeron.context().useConductorAgentInvoker())
             {
                 throw new ClusterException("Aeron client must use conductor agent invoker");
             }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
@@ -2229,7 +2229,7 @@ public final class ConsensusModule implements AutoCloseable
          * @see Configuration#FILE_SYNC_LEVEL_PROP_NAME
          */
         @Config
-        int fileSyncLevel()
+        public int fileSyncLevel()
         {
             return fileSyncLevel;
         }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusterMarkFile.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusterMarkFile.java
@@ -132,7 +132,7 @@ public final class ClusterMarkFile implements AutoCloseable
         final EpochClock epochClock,
         final long timeoutMs)
     {
-        this(file, type, errorBufferLength, epochClock, timeoutMs, 0);
+        this(file, type, errorBufferLength, epochClock, timeoutMs, PAGE_MIN_SIZE);
     }
 
     /**
@@ -159,14 +159,11 @@ public final class ClusterMarkFile implements AutoCloseable
             throw new IllegalArgumentException("Invalid errorBufferLength: " + errorBufferLength);
         }
 
-        if (0 != filePageSize)
-        {
-            LogBufferDescriptor.checkPageSize(filePageSize);
-        }
+        LogBufferDescriptor.checkPageSize(filePageSize);
 
         final boolean markFileExists = file.exists();
         final int totalFileLength =
-            BitUtil.align(HEADER_LENGTH + errorBufferLength, 0 != filePageSize ? filePageSize : PAGE_MIN_SIZE);
+            BitUtil.align(HEADER_LENGTH + errorBufferLength, filePageSize);
 
         final MessageHeaderDecoder messageHeaderDecoder = new MessageHeaderDecoder();
 

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ClusterBackupContextTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ClusterBackupContextTest.java
@@ -68,6 +68,7 @@ class ClusterBackupContextTest
         when(aeronContext.aeronDirectoryName()).thenReturn("funny");
         when(aeronContext.subscriberErrorHandler()).thenReturn(errorHandler);
         when(aeronContext.useConductorAgentInvoker()).thenReturn(true);
+        when(aeronContext.filePageSize()).thenReturn(PAGE_MIN_SIZE);
         final Aeron aeron = mock(Aeron.class);
         when(aeron.context()).thenReturn(aeronContext);
         final AtomicCounter errorCounter = mock(AtomicCounter.class);

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleContextTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleContextTest.java
@@ -26,6 +26,8 @@ import io.aeron.cluster.client.ClusterException;
 import io.aeron.cluster.codecs.mark.MarkFileHeaderDecoder;
 import io.aeron.cluster.service.ClusterClock;
 import io.aeron.cluster.service.ClusterMarkFile;
+import io.aeron.driver.MediaDriver;
+import io.aeron.driver.ThreadingMode;
 import io.aeron.exceptions.ConfigurationException;
 import io.aeron.security.Authenticator;
 import io.aeron.security.AuthenticatorSupplier;
@@ -36,6 +38,7 @@ import io.aeron.security.SessionProxy;
 import io.aeron.test.TestContexts;
 import io.aeron.test.Tests;
 import io.aeron.test.cluster.TestClusterClock;
+import org.agrona.BitUtil;
 import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
 import org.agrona.SystemUtil;
@@ -58,18 +61,53 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 
-import static io.aeron.AeronCounters.*;
-import static io.aeron.cluster.ConsensusModule.Configuration.*;
+import static io.aeron.AeronCounters.CLUSTER_ELECTION_COUNT_TYPE_ID;
+import static io.aeron.AeronCounters.CLUSTER_LEADERSHIP_TERM_ID_TYPE_ID;
+import static io.aeron.AeronCounters.NODE_CONTROL_TOGGLE_TYPE_ID;
+import static io.aeron.cluster.ConsensusModule.Configuration.ALLOW_ONLY_BACKUP_QUERIES;
+import static io.aeron.cluster.ConsensusModule.Configuration.AUTHENTICATOR_SUPPLIER_PROP_NAME;
+import static io.aeron.cluster.ConsensusModule.Configuration.AUTHORISATION_SERVICE_SUPPLIER_PROP_NAME;
+import static io.aeron.cluster.ConsensusModule.Configuration.CLUSTER_CLOCK_PROP_NAME;
+import static io.aeron.cluster.ConsensusModule.Configuration.COMMIT_POSITION_TYPE_ID;
+import static io.aeron.cluster.ConsensusModule.Configuration.CONSENSUS_MODULE_ERROR_COUNT_TYPE_ID;
+import static io.aeron.cluster.ConsensusModule.Configuration.CONSENSUS_MODULE_STATE_TYPE_ID;
+import static io.aeron.cluster.ConsensusModule.Configuration.CONTROL_TOGGLE_TYPE_ID;
+import static io.aeron.cluster.ConsensusModule.Configuration.DEFAULT_AUTHORISATION_SERVICE_SUPPLIER;
+import static io.aeron.cluster.ConsensusModule.Configuration.ELECTION_STATE_TYPE_ID;
+import static io.aeron.cluster.ConsensusModule.Configuration.SERVICE_ID;
+import static io.aeron.cluster.ConsensusModule.Configuration.SNAPSHOT_COUNTER_TYPE_ID;
+import static io.aeron.cluster.ConsensusModule.Configuration.TIMER_SERVICE_SUPPLIER_PRIORITY_HEAP;
+import static io.aeron.cluster.ConsensusModule.Configuration.TIMER_SERVICE_SUPPLIER_PROP_NAME;
+import static io.aeron.cluster.ConsensusModule.Configuration.TIMER_SERVICE_SUPPLIER_WHEEL;
 import static io.aeron.cluster.codecs.mark.ClusterComponentType.CONSENSUS_MODULE;
 import static io.aeron.cluster.service.ClusterMarkFile.ERROR_BUFFER_MIN_LENGTH;
+import static io.aeron.cluster.service.ClusterMarkFile.HEADER_LENGTH;
 import static io.aeron.cluster.service.ClusteredServiceContainer.Configuration.MARK_FILE_DIR_PROP_NAME;
+import static io.aeron.logbuffer.LogBufferDescriptor.PAGE_MIN_SIZE;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class ConsensusModuleContextTest
 {
@@ -456,7 +494,8 @@ class ConsensusModuleContextTest
             CONSENSUS_MODULE,
             ERROR_BUFFER_MIN_LENGTH,
             epochClock,
-            1_000);
+            1_000,
+            PAGE_MIN_SIZE);
         final long existingCandidateTermId = 23;
 
         assertEquals(Aeron.NULL_VALUE, clusterMarkFile.candidateTermId());
@@ -580,7 +619,12 @@ class ConsensusModuleContextTest
         final @TempDir File otherDir) throws IOException
     {
         final ClusterMarkFile clusterMarkFile = new ClusterMarkFile(
-            new File(otherDir, "test.me"), CONSENSUS_MODULE, ERROR_BUFFER_MIN_LENGTH, SystemEpochClock.INSTANCE, 10);
+            new File(otherDir, "test.me"),
+            CONSENSUS_MODULE,
+            ERROR_BUFFER_MIN_LENGTH,
+            SystemEpochClock.INSTANCE,
+            10,
+            PAGE_MIN_SIZE);
         context
             .clusterDir(clusterDir)
             .markFileDir(markFileDir)
@@ -900,6 +944,56 @@ class ConsensusModuleContextTest
         finally
         {
             CloseHelper.quietClose(context::close);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 8192, 32 * 1024 })
+    void shouldAlignMarkFileToTheAeronClientFilePageSize(final int filePageSize)
+    {
+        final Aeron.Context aeronContext = context.aeron().context();
+        when(aeronContext.filePageSize()).thenReturn(filePageSize);
+
+        context.conclude();
+
+        final File file = new File(context.markFileDir(), ClusterMarkFile.FILENAME);
+        assertTrue(file.exists());
+        assertEquals(BitUtil.align(context.errorBufferLength() + HEADER_LENGTH, filePageSize), file.length());
+
+        verify(aeronContext).filePageSize();
+    }
+
+    @Test
+    void shouldAlignMarkFileBasedOnTheMediaDriverFilePageSize() throws IOException
+    {
+        final Path aeronDir = Paths.get(CommonContext.generateRandomDirName());
+        Files.createDirectories(aeronDir);
+
+        final int filePageSize = 1024 * 1024;
+        try (MediaDriver driver = MediaDriver.launch(new MediaDriver.Context()
+            .aeronDirectoryName(aeronDir.toString())
+            .threadingMode(ThreadingMode.SHARED)
+            .filePageSize(filePageSize)))
+        {
+            final ConsensusModule.Context ctx = TestContexts.localhostConsensusModule()
+                .clusterDir(clusterDir)
+                .aeronDirectoryName(driver.aeronDirectoryName())
+                .ingressChannel("aeron:ipc")
+                .egressChannel("aeron:udp?endpoint=localhost:0")
+                .replicationChannel("aeron:udp?endpoint=localhost:0")
+                .errorBufferLength(1919191);
+            try
+            {
+                ctx.conclude();
+
+                final File file = new File(ctx.markFileDir(), ClusterMarkFile.FILENAME);
+                assertTrue(file.exists());
+                assertEquals(BitUtil.align(context.errorBufferLength() + HEADER_LENGTH, filePageSize), file.length());
+            }
+            finally
+            {
+                ctx.close();
+            }
         }
     }
 

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleContextTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleContextTest.java
@@ -125,6 +125,7 @@ class ConsensusModuleContextTest
         when(aeronContext.subscriberErrorHandler()).thenReturn(new RethrowingErrorHandler());
         when(aeronContext.aeronDirectoryName()).thenReturn("some aeron dir");
         when(aeronContext.useConductorAgentInvoker()).thenReturn(true);
+        when(aeronContext.filePageSize()).thenReturn(PAGE_MIN_SIZE);
         final AgentInvoker conductorInvoker = mock(AgentInvoker.class);
         final Aeron aeron = mock(Aeron.class);
         when(aeron.addCounter(

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleContextTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleContextTest.java
@@ -954,13 +954,20 @@ class ConsensusModuleContextTest
         final Aeron.Context aeronContext = context.aeron().context();
         when(aeronContext.filePageSize()).thenReturn(filePageSize);
 
-        context.conclude();
+        try
+        {
+            context.conclude();
 
-        final File file = new File(context.markFileDir(), ClusterMarkFile.FILENAME);
-        assertTrue(file.exists());
-        assertEquals(BitUtil.align(context.errorBufferLength() + HEADER_LENGTH, filePageSize), file.length());
+            final File file = new File(context.markFileDir(), ClusterMarkFile.FILENAME);
+            assertTrue(file.exists());
+            assertEquals(BitUtil.align(context.errorBufferLength() + HEADER_LENGTH, filePageSize), file.length());
 
-        verify(aeronContext).filePageSize();
+            verify(aeronContext).filePageSize();
+        }
+        finally
+        {
+            context.close();
+        }
     }
 
     @Test

--- a/aeron-cluster/src/test/java/io/aeron/cluster/service/ClusterMarkFileTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/service/ClusterMarkFileTest.java
@@ -19,6 +19,7 @@ import io.aeron.Aeron;
 import io.aeron.cluster.codecs.mark.ClusterComponentType;
 import io.aeron.cluster.codecs.mark.MarkFileHeaderDecoder;
 import io.aeron.cluster.codecs.mark.MarkFileHeaderEncoder;
+import org.agrona.BitUtil;
 import org.agrona.IoUtil;
 import org.agrona.MarkFile;
 import org.agrona.SemanticVersion;
@@ -45,8 +46,19 @@ import java.nio.file.StandardOpenOption;
 
 import static io.aeron.cluster.service.ClusterMarkFile.ERROR_BUFFER_MAX_LENGTH;
 import static io.aeron.cluster.service.ClusterMarkFile.ERROR_BUFFER_MIN_LENGTH;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static io.aeron.cluster.service.ClusterMarkFile.HEADER_LENGTH;
+import static io.aeron.logbuffer.LogBufferDescriptor.PAGE_MIN_SIZE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class ClusterMarkFileTest
 {
@@ -64,7 +76,8 @@ class ClusterMarkFileTest
             ClusterComponentType.CONSENSUS_MODULE,
             errorBufferLength,
             SystemEpochClock.INSTANCE,
-            10));
+            10,
+            PAGE_MIN_SIZE));
         assertEquals("Invalid errorBufferLength: " + errorBufferLength, exception.getMessage());
     }
 
@@ -118,10 +131,10 @@ class ClusterMarkFileTest
         epochClock.advance(35984758934759843L);
 
         try (ClusterMarkFile clusterMarkFile =
-            new ClusterMarkFile(file, componentType, ERROR_BUFFER_MIN_LENGTH, epochClock, 1000))
+            new ClusterMarkFile(file, componentType, ERROR_BUFFER_MIN_LENGTH, epochClock, 1000, PAGE_MIN_SIZE))
         {
             assertTrue(file.exists());
-            assertEquals(ClusterMarkFile.HEADER_LENGTH + ERROR_BUFFER_MIN_LENGTH, file.length());
+            assertEquals(HEADER_LENGTH + ERROR_BUFFER_MIN_LENGTH, file.length());
 
             clusterMarkFile.signalReady();
 
@@ -139,7 +152,7 @@ class ClusterMarkFileTest
                 0,
                 0,
                 0,
-                ClusterMarkFile.HEADER_LENGTH,
+                HEADER_LENGTH,
                 ERROR_BUFFER_MIN_LENGTH,
                 0,
                 "",
@@ -179,8 +192,8 @@ class ClusterMarkFileTest
         final CachedEpochClock epochClock = new CachedEpochClock();
         epochClock.update(123456L);
 
-        try (ClusterMarkFile clusterMarkFile =
-            new ClusterMarkFile(file, ClusterComponentType.BACKUP, ERROR_BUFFER_MIN_LENGTH, epochClock, 1000))
+        try (ClusterMarkFile clusterMarkFile = new ClusterMarkFile(
+            file, ClusterComponentType.BACKUP, ERROR_BUFFER_MIN_LENGTH, epochClock, 1000, PAGE_MIN_SIZE))
         {
             clusterMarkFile.signalReady();
 
@@ -208,7 +221,7 @@ class ClusterMarkFileTest
 
         epochClock.update(753498573948593L);
         try (ClusterMarkFile clusterMarkFile = new ClusterMarkFile(
-            file, ClusterComponentType.CONSENSUS_MODULE, ERROR_BUFFER_MIN_LENGTH * 2, epochClock, 2222))
+            file, ClusterComponentType.CONSENSUS_MODULE, ERROR_BUFFER_MIN_LENGTH * 2, epochClock, 2222, PAGE_MIN_SIZE))
         {
             verifyMarkFileContents(
                 clusterMarkFile,
@@ -224,7 +237,7 @@ class ClusterMarkFileTest
                 insgresStreamId,
                 memberId,
                 serviceId,
-                ClusterMarkFile.HEADER_LENGTH,
+                HEADER_LENGTH,
                 ERROR_BUFFER_MIN_LENGTH * 2,
                 clusterId,
                 aeronDir,
@@ -384,8 +397,13 @@ class ClusterMarkFileTest
         }
 
         // should overwrite existing data when message header offset is being added
-        try (ClusterMarkFile clusterMarkFile =
-            new ClusterMarkFile(file.toFile(), currentComponentType, ERROR_BUFFER_MIN_LENGTH * 2, epochClock, 1000))
+        try (ClusterMarkFile clusterMarkFile = new ClusterMarkFile(
+            file.toFile(),
+            currentComponentType,
+            ERROR_BUFFER_MIN_LENGTH * 2,
+            epochClock,
+            1000,
+            PAGE_MIN_SIZE))
         {
             clusterMarkFile.memberId(8);
             clusterMarkFile.clusterId(3);
@@ -404,7 +422,7 @@ class ClusterMarkFileTest
                 0,
                 8,
                 0,
-                ClusterMarkFile.HEADER_LENGTH,
+                HEADER_LENGTH,
                 ERROR_BUFFER_MIN_LENGTH * 2,
                 3,
                 "",
@@ -424,7 +442,8 @@ class ClusterMarkFileTest
             ClusterComponentType.STANDBY,
             ERROR_BUFFER_MIN_LENGTH,
             SystemEpochClock.INSTANCE,
-            100);
+            100,
+            PAGE_MIN_SIZE);
 
         final MarkFileHeaderEncoder encoder = clusterMarkFile.encoder();
         final MarkFileHeaderDecoder decoder = clusterMarkFile.decoder();
@@ -457,7 +476,8 @@ class ClusterMarkFileTest
             ClusterComponentType.STANDBY,
             ERROR_BUFFER_MIN_LENGTH,
             SystemEpochClock.INSTANCE,
-            100);
+            100,
+            PAGE_MIN_SIZE);
 
         assertEquals(0, clusterMarkFile.clusterId());
 
@@ -482,7 +502,8 @@ class ClusterMarkFileTest
             ClusterComponentType.STANDBY,
             ERROR_BUFFER_MIN_LENGTH,
             SystemEpochClock.INSTANCE,
-            100);
+            100,
+            PAGE_MIN_SIZE);
 
         assertEquals(0, clusterMarkFile.memberId());
 
@@ -507,7 +528,8 @@ class ClusterMarkFileTest
             ClusterComponentType.STANDBY,
             ERROR_BUFFER_MIN_LENGTH,
             SystemEpochClock.INSTANCE,
-            100);
+            100,
+            PAGE_MIN_SIZE);
 
         assertEquals(Aeron.NULL_VALUE, clusterMarkFile.candidateTermId());
 
@@ -528,7 +550,8 @@ class ClusterMarkFileTest
             ClusterComponentType.STANDBY,
             ERROR_BUFFER_MIN_LENGTH,
             SystemEpochClock.INSTANCE,
-            100);
+            100,
+            PAGE_MIN_SIZE);
 
         assertEquals(0, clusterMarkFile.activityTimestampVolatile());
 
@@ -561,7 +584,8 @@ class ClusterMarkFileTest
             ClusterComponentType.STANDBY,
             ERROR_BUFFER_MIN_LENGTH,
             SystemEpochClock.INSTANCE,
-            100);
+            100,
+            PAGE_MIN_SIZE);
 
         clusterMarkFile.encoder()
             .clusterId(123)
@@ -605,7 +629,8 @@ class ClusterMarkFileTest
             ClusterComponentType.STANDBY,
             ERROR_BUFFER_MIN_LENGTH,
             SystemEpochClock.INSTANCE,
-            100);
+            100,
+            PAGE_MIN_SIZE);
 
         assertEquals(0, clusterMarkFile.decoder().version());
 
@@ -625,7 +650,8 @@ class ClusterMarkFileTest
             ClusterComponentType.STANDBY,
             ERROR_BUFFER_MIN_LENGTH,
             SystemEpochClock.INSTANCE,
-            100);
+            100,
+            PAGE_MIN_SIZE);
 
         assertEquals(0, clusterMarkFile.decoder().version());
 
@@ -635,6 +661,89 @@ class ClusterMarkFileTest
         clusterMarkFile.close();
 
         clusterMarkFile.signalFailedStart();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 4096, 32 * 1024 })
+    @SuppressWarnings("try")
+    void shouldAlignMarkFileLengthBasedOnTheFilePageSizeFromAeronClient(final int filePageSize)
+    {
+        final int errorBufferLength = 1345679;
+
+        final File file = tempDir.resolve("test-mark.file").toFile();
+        try (ClusterMarkFile ignored = new ClusterMarkFile(
+            file,
+            ClusterComponentType.STANDBY,
+            errorBufferLength,
+            SystemEpochClock.INSTANCE,
+            100,
+            filePageSize))
+        {
+            assertEquals(BitUtil.align(HEADER_LENGTH + errorBufferLength, filePageSize), file.length());
+        }
+    }
+
+    @Test
+    @SuppressWarnings("try")
+    void shouldAlignMarkFileLengthTo4KBIfFilePageSizeIsZero()
+    {
+        final int errorBufferLength = 2352371;
+        final File file = tempDir.resolve("test-mark.file").toFile();
+        try (ClusterMarkFile ignored = new ClusterMarkFile(
+            file,
+            ClusterComponentType.STANDBY,
+            errorBufferLength,
+            SystemEpochClock.INSTANCE,
+            100,
+            0))
+        {
+            assertEquals(BitUtil.align(HEADER_LENGTH + errorBufferLength, PAGE_MIN_SIZE), file.length());
+        }
+    }
+
+    @Test
+    void shouldRejectFilePageSizeIfNotPowerOf2()
+    {
+        final IllegalStateException exception = assertThrowsExactly(
+            IllegalStateException.class, () -> new ClusterMarkFile(
+            tempDir.resolve("test-mark.file").toFile(),
+            ClusterComponentType.STANDBY,
+            ERROR_BUFFER_MIN_LENGTH,
+            SystemEpochClock.INSTANCE,
+            100,
+            4199));
+
+        assertEquals("Page size not a power of 2: page size=4199", exception.getMessage());
+    }
+
+    @Test
+    void shouldRejectFilePageSizeIfTooSmall()
+    {
+        final IllegalStateException exception = assertThrowsExactly(
+            IllegalStateException.class, () -> new ClusterMarkFile(
+            tempDir.resolve("test-mark.file").toFile(),
+            ClusterComponentType.STANDBY,
+            ERROR_BUFFER_MIN_LENGTH,
+            SystemEpochClock.INSTANCE,
+            100,
+            100));
+
+        assertEquals("Page size less than min size of 4096: page size=100", exception.getMessage());
+    }
+
+    @Test
+    void shouldRejectFilePageSizeIfTooBig()
+    {
+        final IllegalStateException exception = assertThrowsExactly(
+            IllegalStateException.class, () -> new ClusterMarkFile(
+            tempDir.resolve("test-mark.file").toFile(),
+            ClusterComponentType.STANDBY,
+            ERROR_BUFFER_MIN_LENGTH,
+            SystemEpochClock.INSTANCE,
+            100,
+            Integer.MAX_VALUE));
+
+        assertEquals("Page size more than max size of 1073741824: page size=2147483647", exception.getMessage());
     }
 
     private static void verifyMarkFileContents(

--- a/aeron-cluster/src/test/java/io/aeron/cluster/service/ClusteredServiceContainerContextTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/service/ClusteredServiceContainerContextTest.java
@@ -449,14 +449,20 @@ class ClusteredServiceContainerContextTest
     {
         final Aeron.Context aeronContext = context.aeron().context();
         when(aeronContext.filePageSize()).thenReturn(filePageSize);
+        try
+        {
+            context.conclude();
 
-        context.conclude();
+            final File file = new File(context.markFileDir(), ClusterMarkFile.markFilenameForService(serviceId));
+            assertTrue(file.exists());
+            assertEquals(BitUtil.align(context.errorBufferLength() + HEADER_LENGTH, filePageSize), file.length());
 
-        final File file = new File(context.markFileDir(), ClusterMarkFile.markFilenameForService(serviceId));
-        assertTrue(file.exists());
-        assertEquals(BitUtil.align(context.errorBufferLength() + HEADER_LENGTH, filePageSize), file.length());
-
-        verify(aeronContext).filePageSize();
+            verify(aeronContext).filePageSize();
+        }
+        finally
+        {
+            context.close();
+        }
     }
 
     @Test

--- a/aeron-cluster/src/test/java/io/aeron/cluster/service/ClusteredServiceContainerContextTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/service/ClusteredServiceContainerContextTest.java
@@ -50,9 +50,23 @@ import static io.aeron.cluster.service.ClusterMarkFile.HEADER_LENGTH;
 import static io.aeron.cluster.service.ClusteredServiceContainer.Configuration.MARK_FILE_DIR_PROP_NAME;
 import static io.aeron.logbuffer.LogBufferDescriptor.PAGE_MIN_SIZE;
 import static java.nio.charset.StandardCharsets.US_ASCII;
-import static org.hamcrest.MatcherAssert.*;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class ClusteredServiceContainerContextTest
 {
@@ -68,6 +82,7 @@ class ClusteredServiceContainerContextTest
         final Aeron.Context aeronContext = mock(Aeron.Context.class);
         when(aeronContext.aeronDirectoryName()).thenReturn("funny");
         when(aeronContext.subscriberErrorHandler()).thenReturn(errorHandler);
+        when(aeronContext.filePageSize()).thenReturn(PAGE_MIN_SIZE);
         final Aeron aeron = mock(Aeron.class);
         when(aeron.addCounter(
             anyInt(), any(DirectBuffer.class), anyInt(), anyInt(), any(DirectBuffer.class), anyInt(), anyInt()))

--- a/aeron-cluster/src/test/java/io/aeron/cluster/service/ClusteredServiceContainerContextTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/service/ClusteredServiceContainerContextTest.java
@@ -17,10 +17,14 @@ package io.aeron.cluster.service;
 
 import io.aeron.Aeron;
 import io.aeron.ChannelUri;
+import io.aeron.CommonContext;
 import io.aeron.Counter;
 import io.aeron.RethrowingErrorHandler;
 import io.aeron.archive.client.AeronArchive;
 import io.aeron.cluster.codecs.mark.ClusterComponentType;
+import io.aeron.driver.MediaDriver;
+import io.aeron.driver.ThreadingMode;
+import org.agrona.BitUtil;
 import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.NoOpLock;
@@ -42,7 +46,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import static io.aeron.cluster.service.ClusterMarkFile.ERROR_BUFFER_MIN_LENGTH;
+import static io.aeron.cluster.service.ClusterMarkFile.HEADER_LENGTH;
 import static io.aeron.cluster.service.ClusteredServiceContainer.Configuration.MARK_FILE_DIR_PROP_NAME;
+import static io.aeron.logbuffer.LogBufferDescriptor.PAGE_MIN_SIZE;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.hamcrest.MatcherAssert.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -74,7 +80,8 @@ class ClusteredServiceContainerContextTest
             .errorCounter(errorCounter)
             .errorHandler(errorHandler)
             .clusteredService(clusteredService)
-            .clusterDir(clusterDir);
+            .clusterDir(clusterDir)
+            .serviceId(serviceId);
     }
 
     @Test
@@ -181,7 +188,8 @@ class ClusteredServiceContainerContextTest
             ClusterComponentType.CONSENSUS_MODULE,
             ERROR_BUFFER_MIN_LENGTH,
             SystemEpochClock.INSTANCE,
-            10);
+            10,
+            PAGE_MIN_SIZE);
         context
             .serviceId(serviceId)
             .clusterDir(clusterDir)
@@ -432,6 +440,53 @@ class ClusteredServiceContainerContextTest
         finally
         {
             CloseHelper.quietClose(context::close);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 8192, 32 * 1024 })
+    void shouldAlignMarkFileToTheAeronClientFilePageSize(final int filePageSize)
+    {
+        final Aeron.Context aeronContext = context.aeron().context();
+        when(aeronContext.filePageSize()).thenReturn(filePageSize);
+
+        context.conclude();
+
+        final File file = new File(context.markFileDir(), ClusterMarkFile.markFilenameForService(serviceId));
+        assertTrue(file.exists());
+        assertEquals(BitUtil.align(context.errorBufferLength() + HEADER_LENGTH, filePageSize), file.length());
+
+        verify(aeronContext).filePageSize();
+    }
+
+    @Test
+    void shouldAlignMarkFileBasedOnTheMediaDriverFilePageSize() throws IOException
+    {
+        final Path aeronDir = Paths.get(CommonContext.generateRandomDirName());
+        Files.createDirectories(aeronDir);
+
+        final int filePageSize = 1024 * 1024;
+        try (MediaDriver driver = MediaDriver.launch(new MediaDriver.Context()
+            .aeronDirectoryName(aeronDir.toString())
+            .threadingMode(ThreadingMode.SHARED)
+            .filePageSize(filePageSize)))
+        {
+            context
+                .aeron(null)
+                .aeronDirectoryName(driver.aeronDirectoryName())
+                .errorBufferLength(1919191);
+            try
+            {
+                context.conclude();
+
+                final File file = new File(context.markFileDir(), ClusterMarkFile.markFilenameForService(serviceId));
+                assertTrue(file.exists());
+                assertEquals(BitUtil.align(context.errorBufferLength() + HEADER_LENGTH, filePageSize), file.length());
+            }
+            finally
+            {
+                context.close();
+            }
         }
     }
 }

--- a/aeron-driver/src/main/c/aeron_driver.c
+++ b/aeron-driver/src/main/c/aeron_driver.c
@@ -252,6 +252,7 @@ void aeron_driver_fill_cnc_metadata(aeron_driver_context_t *context)
     metadata->client_liveness_timeout = (int64_t)context->client_liveness_timeout_ns;
     metadata->start_timestamp = context->epoch_clock();
     metadata->pid = getpid();
+    metadata->file_page_size = (int32_t)context->file_page_size;
 
     context->to_driver_buffer = aeron_cnc_to_driver_buffer(metadata);
     context->to_clients_buffer = aeron_cnc_to_clients_buffer(metadata);

--- a/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
@@ -697,7 +697,8 @@ public final class MediaDriver implements AutoCloseable
                     clientLivenessTimeoutNs,
                     errorBufferLength,
                     epochClock.time(),
-                    SystemUtil.getPid());
+                    SystemUtil.getPid(),
+                    filePageSize);
 
                 concludeCounters();
                 concludeDependantProperties();

--- a/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
@@ -677,7 +677,7 @@ public final class MediaDriver implements AutoCloseable
                 validateUntetheredTimeouts(untetheredWindowLimitTimeoutNs, untetheredRestingTimeoutNs, timerIntervalNs);
 
                 final long cncFileLength = BitUtil.align(
-                    (long)END_OF_METADATA_OFFSET +
+                    (long)META_DATA_LENGTH +
                     conductorBufferLength +
                     toClientsBufferLength +
                     countersMetadataBufferLength(counterValuesBufferLength) +

--- a/aeron-driver/src/test/java/io/aeron/driver/MediaDriverContextTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/MediaDriverContextTest.java
@@ -15,6 +15,8 @@
  */
 package io.aeron.driver;
 
+import io.aeron.CncFileDescriptor;
+import io.aeron.CommonContext;
 import io.aeron.driver.MediaDriver.Context;
 import io.aeron.driver.media.ControlTransportPoller;
 import io.aeron.driver.media.DataTransportPoller;
@@ -23,6 +25,7 @@ import io.aeron.driver.status.SystemCounterDescriptor;
 import io.aeron.exceptions.ConfigurationException;
 import org.agrona.ErrorHandler;
 import org.agrona.concurrent.CountedErrorHandler;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.status.AtomicCounter;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
@@ -37,6 +40,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.CyclicBarrier;
@@ -325,6 +329,20 @@ class MediaDriverContextTest
         assertNotNull(dataTransportPoller);
 
         assertSame(context.countedErrorHandler(), getErrorHandler(dataTransportPoller));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 4096, 2 * 1024 * 1024 })
+    void shouldAddFilePageSizeToTheCncFile(final int filePageSize) throws IOException
+    {
+        final Path dir = Paths.get(CommonContext.generateRandomDirName());
+        Files.createDirectories(dir);
+        context.aeronDirectoryName(dir.toString()).filePageSize(filePageSize);
+
+        context.conclude();
+
+        final UnsafeBuffer metaDataBuffer = CncFileDescriptor.createMetaDataBuffer(context.cncByteBuffer());
+        assertEquals(filePageSize, CncFileDescriptor.filePageSize(metaDataBuffer));
     }
 
     private static ErrorHandler getErrorHandler(final UdpTransportPoller transportPoller) throws Exception

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterBackupContextTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterBackupContextTest.java
@@ -16,9 +16,12 @@
 package io.aeron.cluster;
 
 import io.aeron.Aeron;
+import io.aeron.CommonContext;
 import io.aeron.RethrowingErrorHandler;
 import io.aeron.cluster.service.ClusterMarkFile;
-import org.agrona.concurrent.AgentInvoker;
+import io.aeron.driver.MediaDriver;
+import io.aeron.driver.ThreadingMode;
+import org.agrona.BitUtil;
 import org.agrona.concurrent.SystemEpochClock;
 import org.agrona.concurrent.status.AtomicCounter;
 import org.junit.jupiter.api.AfterEach;
@@ -32,13 +35,23 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import static io.aeron.cluster.codecs.mark.ClusterComponentType.BACKUP;
 import static io.aeron.cluster.service.ClusterMarkFile.ERROR_BUFFER_MIN_LENGTH;
+import static io.aeron.cluster.service.ClusterMarkFile.HEADER_LENGTH;
 import static io.aeron.cluster.service.ClusteredServiceContainer.Configuration.MARK_FILE_DIR_PROP_NAME;
+import static io.aeron.logbuffer.LogBufferDescriptor.PAGE_MIN_SIZE;
 import static java.nio.charset.StandardCharsets.US_ASCII;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class ClusterBackupContextTest
@@ -54,10 +67,9 @@ class ClusterBackupContextTest
         final Aeron.Context aeronContext = mock(Aeron.Context.class);
         when(aeronContext.aeronDirectoryName()).thenReturn("funny");
         when(aeronContext.subscriberErrorHandler()).thenReturn(errorHandler);
-        final AgentInvoker conductorAgentInvoker = mock(AgentInvoker.class);
+        when(aeronContext.useConductorAgentInvoker()).thenReturn(true);
         final Aeron aeron = mock(Aeron.class);
         when(aeron.context()).thenReturn(aeronContext);
-        when(aeron.conductorAgentInvoker()).thenReturn(conductorAgentInvoker);
         final AtomicCounter errorCounter = mock(AtomicCounter.class);
         context = new ClusterBackup.Context()
             .aeron(aeron)
@@ -170,7 +182,11 @@ class ClusterBackupContextTest
         final @TempDir File otherDir) throws IOException
     {
         final ClusterMarkFile clusterMarkFile = new ClusterMarkFile(
-            new File(otherDir, "abc.xyz"), BACKUP, ERROR_BUFFER_MIN_LENGTH, SystemEpochClock.INSTANCE, 4);
+            new File(otherDir, "abc.xyz"),
+            BACKUP, ERROR_BUFFER_MIN_LENGTH,
+            SystemEpochClock.INSTANCE,
+            4,
+            PAGE_MIN_SIZE);
         context
             .clusterDir(clusterDir)
             .markFileDir(markFileDir)
@@ -184,5 +200,47 @@ class ClusterBackupContextTest
         final File linkFile = new File(context.clusterDir(), ClusterMarkFile.LINK_FILENAME);
         assertTrue(linkFile.exists());
         assertEquals(otherDir.getCanonicalPath(), new String(Files.readAllBytes(linkFile.toPath()), US_ASCII));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 4096, 16 * 1024 })
+    void shouldAlignMarkFileBasedOnTheAeronClientFilePageSize(final int filePageSize)
+    {
+        final Aeron.Context aeronContext = context.aeron().context();
+        when(aeronContext.filePageSize()).thenReturn(filePageSize);
+        context.errorBufferLength(3131311);
+
+        context.conclude();
+
+        final File file = new File(context.markFileDir(), ClusterMarkFile.FILENAME);
+        assertTrue(file.exists());
+        assertEquals(BitUtil.align(context.errorBufferLength() + HEADER_LENGTH, filePageSize), file.length());
+
+        verify(aeronContext).filePageSize();
+    }
+
+    @Test
+    void shouldAlignMarkFileBasedOnTheMediaDriverFilePageSize() throws IOException
+    {
+        final Path aeronDir = Paths.get(CommonContext.generateRandomDirName());
+        Files.createDirectories(aeronDir);
+
+        final int filePageSize = 1024 * 1024;
+        try (MediaDriver driver = MediaDriver.launch(new MediaDriver.Context()
+            .aeronDirectoryName(aeronDir.toString())
+            .threadingMode(ThreadingMode.SHARED)
+            .filePageSize(filePageSize)))
+        {
+            context
+                .aeron(null)
+                .aeronDirectoryName(driver.aeronDirectoryName())
+                .errorBufferLength(1919191);
+
+            context.conclude();
+
+            final File file = new File(context.markFileDir(), ClusterMarkFile.FILENAME);
+            assertTrue(file.exists());
+            assertEquals(BitUtil.align(context.errorBufferLength() + HEADER_LENGTH, filePageSize), file.length());
+        }
     }
 }

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterBackupContextTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterBackupContextTest.java
@@ -210,13 +210,20 @@ class ClusterBackupContextTest
         when(aeronContext.filePageSize()).thenReturn(filePageSize);
         context.errorBufferLength(3131311);
 
-        context.conclude();
+        try
+        {
+            context.conclude();
 
-        final File file = new File(context.markFileDir(), ClusterMarkFile.FILENAME);
-        assertTrue(file.exists());
-        assertEquals(BitUtil.align(context.errorBufferLength() + HEADER_LENGTH, filePageSize), file.length());
+            final File file = new File(context.markFileDir(), ClusterMarkFile.FILENAME);
+            assertTrue(file.exists());
+            assertEquals(BitUtil.align(context.errorBufferLength() + HEADER_LENGTH, filePageSize), file.length());
 
-        verify(aeronContext).filePageSize();
+            verify(aeronContext).filePageSize();
+        }
+        finally
+        {
+            context.close();
+        }
     }
 
     @Test

--- a/aeron-system-tests/src/test/java/io/aeron/driver/FilePageSizeTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/driver/FilePageSizeTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2014-2025 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.driver;
+
+import io.aeron.test.SystemTestWatcher;
+import io.aeron.test.driver.TestMediaDriver;
+import org.agrona.CloseHelper;
+import org.agrona.concurrent.SystemEpochClock;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.File;
+import java.util.concurrent.TimeUnit;
+
+import static io.aeron.CommonContext.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class FilePageSizeTest
+{
+    @RegisterExtension
+    final SystemTestWatcher systemTestWatcher = new SystemTestWatcher();
+
+    private TestMediaDriver driver;
+
+    @AfterEach
+    void after()
+    {
+        CloseHelper.closeAll(driver);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 16 * 1024, 2 * 1024 * 1024 })
+    void shouldStoreFilePageSizeInTheCnCFileMetadata(final int filePageSize)
+    {
+        driver = TestMediaDriver.launch(new MediaDriver.Context()
+            .dirDeleteOnStart(true)
+            .dirDeleteOnShutdown(true)
+            .threadingMode(ThreadingMode.SHARED)
+            .aeronDirectoryName(generateRandomDirName())
+            .filePageSize(filePageSize), systemTestWatcher);
+
+        systemTestWatcher.dataCollector().add(driver.context().aeronDirectory());
+
+        assertEquals(filePageSize, driverFilePageSize(
+            new File(driver.aeronDirectoryName()), SystemEpochClock.INSTANCE, TimeUnit.SECONDS.toMillis(1)));
+    }
+}

--- a/aeron-system-tests/src/test/java/io/aeron/driver/FilePageSizeTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/driver/FilePageSizeTest.java
@@ -57,6 +57,6 @@ public class FilePageSizeTest
         systemTestWatcher.dataCollector().add(driver.context().aeronDirectory());
 
         assertEquals(filePageSize, driverFilePageSize(
-            new File(driver.aeronDirectoryName()), SystemEpochClock.INSTANCE, TimeUnit.SECONDS.toMillis(1)));
+            new File(driver.aeronDirectoryName()), SystemEpochClock.INSTANCE, TimeUnit.SECONDS.toMillis(10)));
     }
 }

--- a/aeron-system-tests/src/test/java/io/aeron/driver/SystemCountersTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/driver/SystemCountersTest.java
@@ -58,7 +58,7 @@ public class SystemCountersTest
     }
 
     @Test
-    void shouldCreatePublicationUsingSparseFiles()
+    void verifySystemCounterLabels()
     {
         final CountersReader countersReader = aeron.countersReader();
         final Int2ObjectHashMap<String> idToLabel = new Int2ObjectHashMap<>();

--- a/aeron-test-support/src/main/java/io/aeron/test/driver/CTestMediaDriver.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/driver/CTestMediaDriver.java
@@ -226,6 +226,7 @@ public final class CTestMediaDriver implements TestMediaDriver
         environment.put("AERON_TERM_BUFFER_SPARSE_FILE", Boolean.toString(context.termBufferSparseFile()));
         environment.put("AERON_TERM_BUFFER_LENGTH", String.valueOf(context.publicationTermBufferLength()));
         environment.put("AERON_IPC_TERM_BUFFER_LENGTH", String.valueOf(context.ipcTermBufferLength()));
+        environment.put("AERON_FILE_PAGE_SIZE", String.valueOf(context.filePageSize()));
         environment.put(
             "AERON_PUBLICATION_UNBLOCK_TIMEOUT", String.valueOf(context.publicationUnblockTimeoutNs()));
         environment.put(


### PR DESCRIPTION
This PR implement mark file length alignment based on the `aeron.file.page.size` configured on the media driver. The file page size value is now stored in the CnC file.