### PR TITLE
Archive client poll

### DIFF
--- a/aeron-archive/src/main/cpp/client/ReplayMerge.h
+++ b/aeron-archive/src/main/cpp/client/ReplayMerge.h
@@ -26,6 +26,7 @@ constexpr const std::int32_t REPLAY_MERGE_REPLAY_REMOVE_THRESHOLD = 0;
 constexpr const std::int64_t REPLAY_MERGE_PROGRESS_TIMEOUT_DEFAULT_MS = 5 * 1000;
 constexpr const std::int64_t REPLAY_MERGE_INITIAL_GET_MAX_RECORDED_POSITION_BACKOFF_MS = 8;
 constexpr const std::int64_t REPLAY_MERGE_GET_MAX_RECORDED_POSITION_BACKOFF_MAX_MS = 500;
+constexpr const std::int64_t REPLAY_MERGE_ARCHIVE_POLL_INTERVAL_MS = 100;
 
 /**
  * Replay a recorded stream from a starting position and merge with live stream to consume a full history of a stream.
@@ -88,26 +89,31 @@ public:
                 case State::RESOLVE_REPLAY_PORT:
                     workCount += resolveReplayPort(nowMs);
                     checkProgress(nowMs);
+                    pollArchiveEvents(nowMs);
                     break;
 
                 case State::GET_RECORDING_POSITION:
                     workCount += getRecordingPosition(nowMs);
                     checkProgress(nowMs);
+                    pollArchiveEvents(nowMs);
                     break;
 
                 case State::REPLAY:
                     workCount += replay(nowMs);
                     checkProgress(nowMs);
+                    pollArchiveEvents(nowMs);
                     break;
 
                 case State::CATCHUP:
                     workCount += catchup(nowMs);
                     checkProgress(nowMs);
+                    pollArchiveEvents(nowMs);
                     break;
 
                 case State::ATTEMPT_LIVE_JOIN:
                     workCount += attemptLiveJoin(nowMs);
                     checkProgress(nowMs);
+                    pollArchiveEvents(nowMs);
                     break;
 
                 default:
@@ -211,6 +217,7 @@ private:
     long long m_timeOfLastProgressMs = 0;
     long long m_timeOfNextGetMaxRecordedPositionMs;
     long long m_getMaxRecordedPositionBackoffMs = REPLAY_MERGE_INITIAL_GET_MAX_RECORDED_POSITION_BACKOFF_MS;
+    long long m_timeOfLastScheduledArchivePollMs = 0;
     bool m_isLiveAdded = false;
     bool m_isReplayActive = false;
 
@@ -248,6 +255,8 @@ private:
     void stopReplay();
 
     void checkProgress(long long nowMs);
+
+    void pollArchiveEvents(long long nowMs);
 
     static bool pollForResponse(AeronArchive &archive, std::int64_t correlationId);
 };

--- a/aeron-archive/src/main/java/io/aeron/archive/ReplicationSession.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ReplicationSession.java
@@ -38,6 +38,7 @@ class ReplicationSession implements Session, RecordingDescriptorConsumer
 {
     private static final int REPLAY_REMOVE_THRESHOLD = 0;
     private static final int RETRY_ATTEMPTS = 3;
+    private static final int SOURCE_ARCHIVE_POLL_INTERVAL_MS = 100;
     private final int replicationSessionId;
 
     @SuppressWarnings("JavadocVariable")
@@ -95,6 +96,7 @@ class ReplicationSession implements Session, RecordingDescriptorConsumer
     private long responsePublicationRegistrationId = NULL_VALUE;
     private ExclusivePublication responsePublication = null;
     private ArchiveProxy responseArchiveProxy = null;
+    private long timeOfLastScheduledSourceArchivePollMs;
 
     ReplicationSession(
         final long srcRecordingId,
@@ -211,42 +213,52 @@ class ReplicationSession implements Session, RecordingDescriptorConsumer
 
                 case REPLICATE_DESCRIPTOR:
                     workCount += replicateDescriptor();
+                    pollSourceArchiveEvents();
                     break;
 
                 case SRC_RECORDING_POSITION:
                     workCount += srcRecordingPosition();
+                    pollSourceArchiveEvents();
                     break;
 
                 case EXTEND:
                     workCount += extend();
+                    pollSourceArchiveEvents();
                     break;
 
                 case REPLAY_TOKEN:
                     workCount += replayToken();
+                    pollSourceArchiveEvents();
                     break;
 
                 case GET_ARCHIVE_PROXY:
                     workCount += getArchiveProxy();
+                    pollSourceArchiveEvents();
                     break;
 
                 case REPLAY:
                     workCount += replay();
+                    pollSourceArchiveEvents();
                     break;
 
                 case AWAIT_IMAGE:
                     workCount += awaitImage();
+                    pollSourceArchiveEvents();
                     break;
 
                 case REPLICATE:
                     workCount += replicate();
+                    pollSourceArchiveEvents();
                     break;
 
                 case CATCHUP:
                     workCount += catchup();
+                    pollSourceArchiveEvents();
                     break;
 
                 case ATTEMPT_LIVE_JOIN:
                     workCount += attemptLiveJoin();
+                    pollSourceArchiveEvents();
                     break;
 
                 case DONE:
@@ -953,6 +965,23 @@ class ReplicationSession implements Session, RecordingDescriptorConsumer
         state = newState;
         activeCorrelationId = NULL_VALUE;
         timeOfLastActionMs = epochClock.time();
+    }
+
+    private void pollSourceArchiveEvents()
+    {
+        final long nowMs = epochClock.time();
+
+        if (activeCorrelationId == Aeron.NULL_VALUE &&
+            (nowMs > (timeOfLastScheduledSourceArchivePollMs + SOURCE_ARCHIVE_POLL_INTERVAL_MS)))
+        {
+            timeOfLastScheduledSourceArchivePollMs = nowMs;
+
+            final String errorMessage = srcArchive.pollForErrorResponse();
+            if (null != errorMessage)
+            {
+                throw new ArchiveException(errorMessage);
+            }
+        }
     }
 
     @SuppressWarnings("unused")

--- a/aeron-client/src/main/c/aeron_client.c
+++ b/aeron-client/src/main/c/aeron_client.c
@@ -741,14 +741,14 @@ static int aeron_async_destination_poll(aeron_async_destination_t *async)
         case AERON_CLIENT_TIMEOUT_MEDIA_DRIVER:
         {
             AERON_SET_ERR(
-                AERON_CLIENT_ERROR_DRIVER_TIMEOUT, "%s", "async_add_publication no response from media driver");
+                AERON_CLIENT_ERROR_DRIVER_TIMEOUT, "%s", "async_add_destination no response from media driver");
             aeron_async_cmd_free(async);
             return -1;
         }
 
         default:
         {
-            AERON_SET_ERR(EINVAL, "async_add_counter async status %s", "unknown");
+            AERON_SET_ERR(EINVAL, "async_add_destination async status %s", "unknown");
             aeron_async_cmd_free(async);
             return -1;
         }


### PR DESCRIPTION
This is to make sure we are polling archive client in replay merge and replication session. 

If archive times out dormant archive client during catchup phase, both replay merge and replication session may be unable to transition to live stream. For ReplayMerge polling archive client internally is important to avoid interfering with in-flight responses. 

Polling is done at 100ms interval. Feel free to close if I've misunderstood something or there is a better approach.