### PR TITLE
Ensures proper handling when ingress publication is closed but not null

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
@@ -2437,7 +2437,7 @@ public final class AeronCluster implements AutoCloseable
             CloseHelper.closeAll(memberByIdMap.values());
             memberByIdMap = parseIngressEndpoints(ctx, egressPoller.detail());
 
-            if (null == ingressPublication)
+            if (null == ingressPublication || ingressPublication.isClosed())
             {
                 final MemberIngress member = memberByIdMap.get(leaderMemberId);
                 final ChannelUri channelUri = ChannelUri.parse(ctx.ingressChannel());


### PR DESCRIPTION
When member changes or ingressChannel only config follower endpoints, the memberByIdMap only contains follower endpoints. During the AeronCluster connection process, the follower will return a redirection request containing information about all the nodes in the cluster. All Publications will be closed, including the ingressPublication.

In the current implementation, if the ingressChannel does not contain the Leader information, it cannot correctly handle the redirect request, even though the egressPoller already includes information about all the nodes in the cluster.

If, in the UpdateMember function, we check whether ingressPublication is closed or set ingressPublication to null, this situation can be handled correctly.
