### PR TITLE
[Java/C] Prevent NetworkPublication's `pub-lmt` from wrapping around into the dirty term.

### DIFF
--- a/aeron-driver/src/main/c/aeron_ipc_publication.c
+++ b/aeron-driver/src/main/c/aeron_ipc_publication.c
@@ -302,6 +302,7 @@ int aeron_ipc_publication_update_pub_pos_and_lmt(aeron_ipc_publication_t *public
             aeron_counter_set_ordered(publication->pub_lmt_position.value_addr, consumer_position);
             publication->conductor_fields.trip_limit = consumer_position;
             aeron_ipc_publication_clean_buffer(publication, consumer_position);
+            work_count++;
         }
     }
 

--- a/aeron-driver/src/main/c/aeron_ipc_publication.c
+++ b/aeron-driver/src/main/c/aeron_ipc_publication.c
@@ -286,12 +286,12 @@ int aeron_ipc_publication_update_pub_pos_and_lmt(aeron_ipc_publication_t *public
                 }
             }
 
-            int64_t proposed_limit = min_sub_pos + publication->term_window_length;
-            if (proposed_limit > publication->conductor_fields.trip_limit)
+            int64_t new_limit_position = min_sub_pos + publication->term_window_length;
+            if (new_limit_position > publication->conductor_fields.trip_limit)
             {
                 aeron_ipc_publication_clean_buffer(publication, min_sub_pos);
-                aeron_counter_set_ordered(publication->pub_lmt_position.value_addr, proposed_limit);
-                publication->conductor_fields.trip_limit = proposed_limit + publication->trip_gain;
+                aeron_counter_set_ordered(publication->pub_lmt_position.value_addr, new_limit_position);
+                publication->conductor_fields.trip_limit = new_limit_position + publication->trip_gain;
                 work_count++;
             }
 

--- a/aeron-driver/src/main/c/aeron_network_publication.c
+++ b/aeron-driver/src/main/c/aeron_network_publication.c
@@ -992,13 +992,12 @@ int aeron_network_publication_update_pub_pos_and_lmt(aeron_network_publication_t
             {
                 aeron_network_publication_clean_buffer(publication, min_consumer_position - publication->term_buffer_length);
                 const int64_t clean_position = publication->conductor_fields.clean_position;
-                const int32_t clean_offset = (int32_t)(clean_position & publication->term_length_mask);
-                const int64_t term_based_clean_position = clean_position - clean_offset;
-                const int64_t term_based_new_limit_position =
-                        new_limit_position - (new_limit_position & publication->term_length_mask);
-                const int64_t wrap_around_gap = term_based_new_limit_position - term_based_clean_position;
-                const int64_t max_wrap_around_gap = publication->term_buffer_length << 1;
-                if (wrap_around_gap < max_wrap_around_gap || (wrap_around_gap == max_wrap_around_gap && 0 != clean_offset))
+                const int32_t dirty_term_id = aeron_logbuffer_compute_term_id_from_position(
+                    clean_position, publication->position_bits_to_shift, publication->initial_term_id);
+                const int32_t active_term_id = aeron_logbuffer_compute_term_id_from_position(
+                    new_limit_position, publication->position_bits_to_shift, publication->initial_term_id);
+                const int32_t term_gap = aeron_logbuffer_compute_term_count(active_term_id, dirty_term_id);
+                if (term_gap < 2 || (2 == term_gap && 0 != (clean_position & publication->term_length_mask)))
                 {
                     aeron_counter_set_ordered(publication->pub_lmt_position.value_addr, new_limit_position);
                 }

--- a/aeron-driver/src/main/java/io/aeron/driver/IpcPublication.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/IpcPublication.java
@@ -380,12 +380,12 @@ public final class IpcPublication implements DriverManagedResource, Subscribable
                     consumerPosition = maxSubscriberPosition;
                 }
 
-                final long proposedLimit = minSubscriberPosition + termWindowLength;
-                if (proposedLimit > tripLimit)
+                final long newLimitPosition = minSubscriberPosition + termWindowLength;
+                if (newLimitPosition >= tripLimit)
                 {
                     cleanBufferTo(minSubscriberPosition);
-                    publisherLimit.setOrdered(proposedLimit);
-                    tripLimit = proposedLimit + tripGain;
+                    publisherLimit.setOrdered(newLimitPosition);
+                    tripLimit = newLimitPosition + tripGain;
                     workCount = 1;
                 }
             }
@@ -394,6 +394,7 @@ public final class IpcPublication implements DriverManagedResource, Subscribable
                 tripLimit = consumerPosition;
                 publisherLimit.setOrdered(consumerPosition);
                 cleanBufferTo(consumerPosition);
+                workCount = 1;
             }
         }
 

--- a/aeron-driver/src/main/java/io/aeron/driver/NetworkPublication.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/NetworkPublication.java
@@ -44,9 +44,23 @@ import java.util.ArrayList;
 
 import static io.aeron.driver.Configuration.PUBLICATION_HEARTBEAT_TIMEOUT_NS;
 import static io.aeron.driver.Configuration.PUBLICATION_SETUP_TIMEOUT_NS;
