### PR TITLE
Poll archive client for ReplicationSession and ReplayMerge

### DIFF
--- a/.github/workflows/ci-low-cadence.yml
+++ b/.github/workflows/ci-low-cadence.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         java: [ '17', '21', '24' ]
-        os: ['ubuntu-24.04', 'windows-latest', 'macos-latest']
+        os: ['ubuntu-24.04', 'windows-latest', 'macos-15']
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         java: [ '17', '21', '24' ]
-        os: ['ubuntu-24.04', 'windows-latest', 'macos-latest']
+        os: ['ubuntu-24.04', 'windows-latest', 'macos-15']
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -382,7 +382,7 @@ jobs:
 
   cpp-xcode-build:
     name: C++ Xcode (macOS)
-    runs-on: macos-latest
+    runs-on: macos-15
     timeout-minutes: 60
     env:
       CC: clang

--- a/aeron-archive/src/main/c/client/aeron_archive_replay_merge.c
+++ b/aeron-archive/src/main/c/client/aeron_archive_replay_merge.c
@@ -287,8 +287,6 @@ int aeron_archive_replay_merge_close(aeron_archive_replay_merge_t *replay_merge)
     aeron_free(replay_merge->replay_endpoint);
     aeron_free(replay_merge);
 
-    aeron_archive_replay_merge_set_state(replay_merge, CLOSED);
-
     return 0;
 }
 

--- a/aeron-archive/src/main/c/client/aeron_archive_replay_merge.c
+++ b/aeron-archive/src/main/c/client/aeron_archive_replay_merge.c
@@ -808,7 +808,7 @@ static int aeron_archive_replay_merge_poll_for_response(bool *found_response_p, 
 
         if (poll_count == 0 && !aeron_subscription_is_connected(poller->subscription))
         {
-            AERON_SET_ERR(-AERON_ERROR_CODE_GENERIC_ERROR, "%s", "subscription to archive is not connected");
+            AERON_SET_ERR(-AERON_ERROR_CODE_GENERIC_ERROR, "%s", "archive is not connected");
             return -1;
         }
     }

--- a/aeron-archive/src/main/c/client/aeron_archive_replay_merge.c
+++ b/aeron-archive/src/main/c/client/aeron_archive_replay_merge.c
@@ -22,6 +22,7 @@
 #include "util/aeron_error.h"
 #include "uri/aeron_uri_string_builder.h"
 #include "aeron_archive_client.h"
+#include "command/aeron_control_protocol.h"
 
 #define REPLAY_MERGE_LIVE_ADD_MAX_WINDOW (32 * 1024 * 1024)
 #define REPLAY_MERGE_REPLAY_REMOVE_THRESHOLD (0)
@@ -807,7 +808,7 @@ static int aeron_archive_replay_merge_poll_for_response(bool *found_response_p, 
 
         if (poll_count == 0 && !aeron_subscription_is_connected(poller->subscription))
         {
-            AERON_APPEND_ERR("%s", "");
+            AERON_SET_ERR(-AERON_ERROR_CODE_GENERIC_ERROR, "%s", "subscription to archive is not connected");
             return -1;
         }
     }

--- a/aeron-archive/src/main/java/io/aeron/archive/ReplicationSession.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ReplicationSession.java
@@ -219,7 +219,6 @@ class ReplicationSession implements Session, RecordingDescriptorConsumer
 
                 case EXTEND:
                     workCount += extend();
-                    workCount += pollSourceArchiveEvents();
                     break;
 
                 case REPLAY_TOKEN:
@@ -228,7 +227,6 @@ class ReplicationSession implements Session, RecordingDescriptorConsumer
 
                 case GET_ARCHIVE_PROXY:
                     workCount += getArchiveProxy();
-                    workCount += pollSourceArchiveEvents();
                     break;
 
                 case REPLAY:
@@ -237,17 +235,15 @@ class ReplicationSession implements Session, RecordingDescriptorConsumer
 
                 case AWAIT_IMAGE:
                     workCount += awaitImage();
-                    workCount += pollSourceArchiveEvents();
                     break;
 
                 case REPLICATE:
                     workCount += replicate();
-                    workCount += pollSourceArchiveEvents();
+
                     break;
 
                 case CATCHUP:
                     workCount += catchup();
