### PR TITLE
[Driver/Java] Detect `Address in use` errors synchronoously when creating endpoints.

### DIFF
--- a/aeron-client/src/main/java/io/aeron/DriverEventsAdapter.java
+++ b/aeron-client/src/main/java/io/aeron/DriverEventsAdapter.java
@@ -107,6 +107,7 @@ class DriverEventsAdapter implements MessageHandler
 
                 if (CHANNEL_ENDPOINT_ERROR == errorCode)
                 {
+                    // This code is left for backwards compatibility with versions prior to 1.48.5
                     notProcessed = false;
                     conductor.onChannelEndpointError(correlationId, errorResponse.errorMessage());
                 }

--- a/aeron-client/src/main/java/io/aeron/DriverEventsAdapter.java
+++ b/aeron-client/src/main/java/io/aeron/DriverEventsAdapter.java
@@ -107,7 +107,7 @@ class DriverEventsAdapter implements MessageHandler
 
                 if (CHANNEL_ENDPOINT_ERROR == errorCode)
                 {
-                    // This code is left for backwards compatibility with versions prior to 1.48.5
+                    // This code is left for backwards compatibility with older media driver versions
                     notProcessed = false;
                     conductor.onChannelEndpointError(correlationId, errorResponse.errorMessage());
                 }

--- a/aeron-driver/src/main/c/media/aeron_send_channel_endpoint.c
+++ b/aeron-driver/src/main/c/media/aeron_send_channel_endpoint.c
@@ -196,7 +196,6 @@ int aeron_send_channel_endpoint_create(
             _endpoint->destination_tracker, &_endpoint->tracker_num_destinations);
     }
 
-    // TODO: Remove the update and just create in a single shot.
     aeron_channel_endpoint_status_update_label(
         counters_manager,
         _endpoint->channel_status.counter_id,

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -2134,6 +2134,7 @@ public final class DriverConductor implements Agent
                     params, channelEndpoint.socketSndbufLength(), ctx, udpChannel.originalUriString(), null);
 
                 channelEndpoint.openChannel(ctx.driverConductorProxy());
+                channelEndpoint.indicateActive();
 
                 senderProxy.registerSendChannelEndpoint(channelEndpoint);
                 sendChannelEndpointByChannelMap.put(udpChannel.canonicalForm(), channelEndpoint);
@@ -2402,6 +2403,7 @@ public final class DriverConductor implements Agent
                 validateInitialWindowForRcvBuf(params, channel, channelEndpoint.socketRcvbufLength(), ctx, null);
 
                 channelEndpoint.openChannel(ctx.driverConductorProxy());
+                channelEndpoint.indicateActive();
 
                 receiverProxy.registerReceiveChannelEndpoint(channelEndpoint);
                 receiveChannelEndpointByChannelMap.put(udpChannel.canonicalForm(), channelEndpoint);

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -2133,8 +2133,10 @@ public final class DriverConductor implements Agent
                 validateMtuForSndbuf(
                     params, channelEndpoint.socketSndbufLength(), ctx, udpChannel.originalUriString(), null);
 
-                sendChannelEndpointByChannelMap.put(udpChannel.canonicalForm(), channelEndpoint);
+                channelEndpoint.openChannel(ctx.driverConductorProxy());
+
                 senderProxy.registerSendChannelEndpoint(channelEndpoint);
+                sendChannelEndpointByChannelMap.put(udpChannel.canonicalForm(), channelEndpoint);
             }
             catch (final Exception ex)
             {

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -398,12 +398,6 @@ public final class DriverConductor implements Agent
         }
     }
 
