### PR TITLE
[Java] Fix IndexedReplicatedRecording LIVE_CHANNEL config

### DIFF
--- a/aeron-samples/src/main/java/io/aeron/samples/archive/IndexedReplicatedRecording.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/archive/IndexedReplicatedRecording.java
@@ -75,6 +75,7 @@ public class IndexedReplicatedRecording implements AutoCloseable
     private static final int LIVE_STREAM_ID = 1033;
     private static final String LIVE_CHANNEL = new ChannelUriStringBuilder()
         .media("udp")
+        .controlMode(CommonContext.MDC_CONTROL_MODE_DYNAMIC)
         .controlEndpoint("localhost:8100")
         .termLength(TERM_LENGTH)
         .build();


### PR DESCRIPTION
When running this IndexedReplicatedRecording example, the following error will be reported.
It seems to be an issue with the LIVE_CHANNEL configuration, I've submitted this MR to fix it. Please review it.

```
Exception in thread "main" io.aeron.exceptions.RegistrationException: ERROR - java.lang.IllegalArgumentException : 'control' parameter requires that either 'endpoint' or 'control-mode' is specified, channel=aeron:udp?control=localhost:8100|term-length=65536, errorCodeValue=11
	at io.aeron.ClientConductor.onError(ClientConductor.java:224)
	at io.aeron.DriverEventsAdapter.onMessage(DriverEventsAdapter.java:116)
	at org.agrona.concurrent.broadcast.CopyBroadcastReceiver.receive(CopyBroadcastReceiver.java:116)
	at io.aeron.DriverEventsAdapter.receive(DriverEventsAdapter.java:69)
	at io.aeron.ClientConductor.service(ClientConductor.java:1471)
	at io.aeron.ClientConductor.awaitResponse(ClientConductor.java:1529)
	at io.aeron.ClientConductor.addExclusivePublication(ClientConductor.java:473)
	at io.aeron.Aeron.addExclusivePublication(Aeron.java:294)
	at io.aeron.samples.archive.IndexedReplicatedRecording.main(IndexedReplicatedRecording.java:195)
```