### PR TITLE
[C] More immediate close of send channel endpoints

### DIFF
--- a/aeron-driver/src/main/c/media/aeron_send_channel_endpoint.c
+++ b/aeron-driver/src/main/c/media/aeron_send_channel_endpoint.c
@@ -252,7 +252,10 @@ int aeron_send_channel_endpoint_delete(
 
     aeron_int64_to_ptr_hash_map_delete(&endpoint->publication_dispatch_map);
     aeron_udp_channel_delete(endpoint->conductor_fields.udp_channel);
-    endpoint->transport_bindings->close_func(&endpoint->transport);
+    if (endpoint->conductor_fields.status != AERON_SEND_CHANNEL_ENDPOINT_STATUS_CLOSED)
+    {
+        endpoint->transport_bindings->close_func(&endpoint->transport);
+    }
 
     if (NULL != endpoint->port_manager)
     {
@@ -266,6 +269,14 @@ int aeron_send_channel_endpoint_delete(
     }
 
     aeron_free(endpoint);
+
+    return 0;
+}
+
+int aeron_send_channel_endpoint_close(aeron_send_channel_endpoint_t *endpoint)
+{
+    endpoint->transport_bindings->close_func(&endpoint->transport);
+    endpoint->conductor_fields.status = AERON_SEND_CHANNEL_ENDPOINT_STATUS_CLOSED;
 
     return 0;
 }

--- a/aeron-driver/src/main/c/media/aeron_send_channel_endpoint.h
+++ b/aeron-driver/src/main/c/media/aeron_send_channel_endpoint.h
@@ -32,7 +32,8 @@
 typedef enum aeron_send_channel_endpoint_status_enum
 {
     AERON_SEND_CHANNEL_ENDPOINT_STATUS_ACTIVE,
-    AERON_SEND_CHANNEL_ENDPOINT_STATUS_CLOSING
+    AERON_SEND_CHANNEL_ENDPOINT_STATUS_CLOSING,
+    AERON_SEND_CHANNEL_ENDPOINT_STATUS_CLOSED
 }
 aeron_send_channel_endpoint_status_t;
 
@@ -82,6 +83,8 @@ int aeron_send_channel_endpoint_create(
 
 int aeron_send_channel_endpoint_delete(
     aeron_counters_manager_t *counters_manager, aeron_send_channel_endpoint_t *endpoint);
+
+int aeron_send_channel_endpoint_close(aeron_send_channel_endpoint_t *endpoint);
 
 int aeron_send_channel_send(
     aeron_send_channel_endpoint_t *endpoint,


### PR DESCRIPTION
- Removes the managed resource lifecycle between removing the endpoint from the sender and closing the underlying socket.
- If an send channel endpoint is found in the closing state, respond with a temporary resource error.
- Reduces the window of time where we can end up with a port bind error to a very small amount.