-    void onChannelEndpointError(final long statusIndicatorId, final Exception ex)
-    {
-        final String errorMessage = ex.getClass().getName() + " : " + ex.getMessage();
-        clientProxy.onError(statusIndicatorId, CHANNEL_ENDPOINT_ERROR, errorMessage);
-    }
-
     void onPublicationError(
         final long registrationId,
         final long destinationRegistrationId,

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductorProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductorProxy.java
@@ -88,14 +88,6 @@ public final class DriverConductorProxy
      */
     public void channelEndpointError(final long statusIndicatorId, final Exception ex)
     {
-        if (notConcurrent())
-        {
-            driverConductor.onChannelEndpointError(statusIndicatorId, ex);
-        }
-        else
-        {
-            offer(() -> driverConductor.onChannelEndpointError(statusIndicatorId, ex));
-        }
     }
 
     /**

--- a/aeron-driver/src/main/java/io/aeron/driver/Receiver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Receiver.java
@@ -227,7 +227,6 @@ public final class Receiver implements Agent
     {
         if (!channelEndpoint.hasDestinationControl())
         {
-            channelEndpoint.openChannel(conductorProxy);
             channelEndpoint.registerForRead(dataTransportPoller);
             channelEndpoint.indicateActive();
 
@@ -269,8 +268,6 @@ public final class Receiver implements Agent
 
     void onAddDestination(final ReceiveChannelEndpoint channelEndpoint, final ReceiveDestinationTransport transport)
     {
-        transport.openChannel(conductorProxy, channelEndpoint.statusIndicatorCounter());
-
         final int transportIndex = channelEndpoint.addDestination(transport);
         final SelectionKey key = dataTransportPoller.registerForRead(channelEndpoint, transport, transportIndex);
         transport.selectionKey(key);

--- a/aeron-driver/src/main/java/io/aeron/driver/Receiver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Receiver.java
@@ -228,17 +228,12 @@ public final class Receiver implements Agent
         if (!channelEndpoint.hasDestinationControl())
         {
             channelEndpoint.registerForRead(dataTransportPoller);
-            channelEndpoint.indicateActive();
 
             if (channelEndpoint.hasExplicitControl())
             {
                 addPendingSetupMessage(0, 0, 0, channelEndpoint, true, channelEndpoint.explicitControlAddress());
                 channelEndpoint.sendSetupElicitingStatusMessage(0, channelEndpoint.explicitControlAddress(), 0, 0);
             }
-        }
-        else
-        {
-            channelEndpoint.indicateActive();
         }
     }
 

--- a/aeron-driver/src/main/java/io/aeron/driver/Sender.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Sender.java
@@ -165,7 +165,6 @@ public final class Sender extends SenderRhsPadding implements Agent
 
     void onRegisterSendChannelEndpoint(final SendChannelEndpoint channelEndpoint)
     {
-        channelEndpoint.openChannel(conductorProxy);
         channelEndpoint.registerForRead(controlTransportPoller);
         channelEndpoint.indicateActive();
     }

--- a/aeron-driver/src/main/java/io/aeron/driver/Sender.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Sender.java
@@ -166,7 +166,6 @@ public final class Sender extends SenderRhsPadding implements Agent
     void onRegisterSendChannelEndpoint(final SendChannelEndpoint channelEndpoint)
     {
         channelEndpoint.registerForRead(controlTransportPoller);
-        channelEndpoint.indicateActive();
     }
 
     void onCloseSendChannelEndpoint(final SendChannelEndpoint channelEndpoint)

--- a/aeron-driver/src/main/java/io/aeron/driver/media/ReceiveChannelEndpoint.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/ReceiveChannelEndpoint.java
@@ -324,22 +324,7 @@ public class ReceiveChannelEndpoint extends ReceiveChannelEndpointRhsPadding
     {
         if (null == multiRcvDestination)
         {
-            if (conductorProxy.notConcurrent())
-            {
-                openDatagramChannel(statusIndicator);
-            }
-            else
-            {
-                try
-                {
-                    openDatagramChannel(statusIndicator);
-                }
-                catch (final Exception ex)
-                {
-                    conductorProxy.channelEndpointError(statusIndicator.id(), ex);
-                    throw ex;
-                }
-            }
+            openDatagramChannel(statusIndicator);
         }
     }
 

--- a/aeron-driver/src/main/java/io/aeron/driver/media/ReceiveDestinationTransport.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/ReceiveDestinationTransport.java
@@ -130,22 +130,7 @@ public final class ReceiveDestinationTransport extends ReceiveDestinationTranspo
      */
     public void openChannel(final DriverConductorProxy conductorProxy, final AtomicCounter statusIndicator)
     {
-        if (conductorProxy.notConcurrent())
-        {
-            openDatagramChannel(statusIndicator);
-        }
-        else
-        {
-            try
-            {
-                openDatagramChannel(statusIndicator);
-            }
-            catch (final Exception ex)
-            {
-                conductorProxy.channelEndpointError(statusIndicator.id(), ex);
-                throw ex;
-            }
-        }
+        openDatagramChannel(statusIndicator);
 
         LocalSocketAddressStatus.updateBindAddress(
             localSocketAddressIndicator, bindAddressAndPort(), context.countersMetaDataBuffer());

--- a/aeron-driver/src/main/java/io/aeron/driver/media/SendChannelEndpoint.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/SendChannelEndpoint.java
@@ -155,22 +155,7 @@ public class SendChannelEndpoint extends UdpChannelTransport
      */
     public void openChannel(final DriverConductorProxy conductorProxy)
     {
-        if (conductorProxy.notConcurrent())
-        {
-            openDatagramChannel(statusIndicator);
-        }
-        else
-        {
-            try
-            {
-                openDatagramChannel(statusIndicator);
-            }
-            catch (final Exception ex)
-            {
-                conductorProxy.channelEndpointError(statusIndicator.id(), ex);
-                throw ex;
-            }
-        }
+        openDatagramChannel(statusIndicator);
 
         LocalSocketAddressStatus.updateBindAddress(
             requireNonNull(localSocketAddressIndicator, "localSocketAddressIndicator not allocated"),

--- a/aeron-driver/src/test/java/io/aeron/driver/DriverConductorTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/DriverConductorTest.java
@@ -209,7 +209,9 @@ class DriverConductorTest
             .receiverPortManager(new WildcardPortManager(WildcardPortManager.EMPTY_PORT_RANGE, false))
             .asyncTaskExecutor(CALLER_RUNS_TASK_EXECUTOR)
             .asyncTaskExecutorThreads(0)
-            .cncByteBuffer(IoUtil.mapNewFile(dir.resolve("test.cnc").toFile(), 1024));
+            .cncByteBuffer(IoUtil.mapNewFile(dir.resolve("test.cnc").toFile(), 1024))
+            .countersMetaDataBuffer((UnsafeBuffer)spyCountersManager.metaDataBuffer())
+            .countersValuesBuffer((UnsafeBuffer)spyCountersManager.valuesBuffer());
 
         driverProxy = new DriverProxy(toDriverCommands, toDriverCommands.nextCorrelationId());
         driverConductor = new DriverConductor(ctx);

--- a/aeron-driver/src/test/java/io/aeron/driver/DriverConductorTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/DriverConductorTest.java
@@ -710,8 +710,6 @@ class DriverConductorTest
         verify(receiverProxy).registerReceiveChannelEndpoint(captor1.capture());
         receiveChannelEndpoint = captor1.getValue();
 
-        receiveChannelEndpoint.openChannel(mockDriverConductorProxy);
-
         driverConductor.onCreatePublicationImage(
             SESSION_ID, STREAM_ID_1, initialTermId, activeTermId, termOffset, TERM_BUFFER_LENGTH, MTU_LENGTH, 0,
             (short)0, mock(InetSocketAddress.class), sourceAddress, receiveChannelEndpoint);
@@ -740,8 +738,6 @@ class DriverConductorTest
         verify(receiverProxy).registerReceiveChannelEndpoint(captor.capture());
         receiveChannelEndpoint = captor.getValue();
 
-        receiveChannelEndpoint.openChannel(mockDriverConductorProxy);
-
         driverConductor.onCreatePublicationImage(
             SESSION_ID, STREAM_ID_2, 1, 1, 0, TERM_BUFFER_LENGTH, MTU_LENGTH, 0,
             (short)0, mock(InetSocketAddress.class), sourceAddress, receiveChannelEndpoint);
@@ -763,8 +759,6 @@ class DriverConductorTest
         final ArgumentCaptor<ReceiveChannelEndpoint> captor1 = ArgumentCaptor.forClass(ReceiveChannelEndpoint.class);
         verify(receiverProxy).registerReceiveChannelEndpoint(captor1.capture());
         receiveChannelEndpoint = captor1.getValue();
-
-        receiveChannelEndpoint.openChannel(mockDriverConductorProxy);
 
         driverConductor.onCreatePublicationImage(
             SESSION_ID, STREAM_ID_1, 1, 1, 0, TERM_BUFFER_LENGTH, MTU_LENGTH, 0,
@@ -796,8 +790,6 @@ class DriverConductorTest
         final ArgumentCaptor<ReceiveChannelEndpoint> captor1 = ArgumentCaptor.forClass(ReceiveChannelEndpoint.class);
         verify(receiverProxy).registerReceiveChannelEndpoint(captor1.capture());
         receiveChannelEndpoint = captor1.getValue();
-
-        receiveChannelEndpoint.openChannel(mockDriverConductorProxy);
 
         driverConductor.onCreatePublicationImage(
             SESSION_ID, STREAM_ID_1, 1, 1, 0, TERM_BUFFER_LENGTH, MTU_LENGTH, 0,
@@ -845,8 +837,6 @@ class DriverConductorTest
         final ArgumentCaptor<ReceiveChannelEndpoint> captor1 = ArgumentCaptor.forClass(ReceiveChannelEndpoint.class);
         verify(receiverProxy).registerReceiveChannelEndpoint(captor1.capture());
         receiveChannelEndpoint = captor1.getValue();
-
-        receiveChannelEndpoint.openChannel(mockDriverConductorProxy);
 
         driverConductor.onCreatePublicationImage(
             SESSION_ID, STREAM_ID_1, 1, 1, 0, TERM_BUFFER_LENGTH, MTU_LENGTH, 0,

--- a/aeron-driver/src/test/java/io/aeron/driver/ReceiverTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/ReceiverTest.java
@@ -130,6 +130,8 @@ class ReceiverTest
     private Receiver receiver;
     private ReceiverProxy receiverProxy;
     private final ManyToOneConcurrentLinkedQueue<Runnable> toConductorQueue = new ManyToOneConcurrentLinkedQueue<>();
+    private final DriverConductorProxy driverConductorProxy =
+        new DriverConductorProxy(ThreadingMode.DEDICATED, toConductorQueue, mock(AtomicCounter.class));
     private final CongestionControl congestionControl = mock(CongestionControl.class);
     private final MediaDriver.Context ctx = new MediaDriver.Context()
         .systemCounters(mockSystemCounters)
@@ -159,9 +161,6 @@ class ReceiverTest
             anyLong(), anyLong(), anyLong(), anyLong(), anyLong(), anyLong(), anyBoolean()))
             .thenReturn(CongestionControl.packOutcome(INITIAL_WINDOW_LENGTH, false));
         when(congestionControl.initialWindowLength()).thenReturn(INITIAL_WINDOW_LENGTH);
-
-        final DriverConductorProxy driverConductorProxy =
-            new DriverConductorProxy(ThreadingMode.DEDICATED, toConductorQueue, mock(AtomicCounter.class));
 
         final MediaDriver.Context ctx = new MediaDriver.Context()
             .driverCommandQueue(toConductorQueue)
@@ -216,6 +215,7 @@ class ReceiverTest
     @InterruptAfter(10)
     void shouldCreateRcvTermAndSendSmOnSetup() throws IOException
     {
+        receiveChannelEndpoint.openChannel(driverConductorProxy);
         receiverProxy.registerReceiveChannelEndpoint(receiveChannelEndpoint);
         receiverProxy.addSubscription(receiveChannelEndpoint, STREAM_ID);
 
@@ -285,6 +285,7 @@ class ReceiverTest
     @Test
     void shouldInsertDataIntoLogAfterInitialExchange()
     {
+        receiveChannelEndpoint.openChannel(driverConductorProxy);
         receiverProxy.registerReceiveChannelEndpoint(receiveChannelEndpoint);
         receiverProxy.addSubscription(receiveChannelEndpoint, STREAM_ID);
 
@@ -355,6 +356,7 @@ class ReceiverTest
     @Test
     void shouldNotOverwriteDataFrameWithHeartbeat()
     {
+        receiveChannelEndpoint.openChannel(driverConductorProxy);
         receiverProxy.registerReceiveChannelEndpoint(receiveChannelEndpoint);
         receiverProxy.addSubscription(receiveChannelEndpoint, STREAM_ID);
 
@@ -428,6 +430,7 @@ class ReceiverTest
     @Test
     void shouldOverwriteHeartbeatWithDataFrame()
     {
+        receiveChannelEndpoint.openChannel(driverConductorProxy);
         receiverProxy.registerReceiveChannelEndpoint(receiveChannelEndpoint);
         receiver.doWork();
         receiverProxy.addSubscription(receiveChannelEndpoint, STREAM_ID);
@@ -504,6 +507,7 @@ class ReceiverTest
         final int alignedDataFrameLength =
             align(DataHeaderFlyweight.HEADER_LENGTH + FAKE_PAYLOAD.length, FrameDescriptor.FRAME_ALIGNMENT);
 
+        receiveChannelEndpoint.openChannel(driverConductorProxy);
         receiverProxy.registerReceiveChannelEndpoint(receiveChannelEndpoint);
         receiverProxy.addSubscription(receiveChannelEndpoint, STREAM_ID);
 
@@ -578,6 +582,7 @@ class ReceiverTest
     @Test
     void shouldRemoveImageFromDispatcherWithNoActivity()
     {
+        receiveChannelEndpoint.openChannel(driverConductorProxy);
         receiverProxy.registerReceiveChannelEndpoint(receiveChannelEndpoint);
         receiverProxy.addSubscription(receiveChannelEndpoint, STREAM_ID);
 
@@ -601,6 +606,7 @@ class ReceiverTest
     @Test
     void shouldNotRemoveImageFromDispatcherOnRemoveSubscription()
     {
+        receiveChannelEndpoint.openChannel(driverConductorProxy);
         receiverProxy.registerReceiveChannelEndpoint(receiveChannelEndpoint);
         receiverProxy.addSubscription(receiveChannelEndpoint, STREAM_ID);
 

--- a/aeron-system-tests/src/test/java/io/aeron/BusySocketTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/BusySocketTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2014-2025 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron;
+
+import io.aeron.driver.MediaDriver;
+import io.aeron.driver.ThreadingMode;
+import io.aeron.exceptions.RegistrationException;
+import io.aeron.status.ChannelEndpointStatus;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
+import io.aeron.test.Tests;
+import io.aeron.test.driver.TestMediaDriver;
+import org.agrona.CloseHelper;
+import org.agrona.concurrent.status.CountersReader;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@ExtendWith(InterruptingTestCallback.class)
+class BusySocketTest
+{
+    @RegisterExtension
+    final SystemTestWatcher testWatcher = new SystemTestWatcher();
+    private TestMediaDriver driver1, driver2;
+
+    @BeforeEach
+    void setup()
+    {
+        driver1 = TestMediaDriver.launch(new MediaDriver.Context()
+            .aeronDirectoryName(CommonContext.generateRandomDirName())
+            .threadingMode(ThreadingMode.SHARED), testWatcher);
+    }
+
+    @AfterEach
+    void tearDown()
+    {
+        CloseHelper.closeAll(driver1, driver2);
+    }
+
+    @InterruptAfter(20)
+    @ParameterizedTest
+    @MethodSource("arguments")
+    void subscriptionShouldConnectToASocketOnceItIsFreed(
+        final ThreadingMode threadingMode, final String pubChannel, final String subChannel)
+    {
+        driver2 = TestMediaDriver.launch(new MediaDriver.Context()
+            .aeronDirectoryName(CommonContext.generateRandomDirName())
+            .threadingMode(threadingMode), testWatcher);
+
+        final int streamId = 10001;
+
+        try (Aeron aeron1 = Aeron.connect(new Aeron.Context().aeronDirectoryName(driver1.aeronDirectoryName()));
+            Aeron aeron2 = Aeron.connect(new Aeron.Context().aeronDirectoryName(driver2.aeronDirectoryName())))
+        {
+            final ExclusivePublication publication = aeron2.addExclusivePublication(pubChannel, streamId);
+            final Subscription subscription = aeron1.addSubscription(subChannel, streamId);
+            Tests.awaitConnected(subscription);
+            Tests.awaitConnected(publication);
+
+            final int channelStatusId = subscription.channelStatusId();
+
+            for (int i = 0; i < 5; i++)
+            {
+                try
+                {
+                    if (0 == (i & 1))
+                    {
+                        aeron2.addSubscription(subChannel, streamId);
+                    }
+                    else
+                    {
+                        final long registrationId = aeron2.asyncAddSubscription(subChannel, streamId);
+                        while (null == aeron2.getSubscription(registrationId))
+                        {
+                            Tests.yield();
+                        }
+                    }
+                    fail("Subscription should not be created");
+                }
+                catch (final RegistrationException ex)
+                {
+                    assertAddressInUseException(subChannel, ex);
+                }
+            }
+
+            subscription.close();
+
+            Tests.await(
+                () -> CountersReader.RECORD_RECLAIMED == aeron1.countersReader().getCounterState(channelStatusId));
+
+            // Once the socket is closed it is possible to create new Subscription
+            final Subscription newSubscription = aeron2.addSubscription(subChannel, streamId);
+            Tests.awaitConnected(newSubscription);
+        }
+    }
+
+    @InterruptAfter(20)
+    @ParameterizedTest
+    @EnumSource(value = ThreadingMode.class, names = "INVOKER", mode = EnumSource.Mode.EXCLUDE)
+    void mdsSubscriptionShouldConnectToASocketOnceItIsFreed(final ThreadingMode threadingMode)
+    {
+        driver2 = TestMediaDriver.launch(new MediaDriver.Context()
+            .aeronDirectoryName(CommonContext.generateRandomDirName())
+            .threadingMode(threadingMode), testWatcher);
+
+        final int streamId = 10001;
+        final String destination1 = "aeron:udp?endpoint=localhost:8989";
+        final String destination2 = "aeron:udp?endpoint=localhost:9898";
+        final String mdsChannel = "aeron:udp?control-mode=manual";
+
+        try (Aeron aeron1 = Aeron.connect(new Aeron.Context().aeronDirectoryName(driver1.aeronDirectoryName()));
+            Aeron aeron2 = Aeron.connect(new Aeron.Context().aeronDirectoryName(driver2.aeronDirectoryName())))
+        {
+            final ExclusivePublication publication1 =
+                aeron1.addExclusivePublication(destination1 + "|term-length=64k", streamId);
+            final ExclusivePublication publication2 =
+                aeron2.addExclusivePublication(destination2 + "|term-length=64k", streamId);
+            final Subscription subscription = aeron1.addSubscription(destination1, streamId);
+            Tests.awaitConnected(subscription);
+            Tests.awaitConnected(publication1);
+
+            final int channelStatusId = subscription.channelStatusId();
+
+            final Subscription mdsSubscription = aeron2.addSubscription(mdsChannel, streamId);
+            mdsSubscription.addDestination(destination2);
+            Tests.await(() -> ChannelEndpointStatus.ACTIVE == mdsSubscription.channelStatus());
+
+            for (int i = 0; i < 3; i++)
+            {
+                try
+                {
+                    mdsSubscription.addDestination(destination1);
+                    fail("Destination should not be added");
+                }
+                catch (final RegistrationException ex)
+                {
+                    assertAddressInUseException(destination1, ex);
+                    assertEquals(ChannelEndpointStatus.ACTIVE, mdsSubscription.channelStatus());
+                }
+            }
+
+            subscription.close();
+
+            Tests.await(
+                () -> CountersReader.RECORD_RECLAIMED == aeron1.countersReader().getCounterState(channelStatusId));
+
+            // Once the socket is closed it is possible to add a Destination
+            mdsSubscription.addDestination(destination1);
+            Tests.await(() -> mdsSubscription.imageCount() == 2);
+            assertEquals(ChannelEndpointStatus.ACTIVE, mdsSubscription.channelStatus());
+            assertThat(
+                mdsSubscription.localSocketAddresses(),
+                containsInAnyOrder(containsString(":9898"), containsString(":8989")));
+        }
+    }
+
+    static List<Arguments> arguments()
+    {
+        final ArrayList<Arguments> arguments = new ArrayList<>();
+        final String[] pubChannels = {
+            "aeron:udp?term-length=64k|endpoint=localhost:8191",
+            "aeron:udp?term-length=64k|control=localhost:7779|control-mode=dynamic" };
+        final String[] subChannels = {
+            "aeron:udp?endpoint=localhost:8191",
+            "aeron:udp?endpoint=0.0.0.0:8191|control=localhost:7779" };
+        for (final ThreadingMode threadingMode : ThreadingMode.values())
+        {
+            if (ThreadingMode.INVOKER != threadingMode)
+            {
+                for (int i = 0; i < pubChannels.length; i++)
+                {
+                    arguments.add(Arguments.of(threadingMode, pubChannels[i], subChannels[i]));
+                }
+            }
+        }
+        return arguments;
+    }
+
+    private static void assertAddressInUseException(final String subChannel, final RegistrationException ex)
+    {
+        assertEquals(ErrorCode.GENERIC_ERROR, ex.errorCode());
+        assertThat(ex.getMessage(),
+            allOf(containsString(subChannel),
+            anyOf(containsString("Address already in use"),
+            containsString("Address in use"),
+            containsString("failed to bind to address"))));
+    }
+}


### PR DESCRIPTION
Previously Java media driver was opening sockets on the `receiver` thread which means that errors had to be dealt with asynchronously. In some case it lead to unrecoverable errors (see https://github.com/aeron-io/aeron/issues/1830).

This PR aligns Java media driver implementation with the C media driver, i.e. the driver now attempts to open socket on the conductor thread when adding network subscription/publication/destination. If socket cannot be opened an exception is thrown and intermediate resources are cleaned up.