### PR TITLE
[Java] Allow ConsensusModuleExtension to do work while election is in progress.

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -371,6 +371,11 @@ final class ConsensusModuleAgent
             {
                 workCount += consensusWork(timestamp, nowNs);
             }
+
+            if (null != consensusModuleExtension)
+            {
+                workCount += consensusModuleExtension.doWork(nowNs);
+            }
         }
         catch (final AgentTerminationException ex)
         {
@@ -2361,6 +2366,11 @@ final class ConsensusModuleAgent
             }
         }
 
+        if (null != consensusModuleExtension)
+        {
+            workCount += consensusModuleExtension.slowTickWork(nowNs);
+        }
+
         return workCount;
     }
 
@@ -2422,7 +2432,7 @@ final class ConsensusModuleAgent
         workCount += pollStandbySnapshotReplication(nowNs);
         if (null != consensusModuleExtension)
         {
-            workCount += consensusModuleExtension.doWork(nowNs);
+            workCount += consensusModuleExtension.consensusWork(nowNs);
         }
 
         return workCount;

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleExtension.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleExtension.java
@@ -65,6 +65,22 @@ public interface ConsensusModuleExtension extends AutoCloseable
     int doWork(long nowNs);
 
     /**
+     * Similar to {@link #doWork(long)}, but executed less frequently.
+     *
+     * @param nowNs is cluster time in nanoseconds.
+     * @return 0 to indicate no work was currently available, a positive value otherwise.
+     */
+    int slowTickWork(long nowNs);
+
+    /**
+     * Similar to {@link #doWork(long)}, but executed only when there's no election in progress.
+     *
+     * @param nowNs is cluster time in nanoseconds.
+     * @return 0 to indicate no work was currently available, a positive value otherwise.
+     */
+    int consensusWork(long nowNs);
+
+    /**
      * Cluster election is complete and new publication is added for the leadership term. If the node is a follower
      * then the publication will be null.
      *

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ClusterWithNoServicesTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ClusterWithNoServicesTest.java
@@ -230,6 +230,16 @@ class ClusterWithNoServicesTest
             return 0;
         }
 
+        public int slowTickWork(final long nowNs)
+        {
+            return 0;
+        }
+
+        public int consensusWork(final long nowNs)
+        {
+            return 0;
+        }
+
         public void onElectionComplete(final ConsensusControlState consensusControlState)
         {
         }


### PR DESCRIPTION
This is a breaking change - CME#doWork is now executed in every duty cycle, including when elections are in progress. The newly added CME#consensusWork is equivalent to the old CME#doWork. Also, CME#slowTickWork was added to make CME simply mirror all work callbacks of the ConsensusModuleAgent.