### PR TITLE
(bug): move darwin check to __APPLE__

### DIFF
--- a/aeron-client/src/main/cpp/concurrent/AgentRunner.h
+++ b/aeron-client/src/main/cpp/concurrent/AgentRunner.h
@@ -119,7 +119,7 @@ public:
             [&]()
             {
 #if defined(AERON_COMPILER_MSVC)
-#elif defined(Darwin)
+#elif defined(__APPLE__)
                 pthread_setname_np(m_name.c_str());
 #else
                 char threadName[16UL] = {};

--- a/aeron-client/src/main/cpp_wrapper/concurrent/AgentRunner.h
+++ b/aeron-client/src/main/cpp_wrapper/concurrent/AgentRunner.h
@@ -119,7 +119,7 @@ public:
             [&]()
             {
 #if defined(AERON_COMPILER_MSVC)
-#elif defined(Darwin)
+#elif defined(__APPLE__)
                 pthread_setname_np(m_name.c_str());
 #else
                 char threadName[16UL] = {};


### PR DESCRIPTION
builds break on macos due to bad check
```
bazel-out/darwin_arm64-opt/bin/external/+cpp_deps_extension+com_github_aeron_io_aeron/com_github_aeron_io_aeron/include/concurrent/AgentRunner.h:127:17: error: no matching function for call to 'pthread_setname_np'
  127 |                 pthread_setname_np(pthread_self(), threadName);
      |                 ^~~~~~~~~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.5.sdk/usr/include/pthread.h:535:5: note: candidate function not viable: requires 1 argument, but 2 were provided
  535 | int     pthread_setname_np(const char*);
```