### PR TITLE
Update AeronArchive configuration to make retry attempts configurable.

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/client/AeronArchive.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/client/AeronArchive.java
@@ -62,7 +62,6 @@ import static io.aeron.CommonContext.SPARSE_PARAM_NAME;
 import static io.aeron.CommonContext.TERM_LENGTH_PARAM_NAME;
 import static io.aeron.CommonContext.checkDebugTimeout;
 import static io.aeron.CommonContext.getAeronDirectoryName;
-import static io.aeron.archive.client.ArchiveProxy.DEFAULT_RETRY_ATTEMPTS;
 import static io.aeron.driver.Configuration.IDLE_MAX_PARK_NS;
 import static io.aeron.driver.Configuration.IDLE_MAX_SPINS;
 import static io.aeron.driver.Configuration.IDLE_MAX_YIELDS;
@@ -2656,6 +2655,18 @@ public final class AeronArchive implements AutoCloseable
         public static final long MESSAGE_TIMEOUT_DEFAULT_NS = TimeUnit.SECONDS.toNanos(10);
 
         /**
+         * The number of retry attempts to be made when offering requests.
+         */
+        @Config
+        public static final String MESSAGE_RETRY_ATTEMPTS_PROP_NAME = "aeron.archive.message.retryAttempts";
+
+        /**
+         * Default number of retry attempts to be made when offering requests.
+         */
+        @Config
+        public static final int MESSAGE_RETRY_ATTEMPTS_DEFAULT = 3;
+
+        /**
          * Channel for sending control messages to an archive.
          */
         @Config(defaultType = DefaultType.STRING, defaultString = "")
@@ -2821,6 +2832,17 @@ public final class AeronArchive implements AutoCloseable
         }
 
         /**
+         * The number of retry attempts to be made when offering requests.
+         *
+         * @return the number of retry attempts to be made when offering requests.
+         * @see #MESSAGE_RETRY_ATTEMPTS_PROP_NAME
+         */
+        public static int messageRetryAttempts()
+        {
+            return Integer.getInteger(MESSAGE_RETRY_ATTEMPTS_PROP_NAME, MESSAGE_RETRY_ATTEMPTS_DEFAULT);
+        }
+
+        /**
          * Should term buffer files be sparse for control request and response streams.
          *
          * @return {@code true} if term buffer files should be sparse for control request and response streams.
@@ -2983,6 +3005,7 @@ public final class AeronArchive implements AutoCloseable
 
         private volatile boolean isConcluded;
         private long messageTimeoutNs = Configuration.messageTimeoutNs();
+        private int messageRetryAttempts = Configuration.messageRetryAttempts();
         private String recordingEventsChannel = AeronArchive.Configuration.recordingEventsChannel();
         private int recordingEventsStreamId = AeronArchive.Configuration.recordingEventsStreamId();
         private String controlRequestChannel = Configuration.controlChannel();
@@ -3110,6 +3133,31 @@ public final class AeronArchive implements AutoCloseable
         public long messageTimeoutNs()
         {
             return checkDebugTimeout(messageTimeoutNs, TimeUnit.NANOSECONDS);
+        }
+
+        /**
+         * Set the number of retry attempts to be made when offering requests.
+         *
+         * @param messageRetryAttempts the number of retry attempts to be made when offering requests.
+         * @return this for a fluent API.
+         * @see Configuration#MESSAGE_RETRY_ATTEMPTS_PROP_NAME
+         */
+        public Context messageRetryAttempts(final int messageRetryAttempts)
+        {
+            this.messageRetryAttempts = messageRetryAttempts;
+            return this;
+        }
+
+        /**
+         * The number of retry attempts to be made when offering requests.
+         *
+         * @return the number of retry attempts to be made when offering requests.
+         * @see Configuration#MESSAGE_RETRY_ATTEMPTS_PROP_NAME
+         */
+        @Config
+        public int messageRetryAttempts()
+        {
+            return messageRetryAttempts;
         }
 
         /**
@@ -3804,7 +3852,7 @@ public final class AeronArchive implements AutoCloseable
                         ctx.idleStrategy(),
                         ctx.aeron().context().nanoClock(),
                         ctx.messageTimeoutNs(),
-                        DEFAULT_RETRY_ATTEMPTS,
+                        ctx.messageRetryAttempts(),
                         ctx.credentialsSupplier());
 
                     state(State.AWAIT_PUBLICATION_CONNECTED);

--- a/aeron-archive/src/main/java/io/aeron/archive/client/ArchiveProxy.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/client/ArchiveProxy.java
@@ -22,6 +22,7 @@ import io.aeron.security.NullCredentialsSupplier;
 import org.agrona.ExpandableArrayBuffer;
 import org.agrona.concurrent.*;
 
+import static io.aeron.archive.client.AeronArchive.Configuration.MESSAGE_RETRY_ATTEMPTS_DEFAULT;
 import static io.aeron.archive.client.AeronArchive.Configuration.MESSAGE_TIMEOUT_DEFAULT_NS;
 
 /**
@@ -31,8 +32,10 @@ public final class ArchiveProxy
 {
     /**
      * Default number of retry attempts to be made when offering requests.
+     * @deprecated Use {@link AeronArchive.Configuration#MESSAGE_RETRY_ATTEMPTS_DEFAULT}.
      */