-import static io.aeron.driver.status.SystemCounterDescriptor.*;
-import static io.aeron.logbuffer.LogBufferDescriptor.*;
-import static io.aeron.logbuffer.TermScanner.*;
+import static io.aeron.driver.status.SystemCounterDescriptor.HEARTBEATS_SENT;
+import static io.aeron.driver.status.SystemCounterDescriptor.RETRANSMITS_SENT;
+import static io.aeron.driver.status.SystemCounterDescriptor.RETRANSMITTED_BYTES;
+import static io.aeron.driver.status.SystemCounterDescriptor.SENDER_FLOW_CONTROL_LIMITS;
+import static io.aeron.driver.status.SystemCounterDescriptor.SHORT_SENDS;
+import static io.aeron.driver.status.SystemCounterDescriptor.UNBLOCKED_PUBLICATIONS;
+import static io.aeron.logbuffer.LogBufferDescriptor.activeTermCount;
+import static io.aeron.logbuffer.LogBufferDescriptor.computePosition;
+import static io.aeron.logbuffer.LogBufferDescriptor.computeTermIdFromPosition;
+import static io.aeron.logbuffer.LogBufferDescriptor.endOfStreamPosition;
+import static io.aeron.logbuffer.LogBufferDescriptor.indexByPosition;
+import static io.aeron.logbuffer.LogBufferDescriptor.rawTailVolatile;
+import static io.aeron.logbuffer.LogBufferDescriptor.termId;
+import static io.aeron.logbuffer.LogBufferDescriptor.termOffset;
+import static io.aeron.logbuffer.TermScanner.available;
+import static io.aeron.logbuffer.TermScanner.padding;
+import static io.aeron.logbuffer.TermScanner.scanForAvailability;
 import static io.aeron.protocol.DataHeaderFlyweight.BEGIN_AND_END_FLAGS;
 import static io.aeron.protocol.DataHeaderFlyweight.BEGIN_END_AND_EOS_FLAGS;
 import static io.aeron.protocol.StatusMessageFlyweight.END_OF_STREAM_FLAG;
@@ -745,12 +759,12 @@ public final class NetworkPublication
                 {
                     cleanBufferTo(minConsumerPosition - termBufferLength);
                     final long cleanPosition = this.cleanPosition;
-                    final int cleanOffset = (int)(cleanPosition & termLengthMask);
-                    final long termBaseCleanPosition = cleanPosition - cleanOffset;
-                    final long termBaseNewLimitPosition = newLimitPosition - (newLimitPosition & termLengthMask);
-                    final long wrapAroundGap = termBaseNewLimitPosition - termBaseCleanPosition;
-                    final long maxWrapAroundGap = (long)termBufferLength << 1;
-                    if (wrapAroundGap < maxWrapAroundGap || (wrapAroundGap == maxWrapAroundGap && 0 != cleanOffset))
+                    final int dirtyTermId =
+                        computeTermIdFromPosition(cleanPosition, positionBitsToShift, initialTermId);
+                    final int activeTermId =
+                        computeTermIdFromPosition(newLimitPosition, positionBitsToShift, initialTermId);
+                    final int termGap = activeTermId - dirtyTermId;
+                    if (termGap < 2 || (2 == termGap && 0 != (int)(cleanPosition & termLengthMask)))
                     {
                         publisherLimit.setOrdered(newLimitPosition);
                     }

--- a/aeron-driver/src/test/c/aeron_network_publication_test.cpp
+++ b/aeron-driver/src/test/c/aeron_network_publication_test.cpp
@@ -90,7 +90,8 @@ protected:
         aeron_driver_context_close(m_context);
     }
 
-    aeron_send_channel_endpoint_t *createEndpoint(const char *uri)
+    aeron_send_channel_endpoint_t *createEndpoint(
+            const char *uri, aeron_driver_uri_publication_params_t *params, bool is_exclusive)
     {
         aeron_udp_channel_t *channel = nullptr;
         if (0 != aeron_udp_channel_parse(strlen(uri), uri, &m_resolver, &channel, false))
@@ -98,10 +99,14 @@ protected:
             return nullptr;
         }
 
-        aeron_driver_uri_publication_params_t params = {};
-        params.mtu_length = 1408;
+        aeron_driver_conductor_t conductor = {};
+        conductor.context = m_context;
+        if (aeron_diver_uri_publication_params(&channel->uri, params, &conductor, is_exclusive) < 0)
+        {
+            return nullptr;
+        }
         aeron_send_channel_endpoint_t *endpoint = nullptr;
-        if (aeron_send_channel_endpoint_create(&endpoint, channel, &params, m_context, &m_counters_manager, 1) < 0)
+        if (aeron_send_channel_endpoint_create(&endpoint, channel, params, m_context, &m_counters_manager, 1) < 0)
         {
             return nullptr;
         }
