### PR TITLE
Cluster tool exit code bugfix.

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusterTool.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusterTool.java
@@ -252,7 +252,7 @@ public class ClusterTool
         }
         else
         {
-            command.action().act(clusterDir, System.out, args);
+            System.exit(command.action().act(clusterDir, System.out, args));
         }
     }
 


### PR DESCRIPTION
Cluster tool no longer returns exit codes - what makes it impossible to use commands such as `is-leader`.