-    public static final int DEFAULT_RETRY_ATTEMPTS = 3;
+    @Deprecated(since = "1.48.6", forRemoval = true)
+    public static final int DEFAULT_RETRY_ATTEMPTS = MESSAGE_RETRY_ATTEMPTS_DEFAULT;
 
     private final long connectTimeoutNs;
     private final int retryAttempts;
@@ -80,7 +83,7 @@ public final class ArchiveProxy
      * <p>
      * This provides a default {@link IdleStrategy} of a {@link YieldingIdleStrategy} when offers are back pressured
      * with a defaults of {@link AeronArchive.Configuration#MESSAGE_TIMEOUT_DEFAULT_NS} and
-     * {@link #DEFAULT_RETRY_ATTEMPTS}.
+     * {@link AeronArchive.Configuration#MESSAGE_RETRY_ATTEMPTS_DEFAULT}.
      *
      * @param publication publication for sending control messages to an archive.
      * @throws ClassCastException if {@code publication} is not an instance of {@link ExclusivePublication}.
@@ -97,7 +100,7 @@ public final class ArchiveProxy
      * <p>
      * This provides a default {@link IdleStrategy} of a {@link YieldingIdleStrategy} when offers are back pressured
      * with a defaults of {@link AeronArchive.Configuration#MESSAGE_TIMEOUT_DEFAULT_NS} and
-     * {@link #DEFAULT_RETRY_ATTEMPTS}.
+     * {@link AeronArchive.Configuration#MESSAGE_RETRY_ATTEMPTS_DEFAULT}.
      *
      * @param publication publication for sending control messages to an archive.
      * @throws ClassCastException if {@code publication} is not an instance of {@link ExclusivePublication}.
@@ -109,7 +112,7 @@ public final class ArchiveProxy
             YieldingIdleStrategy.INSTANCE,
             SystemNanoClock.INSTANCE,
             MESSAGE_TIMEOUT_DEFAULT_NS,
-            DEFAULT_RETRY_ATTEMPTS,
+            MESSAGE_RETRY_ATTEMPTS_DEFAULT,
             new NullCredentialsSupplier());
     }
 


### PR DESCRIPTION
This pull request introduces a new configuration property for controlling the number of retry attempts when offering requests to the Aeron Archive, moving this setting from `ArchiveProxy` to the main configuration. It also updates the usage and documentation to reflect this change, deprecates the old constant in `ArchiveProxy`, and ensures that the value is configurable via the context and system properties.