@@ -112,7 +117,16 @@ protected:
 
     aeron_network_publication_t *createPublication(const char *uri)
     {
-        aeron_send_channel_endpoint_t *endpoint = createEndpoint(uri);
+        bool is_exclusive = false;
+        aeron_driver_uri_publication_params_t params = {};
+        params.mtu_length = 1408;
+        params.has_mtu_length = true;
+        params.term_length = 65536;
+        params.has_term_length = true;
+        params.publication_window_length = (int32_t)(params.term_length >> 1);
+        params.has_publication_window_length = true;
+
+        aeron_send_channel_endpoint_t *endpoint = createEndpoint(uri, &params, is_exclusive);
         if (nullptr == endpoint)
         {
             return nullptr;
@@ -161,10 +175,22 @@ protected:
         snd_bpe_counter.value_addr = aeron_counters_manager_addr(
             &m_counters_manager, snd_bpe_counter.counter_id);
 
+        if (params.has_position)
+        {
+            const int64_t initial_position = aeron_logbuffer_compute_position(
+                    params.term_id,
+                    (int32_t)params.term_offset,
+                    (size_t)aeron_number_of_trailing_zeroes((int32_t)params.term_length),
+                    params.initial_term_id);
+
+            aeron_counter_set_ordered(pub_pos_position.value_addr, initial_position);
+            aeron_counter_set_ordered(pub_lmt_position.value_addr, initial_position);
+            aeron_counter_set_ordered(snd_pos_position.value_addr, initial_position);
+            aeron_counter_set_ordered(snd_lmt_position.value_addr, initial_position);
+        }
+
         aeron_flow_control_strategy_t *flow_control;
         aeron_unicast_flow_control_strategy_supplier(&flow_control, nullptr, nullptr, nullptr, 0, 0, 0, 0, 0);
-
-        aeron_driver_uri_publication_params_t params = {};
 
         aeron_network_publication_t *publication = nullptr;
         if (aeron_network_publication_create(
@@ -182,7 +208,7 @@ protected:
             &snd_bpe_counter,
             flow_control,
             &params,
-            false,
+            is_exclusive,
             &m_system_counters) < 0)
         {
             aeron_free(flow_control);
@@ -271,14 +297,15 @@ TEST_F(NetworkPublicationTest, shouldReturnStorageSpaceErrorIfNotEnoughStorageSp
     };
     m_context->perform_storage_checks = true;
 
-    aeron_network_publication_t *publication = createPublication("aeron:udp?endpoint=localhost:23245");
+    aeron_network_publication_t *publication = createPublication("aeron:udp?endpoint=localhost:23245|term-length=1m");
 
     ASSERT_EQ(nullptr, publication) << aeron_errmsg();
     EXPECT_EQ(-AERON_ERROR_CODE_STORAGE_SPACE, aeron_errcode());
     auto expected_error_text =
-        std::string("insufficient usable storage for new log of length=4096 usable=190 in ")
+        std::string("insufficient usable storage for new log of length=3149824 usable=190 in ")
             .append(m_context->aeron_dir);
-    EXPECT_NE(std::string::npos, std::string(aeron_errmsg()).find(expected_error_text));
+    const auto error_text = std::string(aeron_errmsg());
+    EXPECT_NE(std::string::npos, error_text.find(expected_error_text));
 }
 
 TEST_F(NetworkPublicationTest, shouldWarnIfRemainingStorageSpaceIsLow)
@@ -290,7 +317,7 @@ TEST_F(NetworkPublicationTest, shouldWarnIfRemainingStorageSpaceIsLow)
     m_context->low_file_store_warning_threshold = 4194304ULL;
     m_context->perform_storage_checks = true;
 
-    aeron_network_publication_t *publication = createPublication("aeron:udp?endpoint=localhost:23245");
+    aeron_network_publication_t *publication = createPublication("aeron:udp?endpoint=localhost:23245|term-length=128k");
 
     ASSERT_NE(nullptr, publication) << aeron_errmsg();
     EXPECT_EQ(0, aeron_errcode());
@@ -305,4 +332,174 @@ TEST_F(NetworkPublicationTest, shouldWarnIfRemainingStorageSpaceIsLow)
         std::string("WARNING: space is running low: threshold=4194304 usable=1048576 in ")
             .append(m_context->aeron_dir);
     EXPECT_NE(std::string::npos, error_text.find(expected_warning));
+}
+
+TEST_F(NetworkPublicationTest, shouldCleanDirtyTermBuffersOneTermBehindTheMinConsumerPosition)
+{
+    const int32_t term_length = 64 * 1024;
+    const int32_t publication_window_length = term_length / 2;
+    const int32_t initial_term_id = 5;
+    const int32_t term_id = 112004;
+    const int32_t term_offset = 384;
+    const int64_t initial_position = (int64_t)term_length * (term_id - initial_term_id) + term_offset;
+    const std::string uri = std::string("aeron:udp?endpoint=localhost:23245")
+            .append("|term-length=").append(std::to_string(term_length))
+            .append("|init-term-id=").append(std::to_string(initial_term_id))
+            .append("|term-id=").append(std::to_string(term_id))
+            .append("|term-offset=").append(std::to_string(term_offset));
+    aeron_network_publication_t *publication = createPublication(uri.c_str());
+    ASSERT_EQ(initial_position, aeron_counter_get(publication->pub_pos_position.value_addr));
+    ASSERT_EQ(initial_position, aeron_counter_get(publication->pub_lmt_position.value_addr));
+    ASSERT_EQ(initial_position, aeron_counter_get(publication->snd_pos_position.value_addr));
+    ASSERT_EQ(initial_position, aeron_counter_get(publication->snd_lmt_position.value_addr));
+    ASSERT_EQ(initial_position, publication->conductor_fields.clean_position);
+
+    aeron_driver_conductor_t conductor = {};
+    aeron_driver_conductor_proxy_t proxy = {};
+    proxy.conductor = &conductor;
+    proxy.threading_mode = AERON_THREADING_MODE_INVOKER;
+    AERON_DECL_ALIGNED(buffer_t data_buffer, 16) = {};
+    sockaddr_storage sockaddr = {};
+    aeron_network_publication_on_status_message(
+            publication, &proxy, data_buffer.data(), sizeof(aeron_status_message_header_t), &sockaddr);
+
+    ASSERT_TRUE(publication->has_receivers);
+
+    EXPECT_EQ(1, aeron_network_publication_update_pub_pos_and_lmt(publication));
+
+    // initial pub-lmt increase
+    aeron_network_publication_update_pub_pos_and_lmt(publication);
+    EXPECT_EQ(initial_position + publication_window_length, aeron_counter_get(publication->pub_lmt_position.value_addr));
+    EXPECT_EQ(initial_position, publication->conductor_fields.clean_position);
+
+    // snd-pos increase less than a term
+    aeron_counter_set_ordered(publication->snd_pos_position.value_addr, initial_position + 4128);
+    aeron_network_publication_update_pub_pos_and_lmt(publication);
+    EXPECT_EQ(initial_position + 4128 + publication_window_length, aeron_counter_get(publication->pub_lmt_position.value_addr));
+    EXPECT_EQ(initial_position, publication->conductor_fields.clean_position);
+
+    // snd-pos increase exactly one term
+    aeron_counter_set_ordered(publication->snd_pos_position.value_addr, initial_position + term_length);
+    aeron_network_publication_update_pub_pos_and_lmt(publication);
+    EXPECT_EQ(initial_position + term_length + publication_window_length, aeron_counter_get(publication->pub_lmt_position.value_addr));
+    EXPECT_EQ(initial_position, publication->conductor_fields.clean_position);
+
+    // snd-pos increase beyond a term
+    aeron_counter_set_ordered(publication->snd_pos_position.value_addr, initial_position + term_length + 192);
+    aeron_network_publication_update_pub_pos_and_lmt(publication);
+    EXPECT_EQ(initial_position + term_length + 192 + publication_window_length, aeron_counter_get(publication->pub_lmt_position.value_addr));
+    EXPECT_EQ(initial_position + 192, publication->conductor_fields.clean_position);
+
+    // clean the rest of the first term
+    aeron_counter_set_ordered(publication->snd_pos_position.value_addr, initial_position + 2 * term_length + 32);
+    aeron_network_publication_update_pub_pos_and_lmt(publication);
+    EXPECT_EQ(initial_position + 2 * term_length + 32 + publication_window_length, aeron_counter_get(publication->pub_lmt_position.value_addr));
+    EXPECT_EQ(initial_position - term_offset + term_length, publication->conductor_fields.clean_position);
+
+    // snd-pos didn't change => no op
+    aeron_network_publication_update_pub_pos_and_lmt(publication);
+    EXPECT_EQ(initial_position + 2 * term_length + 32 + publication_window_length, aeron_counter_get(publication->pub_lmt_position.value_addr));
+    EXPECT_EQ(initial_position - term_offset + term_length, publication->conductor_fields.clean_position);
+
+    // clean the next buffer
+    aeron_counter_set_ordered(publication->snd_pos_position.value_addr, initial_position + 2 * term_length + 8192);
+    aeron_network_publication_update_pub_pos_and_lmt(publication);
+    EXPECT_EQ(initial_position + 2 * term_length + 8192 + publication_window_length, aeron_counter_get(publication->pub_lmt_position.value_addr));
+    EXPECT_EQ(initial_position + term_length + 8192, publication->conductor_fields.clean_position);
+}
+
+TEST_F(NetworkPublicationTest, publicationLimitShouldNotCrossIntoPreviousTermIfTheEntireTermIsDirty)
+{
+    const int32_t term_length = 64 * 1024;
+    const int32_t publication_window_length = term_length / 2;
+    const int32_t initial_term_id = 5;
+    const int32_t term_id = 7;
+    const int32_t term_offset = 65280;
+    const int64_t initial_position = (int64_t)term_length * (term_id - initial_term_id) + term_offset;
+    const std::string uri = std::string("aeron:udp?endpoint=localhost:23245")
+            .append("|term-length=").append(std::to_string(term_length))
+            .append("|init-term-id=").append(std::to_string(initial_term_id))
+            .append("|term-id=").append(std::to_string(term_id))
+            .append("|term-offset=").append(std::to_string(term_offset));
+    aeron_network_publication_t *publication = createPublication(uri.c_str());
+    ASSERT_EQ(initial_position, aeron_counter_get(publication->pub_pos_position.value_addr));
+    ASSERT_EQ(initial_position, aeron_counter_get(publication->pub_lmt_position.value_addr));
+    ASSERT_EQ(initial_position, aeron_counter_get(publication->snd_pos_position.value_addr));
+    ASSERT_EQ(initial_position, aeron_counter_get(publication->snd_lmt_position.value_addr));
+    ASSERT_EQ(initial_position, publication->conductor_fields.clean_position);
+
+    aeron_driver_conductor_t conductor = {};
+    aeron_driver_conductor_proxy_t proxy = {};
+    proxy.conductor = &conductor;
+    proxy.threading_mode = AERON_THREADING_MODE_INVOKER;
+    AERON_DECL_ALIGNED(buffer_t data_buffer, 16) = {};
+    sockaddr_storage sockaddr = {};
+    aeron_network_publication_on_status_message(
+            publication, &proxy, data_buffer.data(), sizeof(aeron_status_message_header_t), &sockaddr);
+
+    ASSERT_TRUE(publication->has_receivers);
+
+    EXPECT_EQ(1, aeron_network_publication_update_pub_pos_and_lmt(publication));
+
+    // pub-lmt can be in the previous term if clean position offset is not zero
+    aeron_counter_set_ordered(publication->snd_pos_position.value_addr, initial_position + term_length);
+    aeron_network_publication_update_pub_pos_and_lmt(publication);
+    EXPECT_EQ(initial_position + term_length + publication_window_length, aeron_counter_get(publication->pub_lmt_position.value_addr));
+    EXPECT_EQ(initial_position, publication->conductor_fields.clean_position);
+
+    // pub-lmt cannot be in the previous term if clean position points to the start of the dirty buffer
+    aeron_counter_set_ordered(publication->snd_pos_position.value_addr, initial_position + 2 * term_length + 64);
+    aeron_network_publication_update_pub_pos_and_lmt(publication);
+    EXPECT_EQ(initial_position + term_length + publication_window_length, aeron_counter_get(publication->pub_lmt_position.value_addr));
+    EXPECT_EQ(initial_position - term_offset + term_length, publication->conductor_fields.clean_position);
+
+    // after cleanup the pub-lmt can move again
+    aeron_network_publication_update_pub_pos_and_lmt(publication);
+    EXPECT_EQ(initial_position + 2 * term_length + 64 + publication_window_length, aeron_counter_get(publication->pub_lmt_position.value_addr));
+    EXPECT_EQ(initial_position + term_length + 64, publication->conductor_fields.clean_position);
+}
+
+TEST_F(NetworkPublicationTest, publicationLimitShouldNotCrossIntoTheDirtyTerm)
+{
+    const int32_t term_length = 64 * 1024;
+    const int32_t publication_window_length = term_length / 2;
+    const int64_t initial_position = 0;
+    const std::string uri = std::string("aeron:udp?endpoint=localhost:23245")
+            .append("|term-length=").append(std::to_string(term_length));
+    aeron_network_publication_t *publication = createPublication(uri.c_str());
+    ASSERT_EQ(initial_position, aeron_counter_get(publication->pub_pos_position.value_addr));
+    ASSERT_EQ(initial_position, aeron_counter_get(publication->pub_lmt_position.value_addr));
+    ASSERT_EQ(initial_position, aeron_counter_get(publication->snd_pos_position.value_addr));
+    ASSERT_EQ(initial_position, aeron_counter_get(publication->snd_lmt_position.value_addr));
+    ASSERT_EQ(initial_position, publication->conductor_fields.clean_position);
+
+    aeron_driver_conductor_t conductor = {};
+    aeron_driver_conductor_proxy_t proxy = {};
+    proxy.conductor = &conductor;
+    proxy.threading_mode = AERON_THREADING_MODE_INVOKER;
+    AERON_DECL_ALIGNED(buffer_t data_buffer, 16) = {};
+    sockaddr_storage sockaddr = {};
+    aeron_network_publication_on_status_message(
+            publication, &proxy, data_buffer.data(), sizeof(aeron_status_message_header_t), &sockaddr);
+
+    ASSERT_TRUE(publication->has_receivers);
+
+    EXPECT_EQ(1, aeron_network_publication_update_pub_pos_and_lmt(publication));
+
+    // initial pub-lmt
+    aeron_counter_set_ordered(publication->snd_pos_position.value_addr, initial_position + 256);
+    aeron_network_publication_update_pub_pos_and_lmt(publication);
+    EXPECT_EQ(initial_position + 256 + publication_window_length, aeron_counter_get(publication->pub_lmt_position.value_addr));
+    EXPECT_EQ(initial_position, publication->conductor_fields.clean_position);
+
+    // new pub-lmt intersects with the clean position
+    aeron_counter_set_ordered(publication->snd_pos_position.value_addr, initial_position + 2 * term_length + 192 + publication_window_length);
+    aeron_network_publication_update_pub_pos_and_lmt(publication);
+    EXPECT_EQ(initial_position + 256 + publication_window_length, aeron_counter_get(publication->pub_lmt_position.value_addr));
+    EXPECT_EQ(initial_position + term_length, publication->conductor_fields.clean_position);
+
+    // after cleanup the pub-lmt can move again
+    aeron_network_publication_update_pub_pos_and_lmt(publication);
+    EXPECT_EQ(initial_position + 2 * term_length + 192 + 2 * publication_window_length, aeron_counter_get(publication->pub_lmt_position.value_addr));
+    EXPECT_EQ(initial_position + term_length + 192 + publication_window_length, publication->conductor_fields.clean_position);
 }

--- a/aeron-driver/src/test/java/io/aeron/driver/NetworkPublicationTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/NetworkPublicationTest.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2014-2025 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.driver;
+
+import io.aeron.driver.buffer.RawLog;
+import io.aeron.driver.media.SendChannelEndpoint;
+import io.aeron.driver.status.SystemCounters;
+import io.aeron.protocol.StatusMessageFlyweight;
+import org.agrona.BufferUtil;
+import org.agrona.concurrent.CachedNanoClock;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.agrona.concurrent.status.AtomicCounter;
+import org.agrona.concurrent.status.AtomicLongPosition;
+import org.agrona.concurrent.status.CountersManager;
+import org.agrona.concurrent.status.Position;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.util.stream.Stream;
+
+import static io.aeron.logbuffer.LogBufferDescriptor.*;
+import static org.agrona.BitUtil.CACHE_LINE_LENGTH;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class NetworkPublicationTest
+{
+    private static final int REGISTRATION_ID = 42;
+    private static final int PUBLICATION_WINDOW_LENGTH = TERM_MIN_LENGTH / 2;
+    private static final int SESSION_ID = 8;
+    private static final int STREAM_ID = 101;
+    private static final int INITIAL_TERM_ID = 99;
+    private static final NetworkPublicationThreadLocals NETWORK_PUBLICATION_THREAD_LOCALS =
+        new NetworkPublicationThreadLocals();
+    private static final UnsafeBuffer[] TERM_BUFFERS = new UnsafeBuffer[PARTITION_COUNT];
+
+    static
+    {
+        for (int i = 0; i < TERM_BUFFERS.length; i++)
+        {
+            TERM_BUFFERS[i] = new UnsafeBuffer(BufferUtil.allocateDirectAligned(TERM_MIN_LENGTH, CACHE_LINE_LENGTH));
+        }
+    }
+
+    private final CountersManager countersManager = new CountersManager(
+        new UnsafeBuffer(BufferUtil.allocateDirectAligned(TERM_MIN_LENGTH, CACHE_LINE_LENGTH)),
+        new UnsafeBuffer(BufferUtil.allocateDirectAligned(8192, CACHE_LINE_LENGTH)));
+    private final MediaDriver.Context ctx = new MediaDriver.Context()
+        .senderCachedNanoClock(new CachedNanoClock())
+        .systemCounters(new SystemCounters(countersManager));
+    private final PublicationParams params = new PublicationParams();
+    private final SendChannelEndpoint sendChannelEndpoint = mock(SendChannelEndpoint.class);
+    private final RawLog rawLog = mock(RawLog.class);
+    private final Position publisherPos = new AtomicLongPosition();
+    private final Position publisherLimit = new AtomicLongPosition();
+    private final Position senderPosition = new AtomicLongPosition();
+    private final Position senderLimit = new AtomicLongPosition();
+    private final AtomicCounter senderBpe = countersManager.newCounter("snd-bpe");
+    private final FlowControl flowControl = mock(FlowControl.class);
+    private final RetransmitHandler retransmitHandler = mock(RetransmitHandler.class);
+    private final StatusMessageFlyweight statusMessageFlyweight = mock(StatusMessageFlyweight.class);
+    private final InetSocketAddress inetSocketAddress = mock(InetSocketAddress.class);
+    private final DriverConductorProxy driverConductorProxy = mock(DriverConductorProxy.class);
+
+    @BeforeEach
+    void before()
+    {
+        final UnsafeBuffer metadataBuffer = new UnsafeBuffer(new byte[LOG_META_DATA_LENGTH]);
+        termLength(metadataBuffer, TERM_MIN_LENGTH);
+        mtuLength(metadataBuffer, 8192);
+        initialTermId(metadataBuffer, INITIAL_TERM_ID);
+        initialiseTailWithTermId(metadataBuffer, 0, INITIAL_TERM_ID);
+        for (int i = 1; i < PARTITION_COUNT; i++)
+        {
+            final int expectedTermId = (INITIAL_TERM_ID + i) - PARTITION_COUNT;
+            initialiseTailWithTermId(metadataBuffer, i, expectedTermId);
+        }
+        isConnected(metadataBuffer, true);
+
+        when(rawLog.metaData()).thenReturn(metadataBuffer);
+        when(rawLog.termBuffers()).thenReturn(TERM_BUFFERS);
+        when(rawLog.sliceTerms()).thenReturn(
+            Stream.of(TERM_BUFFERS).map(UnsafeBuffer::byteBuffer).toArray(ByteBuffer[]::new));
+        when(rawLog.termLength()).thenReturn(TERM_MIN_LENGTH);
+
+        for (final UnsafeBuffer termBuffer : TERM_BUFFERS)
+        {
+            termBuffer.setMemory(0, termBuffer.capacity(), (byte)0xFF);
+        }
+
+        when(flowControl.hasRequiredReceivers()).thenReturn(true);
+    }
+
+    @SuppressWarnings("MethodLength")
+    @ParameterizedTest
+    @ValueSource(longs = { 0L, 512L, 7281770624L })
+    void shouldCleanLogBufferOneTermBehindMinSubPosition(final long initialPosition)
+    {
+        publisherPos.set(initialPosition);
+        publisherLimit.set(initialPosition);
+        senderPosition.set(initialPosition);
+        senderLimit.set(initialPosition);
+
+        final NetworkPublication publication = new NetworkPublication(
+            REGISTRATION_ID,
+            ctx,
+            params,
+            sendChannelEndpoint,
+            rawLog,
+            PUBLICATION_WINDOW_LENGTH,
+            publisherPos,
+            publisherLimit,
+            senderPosition,
+            senderLimit,
+            senderBpe,
+            SESSION_ID,
+            STREAM_ID,
+            INITIAL_TERM_ID,
+            flowControl,
+            retransmitHandler,
+            NETWORK_PUBLICATION_THREAD_LOCALS,
+            true);
+        assertEquals(initialPosition, publication.cleanPosition);
+        final long initialTermBasePosition = initialPosition - (initialPosition & (TERM_MIN_LENGTH - 1));
+
+        // setup initial connection
+        publication.onStatusMessage(statusMessageFlyweight, inetSocketAddress, driverConductorProxy);
+
+        // first iteration: only pub-lmt is updated
+        publication.updatePublisherPositionAndLimit();
+        assertEquals(initialPosition + PUBLICATION_WINDOW_LENGTH, publisherLimit.get());
+        assertEquals(initialPosition, publication.cleanPosition);
+
+        // consumer position didn't change -> no op
+        publication.updatePublisherPositionAndLimit();
+        assertEquals(initialPosition + PUBLICATION_WINDOW_LENGTH, publisherLimit.get());
+        assertEquals(initialPosition, publication.cleanPosition);
+
+        // consumer position moved -> update limit
+        senderPosition.set(initialPosition + 3072);
+        publication.updatePublisherPositionAndLimit();
+        assertEquals(initialPosition + 3072 + PUBLICATION_WINDOW_LENGTH, publisherLimit.get());
+        assertEquals(initialPosition, publication.cleanPosition);
+
+        // consumer position moved -> update limit
+        senderPosition.set(initialPosition + TERM_MIN_LENGTH / 8);
+        publication.updatePublisherPositionAndLimit();
+        assertEquals(initialPosition + TERM_MIN_LENGTH / 8 + PUBLICATION_WINDOW_LENGTH, publisherLimit.get());
+        assertEquals(initialPosition, publication.cleanPosition);
+
+        // consumer position moved by an entire term -> nothing to clean yet
+        senderPosition.set(initialPosition + TERM_MIN_LENGTH);
+        publication.updatePublisherPositionAndLimit();
+        assertEquals(initialPosition + TERM_MIN_LENGTH + PUBLICATION_WINDOW_LENGTH, publisherLimit.get());
+        assertEquals(initialPosition, publication.cleanPosition);
+
+        // consumer position moved again => clean bytes within a first buffer
+        senderPosition.set(initialPosition + TERM_MIN_LENGTH + 128);
+        publication.updatePublisherPositionAndLimit();
+        assertEquals(initialPosition + TERM_MIN_LENGTH + 128 + PUBLICATION_WINDOW_LENGTH, publisherLimit.get());
+        assertEquals(initialPosition + 128, publication.cleanPosition);
+
+        // consumer position moved again => clean the entire first buffer
+        senderPosition.set(initialPosition + 2 * TERM_MIN_LENGTH + 192);
+        publication.updatePublisherPositionAndLimit();
+        assertEquals(initialPosition + 2 * TERM_MIN_LENGTH + 192 + PUBLICATION_WINDOW_LENGTH, publisherLimit.get());
+        assertEquals(initialTermBasePosition + TERM_MIN_LENGTH, publication.cleanPosition);
+
+        // buffer clean trails snd-pos updates by one term
+        senderPosition.set(initialPosition + 2 * TERM_MIN_LENGTH + 4096);
+        publication.updatePublisherPositionAndLimit();
+        assertEquals(initialPosition + 2 * TERM_MIN_LENGTH + 4096 + PUBLICATION_WINDOW_LENGTH, publisherLimit.get());
+        assertEquals(initialPosition + TERM_MIN_LENGTH + 4096, publication.cleanPosition);
+    }
+
+    @Test
+    void pubLimitShouldNotCrossToThePreviousTermIfAnEntireTermIsDirty()
+    {
+        final long initialPosition = TERM_MIN_LENGTH - 1440;
+        publisherPos.set(initialPosition);
+        publisherLimit.set(initialPosition);
+        senderPosition.set(initialPosition);
+        senderLimit.set(initialPosition);
+
+        final NetworkPublication publication = new NetworkPublication(
+            REGISTRATION_ID,
+            ctx,
+            params,
+            sendChannelEndpoint,
+            rawLog,
+            PUBLICATION_WINDOW_LENGTH,
+            publisherPos,
+            publisherLimit,
+            senderPosition,
+            senderLimit,
+            senderBpe,
+            SESSION_ID,
+            STREAM_ID,
+            INITIAL_TERM_ID,
+            flowControl,
+            retransmitHandler,
+            NETWORK_PUBLICATION_THREAD_LOCALS,
+            true);
+        assertEquals(initialPosition, publication.cleanPosition);
+
+        // setup initial connection
+        publication.onStatusMessage(statusMessageFlyweight, inetSocketAddress, driverConductorProxy);
+
+        // no buffer cleaning at first
+        senderPosition.set(initialPosition + TERM_MIN_LENGTH - 128);
+        publication.updatePublisherPositionAndLimit();
+        assertEquals(initialPosition + TERM_MIN_LENGTH - 128 + PUBLICATION_WINDOW_LENGTH, publisherLimit.get());
+        assertEquals(initialPosition, publication.cleanPosition);
+
+        // pub-lmt cannot be changed as clean position is at the start of a dirty term
+        senderPosition.set(initialPosition + 2 * TERM_MIN_LENGTH);
+        publication.updatePublisherPositionAndLimit();
+        assertEquals(initialPosition + TERM_MIN_LENGTH - 128 + PUBLICATION_WINDOW_LENGTH, publisherLimit.get());
+        assertEquals(TERM_MIN_LENGTH, publication.cleanPosition);
+
+        // pub-lmt is allowed to update after clean position moves from the start of a dirty buffer
+        publication.updatePublisherPositionAndLimit();
+        assertEquals(senderPosition.get() + PUBLICATION_WINDOW_LENGTH, publisherLimit.get());
+        assertEquals(initialPosition + TERM_MIN_LENGTH, publication.cleanPosition);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, TERM_MIN_LENGTH - 1024})
+    void pubLimitShouldNotCrossToTheDirtyTerm(final long initialPosition)
+    {
+        publisherPos.set(initialPosition);
+        publisherLimit.set(initialPosition);
+        senderPosition.set(initialPosition);
+        senderLimit.set(initialPosition);
+
+        final NetworkPublication publication = new NetworkPublication(
+            REGISTRATION_ID,
+            ctx,
+            params,
+            sendChannelEndpoint,
+            rawLog,
+            PUBLICATION_WINDOW_LENGTH,
+            publisherPos,
+            publisherLimit,
+            senderPosition,
+            senderLimit,
+            senderBpe,
+            SESSION_ID,
+            STREAM_ID,
+            INITIAL_TERM_ID,
+            flowControl,
+            retransmitHandler,
+            NETWORK_PUBLICATION_THREAD_LOCALS,
+            true);
+        assertEquals(initialPosition, publication.cleanPosition);
+
+        // setup initial connection
+        publication.onStatusMessage(statusMessageFlyweight, inetSocketAddress, driverConductorProxy);
+
+        // new pub-lmt intersects with the clean position
+        senderPosition.set(initialPosition + 256);
+        publication.updatePublisherPositionAndLimit();
+        assertEquals(initialPosition + 256 + PUBLICATION_WINDOW_LENGTH, publisherLimit.get());
+        assertEquals(initialPosition, publication.cleanPosition);
+
+        // new pub-lmt intersects with the clean position
+        senderPosition.set(initialPosition + 2 * TERM_MIN_LENGTH + PUBLICATION_WINDOW_LENGTH);
+        publication.updatePublisherPositionAndLimit();
+        assertEquals(initialPosition + 256 + PUBLICATION_WINDOW_LENGTH, publisherLimit.get());
+        assertEquals(TERM_MIN_LENGTH, publication.cleanPosition);
+    }
+}