-                    workCount += pollSourceArchiveEvents();
                     break;
 
                 case ATTEMPT_LIVE_JOIN:
@@ -257,6 +253,8 @@ class ReplicationSession implements Session, RecordingDescriptorConsumer
                 case DONE:
                     break;
             }
+
+            workCount += pollSourceArchiveEvents();
         }
         catch (final Exception ex)
         {

--- a/aeron-archive/src/main/java/io/aeron/archive/ReplicationSession.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ReplicationSession.java
@@ -239,7 +239,6 @@ class ReplicationSession implements Session, RecordingDescriptorConsumer
 
                 case REPLICATE:
                     workCount += replicate();
-
                     break;
 
                 case CATCHUP:

--- a/aeron-driver/src/main/c/media/aeron_send_channel_endpoint.c
+++ b/aeron-driver/src/main/c/media/aeron_send_channel_endpoint.c
@@ -252,7 +252,10 @@ int aeron_send_channel_endpoint_delete(
 
     aeron_int64_to_ptr_hash_map_delete(&endpoint->publication_dispatch_map);
     aeron_udp_channel_delete(endpoint->conductor_fields.udp_channel);
-    endpoint->transport_bindings->close_func(&endpoint->transport);
+    if (endpoint->conductor_fields.status != AERON_SEND_CHANNEL_ENDPOINT_STATUS_CLOSED)
+    {
+        endpoint->transport_bindings->close_func(&endpoint->transport);
+    }
 
     if (NULL != endpoint->port_manager)
     {
@@ -266,6 +269,14 @@ int aeron_send_channel_endpoint_delete(
     }
 
     aeron_free(endpoint);
+
+    return 0;
+}
+
+int aeron_send_channel_endpoint_close(aeron_send_channel_endpoint_t *endpoint)
+{
+    endpoint->transport_bindings->close_func(&endpoint->transport);
+    endpoint->conductor_fields.status = AERON_SEND_CHANNEL_ENDPOINT_STATUS_CLOSED;
 
     return 0;
 }

--- a/aeron-driver/src/main/c/media/aeron_send_channel_endpoint.h
+++ b/aeron-driver/src/main/c/media/aeron_send_channel_endpoint.h
@@ -32,7 +32,8 @@
 typedef enum aeron_send_channel_endpoint_status_enum
 {
     AERON_SEND_CHANNEL_ENDPOINT_STATUS_ACTIVE,
-    AERON_SEND_CHANNEL_ENDPOINT_STATUS_CLOSING
+    AERON_SEND_CHANNEL_ENDPOINT_STATUS_CLOSING,
+    AERON_SEND_CHANNEL_ENDPOINT_STATUS_CLOSED
 }
 aeron_send_channel_endpoint_status_t;
 
@@ -82,6 +83,8 @@ int aeron_send_channel_endpoint_create(
 
 int aeron_send_channel_endpoint_delete(
     aeron_counters_manager_t *counters_manager, aeron_send_channel_endpoint_t *endpoint);
+
+int aeron_send_channel_endpoint_close(aeron_send_channel_endpoint_t *endpoint);
 
 int aeron_send_channel_send(
     aeron_send_channel_endpoint_t *endpoint,

--- a/aeron-samples/src/main/java/io/aeron/samples/archive/IndexedReplicatedRecording.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/archive/IndexedReplicatedRecording.java
@@ -75,6 +75,7 @@ public class IndexedReplicatedRecording implements AutoCloseable
     private static final int LIVE_STREAM_ID = 1033;
     private static final String LIVE_CHANNEL = new ChannelUriStringBuilder()
         .media("udp")
+        .controlMode(CommonContext.MDC_CONTROL_MODE_DYNAMIC)
         .controlEndpoint("localhost:8100")
         .termLength(TERM_LENGTH)
         .build();


### PR DESCRIPTION
This is to make sure we are polling archive client in replay merge and replication session. If archive times out dormant archive client during catchup phase, both replay merge and replication session may be unable to transition to live stream. For ReplayMerge am polling archive client, to handle internally to avoid interfering with in-flight responses. Perhaps need to introduce a slow tick work to avoid polling every duty cycle. Feel free to close if I've misunderstood something or there is a better approach.