### PR TITLE
[Java] driver: Prefer multicast address bind to avoid port conflicts

### DIFF
--- a/aeron-driver/src/main/java/io/aeron/driver/media/UdpChannelTransport.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/UdpChannelTransport.java
@@ -208,10 +208,13 @@ public abstract class UdpChannelTransport implements AutoCloseable
                 }
 
                 receiveDatagramChannel.setOption(StandardSocketOptions.SO_REUSEADDR, true);
-                try {
+                try
+                {
                     receiveDatagramChannel.bind(
-                            new InetSocketAddress(endPointAddress.getAddress(), endPointAddress.getPort()));
-                } catch (final BindException e) {
+                        new InetSocketAddress(endPointAddress.getAddress(), endPointAddress.getPort()));
+                }
+                catch (final BindException e)
+                {
                     // some platforms like Windows don't allow binding to multicast address, fallback to 0.0.0.0
                     receiveDatagramChannel.bind(new InetSocketAddress(endPointAddress.getPort()));
                 }


### PR DESCRIPTION
When opening a multicast receive socket, attempt to bind to the multicast group address and port first.

- Reduces likelihood of port conflicts when multicast-address binding is supported
- Preserves existing behaviour via fallback on platforms that don't support it