--- a/aeron-driver/src/test/java/io/aeron/driver/NetworkPublicationTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/NetworkPublicationTest.java
@@ -243,7 +243,7 @@ class NetworkPublicationTest
     }
 
     @ParameterizedTest
-    @ValueSource(ints = {0, TERM_MIN_LENGTH - 1024})
+    @ValueSource(ints = {0, TERM_MIN_LENGTH - PUBLICATION_WINDOW_LENGTH})
     void pubLimitShouldNotCrossToTheDirtyTerm(final long initialPosition)
     {
         publisherPos.set(initialPosition);
@@ -275,7 +275,7 @@ class NetworkPublicationTest
         // setup initial connection
         publication.onStatusMessage(statusMessageFlyweight, inetSocketAddress, driverConductorProxy);
 
-        // new pub-lmt intersects with the clean position
+        // initial position
         senderPosition.set(initialPosition + 256);
         publication.updatePublisherPositionAndLimit();
         assertEquals(initialPosition + 256 + PUBLICATION_WINDOW_LENGTH, publisherLimit.get());
@@ -286,5 +286,10 @@ class NetworkPublicationTest
         publication.updatePublisherPositionAndLimit();
         assertEquals(initialPosition + 256 + PUBLICATION_WINDOW_LENGTH, publisherLimit.get());
         assertEquals(TERM_MIN_LENGTH, publication.cleanPosition);
+
+        // after cleanup pub-lmt can move again
+        publication.updatePublisherPositionAndLimit();
+        assertEquals(initialPosition + 2 * TERM_MIN_LENGTH + 2 * PUBLICATION_WINDOW_LENGTH, publisherLimit.get());
+        assertEquals(initialPosition + TERM_MIN_LENGTH + PUBLICATION_WINDOW_LENGTH, publication.cleanPosition);
     }
 }


### PR DESCRIPTION
This PR ensures that `pub-lmt` always stays within a safe boundary, i.e.:
* either one term ahead of the dirty buffer.
* or two terms ahead of the dirty buffer but only if the clean position offset is non zero, i.e. **not** an entire buffer is dirty.

Explanation: `pub-lmt` is a soft constraint, i.e. it can be breached by a publisher but only within a term boundary. This means that if the publisher fills an entire term and the following term is a dirty one then subscribers (sender or spies) might start reading the dirty data before conductor has a chance to clean it up. Therefore if the clean position is at the term start we don't allow `pub-lmt` to be in the previous term.