### PR TITLE
[Archive] Allow for the archive to update the channel for a specific recording.

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveConductor.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveConductor.java
@@ -634,6 +634,40 @@ abstract class ArchiveConductor
         }
     }
 
+    void updateChannel(
+        final long correlationId,
+        final long recordingId,
+        final String channel,
+        final ControlSession controlSession)
+    {
+        if (controlSession.hasActiveListing())
+        {
+            final String msg = "active listing already in progress";
+            controlSession.sendErrorResponse(correlationId, ACTIVE_LISTING, msg);
+        }
+        else if (!catalog.hasRecording(recordingId))
+        {
+            controlSession.sendRecordingUnknown(correlationId, recordingId);
+        }
+        else
+        {
+            final ChannelUri channelUri = ChannelUri.parse(channel);
+            final String strippedChannel = strippedChannelBuilder(channelUri).build();
+
+            final UpdateChannelSession updateChannelSession = new UpdateChannelSession(
+                correlationId,
+                recordingId,
+                channel,
+                strippedChannel,
+                catalog,
+                controlSession,
+                descriptorBuffer);
+
+            addSession(updateChannelSession);
+            controlSession.activeListing(updateChannelSession);
+        }
+    }
+
     void findLastMatchingRecording(
         final long correlationId,
         final long minRecordingId,

--- a/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
@@ -744,6 +744,13 @@ final class Catalog implements AutoCloseable
         forceWrites(catalogChannel);
     }
 
+    void updateChannel(final long recordingId, final String channel)
+    {
+        final int recordingOffset = recordingDescriptorOffset(recordingId);
+
+
+    }
+
     long startPosition(final long recordingId)
     {
         final int offset = recordingDescriptorOffset(recordingId) +

--- a/aeron-archive/src/main/java/io/aeron/archive/ControlRequestDecoders.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ControlRequestDecoders.java
@@ -64,4 +64,5 @@ class ControlRequestDecoders
     final TaggedReplicateRequestDecoder taggedReplicateRequest = new TaggedReplicateRequestDecoder();
     final ArchiveIdRequestDecoder archiveIdRequestDecoder = new ArchiveIdRequestDecoder();
     final ReplayTokenRequestDecoder replayTokenRequestDecoder = new ReplayTokenRequestDecoder();
+    final UpdateChannelRequestDecoder updateChannelRequestDecoder = new UpdateChannelRequestDecoder();
 }

--- a/aeron-archive/src/main/java/io/aeron/archive/ControlSessionAdapter.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ControlSessionAdapter.java
@@ -1047,6 +1047,30 @@ class ControlSessionAdapter implements FragmentHandler
                     final long replayToken = conductor.generateReplayToken(controlSession, recordingId);
                     controlSession.sendOkResponse(correlationId, replayToken);
                 }
+
+                break;
+            }
+
+            case UpdateChannelRequestDecoder.TEMPLATE_ID:
+            {
+                final UpdateChannelRequestDecoder decoder = decoders.updateChannelRequestDecoder;
+                decoder.wrap(
+                    buffer,
+                    offset + MessageHeaderDecoder.ENCODED_LENGTH,
+                    headerDecoder.blockLength(),
+                    headerDecoder.version());
+
+                final long controlSessionId = decoder.controlSessionId();
+                final long correlationId = decoder.correlationId();
+                final long recordingId = decoder.recordingId();
+                final String channel = decoder.channel();
+                final ControlSession controlSession = getControlSession(correlationId, controlSessionId, templateId);
+                if (null != controlSession)
+                {
+                    conductor.updateChannel(correlationId, recordingId, channel, controlSession);
+                }
+
+                break;
             }
         }
     }

--- a/aeron-archive/src/main/java/io/aeron/archive/UpdateChannelSession.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/UpdateChannelSession.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2014-2025 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.archive;
+
+import io.aeron.archive.codecs.RecordingDescriptorDecoder;
+import io.aeron.archive.codecs.RecordingDescriptorHeaderDecoder;
+import org.agrona.concurrent.UnsafeBuffer;
+
+class UpdateChannelSession implements Session
+{
+    private final long correlationId;
+    private final long recordingId;
+    private final String originalChannel;
+    private final String strippedChannel;
+    private final Catalog catalog;
+    private final ControlSession controlSession;
+    private final UnsafeBuffer descriptorBuffer;
+    private final RecordingDescriptorDecoder recordingDescriptorDecoder = new RecordingDescriptorDecoder();
+
+    private boolean isDone;
+
+    UpdateChannelSession(
+        final long correlationId,
+        final long recordingId,
+        final String originalChannel,
+        final String strippedChannel,
+        final Catalog catalog,
+        final ControlSession controlSession,
+        final UnsafeBuffer descriptorBuffer)
+    {
+        this.correlationId = correlationId;
+        this.recordingId = recordingId;
+        this.originalChannel = originalChannel;
+        this.strippedChannel = strippedChannel;
+        this.catalog = catalog;
+        this.controlSession = controlSession;
+        this.descriptorBuffer = descriptorBuffer;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void abort(final String reason)
+    {
+        isDone = true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean isDone()
+    {
+        return isDone;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int doWork()
+    {
+        if (isDone)
+        {
+            return 0;
+        }
+
+        if (catalog.wrapDescriptor(recordingId, descriptorBuffer))
+        {
+            recordingDescriptorDecoder.wrap(
+                descriptorBuffer,
+                RecordingDescriptorHeaderDecoder.BLOCK_LENGTH,
+                RecordingDescriptorDecoder.BLOCK_LENGTH,
+                RecordingDescriptorDecoder.SCHEMA_VERSION);
+
+            final long startPosition = recordingDescriptorDecoder.startPosition();
+            final long stopPosition = recordingDescriptorDecoder.stopPosition();
+            final long startTimestamp = recordingDescriptorDecoder.startTimestamp();
+            final long stopTimestamp = recordingDescriptorDecoder.stopTimestamp();
+            final int imageInitialTermId = recordingDescriptorDecoder.initialTermId();
+            final int segmentFileLength = recordingDescriptorDecoder.segmentFileLength();
+            final int termBufferLength = recordingDescriptorDecoder.termBufferLength();
+            final int mtuLength = recordingDescriptorDecoder.mtuLength();
+            final int sessionId = recordingDescriptorDecoder.sessionId();
+            final int streamId = recordingDescriptorDecoder.streamId();
+            final String ignore1 = recordingDescriptorDecoder.strippedChannel();
+            final String ignore2 = recordingDescriptorDecoder.originalChannel();
+            final String sourceIdentity = recordingDescriptorDecoder.sourceIdentity();
+
+            catalog.replaceRecording(
+                recordingId,
+                startPosition,
+                stopPosition,
+                startTimestamp,
+                stopTimestamp,
+                imageInitialTermId,
+                segmentFileLength,
+                termBufferLength,
+                mtuLength,
+                sessionId,
+                streamId,
+                strippedChannel,
+                originalChannel,
+                sourceIdentity);
+
+            controlSession.sendOkResponse(correlationId);
+            isDone = true;
+        }
+        else
+        {
+            controlSession.sendRecordingUnknown(correlationId, recordingId);
+            isDone = true;
+        }
+
+        return 1;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public long sessionId()
+    {
+        return correlationId;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void close()
+    {
+        controlSession.activeListing(null);
+    }
+}

--- a/aeron-archive/src/main/java/io/aeron/archive/client/AeronArchive.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/client/AeronArchive.java
@@ -2324,6 +2324,37 @@ public final class AeronArchive implements AutoCloseable
         }
     }
 
+    /**
+     * Update the channel for a recording.
+     * <p>
+     * Note: this is an experimental feature and may be removed or changed in a later release.
+     *
+     * @param recordingId       the recording id to update.
+     * @param channel           the new channel to include in the catalogue.
+     */
+    public void updateChannel(final long recordingId, final String channel)
+    {
+        lock.lock();
+        try
+        {
+            ensureConnected();
+            ensureNotReentrant();
+
+            lastCorrelationId = aeron.nextCorrelationId();
+
+            if (!archiveProxy.updateChannel(recordingId, channel, lastCorrelationId, controlSessionId))
+            {
+                throw new ArchiveException("failed to send migrate segments request");
+            }
+
+            pollForResponse(lastCorrelationId);
+        }
+        finally
+        {
+            lock.unlock();
+        }
+    }
+
     private void checkDeadline(final long deadlineNs, final String errorMessage, final long correlationId)
     {
         if (deadlineNs - nanoClock.nanoTime() < 0)

--- a/aeron-archive/src/main/java/io/aeron/archive/client/ArchiveProxy.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/client/ArchiveProxy.java
@@ -58,6 +58,7 @@ import io.aeron.archive.codecs.StopRecordingSubscriptionRequestEncoder;
 import io.aeron.archive.codecs.StopReplayRequestEncoder;
 import io.aeron.archive.codecs.StopReplicationRequestEncoder;
 import io.aeron.archive.codecs.TruncateRecordingRequestEncoder;
+import io.aeron.archive.codecs.UpdateChannelRequestEncoder;
 import io.aeron.security.CredentialsSupplier;
 import io.aeron.security.NullCredentialsSupplier;
 import org.agrona.ExpandableArrayBuffer;
@@ -131,6 +132,7 @@ public final class ArchiveProxy
     private final MigrateSegmentsRequestEncoder migrateSegmentsRequest = new MigrateSegmentsRequestEncoder();
     private final ArchiveIdRequestEncoder archiveIdRequestEncoder = new ArchiveIdRequestEncoder();
     private final ReplayTokenRequestEncoder replayTokenRequestEncoder = new ReplayTokenRequestEncoder();
+    private final UpdateChannelRequestEncoder updateChannelRequestEncoder = new UpdateChannelRequestEncoder();
 
     /**
      * Create a proxy with a {@link ExclusivePublication} for sending control message requests.
@@ -1433,6 +1435,30 @@ public final class ArchiveProxy
         return offer(replayTokenRequestEncoder.encodedLength());
     }
 
+    /**
+     * Update the channel for a recording.
+     *
+     * @param recordingId       the recording id to update.
+     * @param channel           the new channel to include in the catalogue.
+     * @param correlationId     for the request.
+     * @param controlSessionId  for the request.
+     * @return true if successfully offered.
+     */
+    public boolean updateChannel(
+        final long recordingId,
+        final String channel,
+        final long correlationId,
+        final long controlSessionId)
+    {
+        updateChannelRequestEncoder
+            .wrapAndApplyHeader(buffer, 0, messageHeader)
+            .controlSessionId(controlSessionId)
+            .correlationId(correlationId)
+            .recordingId(recordingId)
+            .channel(channel);
+
+        return offer(updateChannelRequestEncoder.encodedLength());
+    }
 
     private boolean offer(final int length)
     {

--- a/aeron-archive/src/main/resources/archive/aeron-archive-codecs.xml
+++ b/aeron-archive/src/main/resources/archive/aeron-archive-codecs.xml
@@ -2,7 +2,7 @@
 <sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
                    package="io.aeron.archive.codecs"
                    id="101"
-                   version="12"
+                   version="13"
                    semanticVersion="5.2"
                    description="Message Codecs for communicating with an Aeron Archive."
                    byteOrder="littleEndian">
@@ -637,6 +637,16 @@
                  sinceVersion="11"
                  description="Ping for heartbeat.">
         <field name="controlSessionId"     id="1" type="int64"/>
+    </sbe:message>
+
+    <sbe:message name="UpdateChannelRequest"
+                 id="107"
+                 sinceVersion="13"
+                 description="Request to update the channel for a recording">
+        <field name="controlSessionId"     id="1" type="int64"/>
+        <field name="correlationId"        id="2" type="int64"/>
+        <field name="recordingId"          id="3" type="int64"/>
+        <data  name="channel"              id="4" type="varAsciiEncoding"/>
     </sbe:message>
 
 </sbe:messageSchema>

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveListRecordingsTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveListRecordingsTest.java
@@ -15,10 +15,16 @@
  */
 package io.aeron.archive;
 
+import io.aeron.ChannelUri;
+import io.aeron.CommonContext;
 import io.aeron.archive.client.AeronArchive;
+import io.aeron.archive.client.ArchiveException;
 import io.aeron.driver.MediaDriver;
+import io.aeron.samples.archive.RecordingDescriptor;
 import io.aeron.samples.archive.RecordingDescriptorCollector;
 import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SlowTest;
 import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.TestContexts;
 import io.aeron.test.driver.TestMediaDriver;
@@ -28,13 +34,21 @@ import org.agrona.concurrent.YieldingIdleStrategy;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 import static io.aeron.archive.ArchiveSystemTests.recordData;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class ArchiveListRecordingsTest
 {
     @RegisterExtension
@@ -99,6 +113,107 @@ public class ArchiveListRecordingsTest
 
             assertEquals(1, aeronArchive.listRecordingsForUri(
                 0, Integer.MAX_VALUE, "alias=snapshot-id:1", result1.streamId(), collector.reset()));
+        }
+    }
+
+    @Test
+    @InterruptAfter(5)
+    void shouldUpdateChannelForARecording()
+    {
+        try (AeronArchive aeronArchive = AeronArchive.connect(TestContexts.ipcAeronArchive()))
+        {
+            final ArchiveSystemTests.RecordingResult result1 = recordData(
+                aeronArchive, 1, "snapshot-id-in-progress:10;complete=true;");
+
+            final RecordingDescriptorCollector collector = new RecordingDescriptorCollector(10);
+
+            assertEquals(1, aeronArchive.listRecordingsForUri(
+                0, Integer.MAX_VALUE, "snapshot-id-in-progress:", result1.streamId(), collector.reset()));
+
+            assertEquals(1, collector.descriptors().size());
+            RecordingDescriptor recordingDescriptor = collector.descriptors().get(0);
+
+            final ChannelUri channel = ChannelUri.parse(recordingDescriptor.originalChannel());
+            channel.put(CommonContext.ALIAS_PARAM_NAME, "snapshot-id:10;");
+
+            aeronArchive.updateChannel(recordingDescriptor.recordingId(), channel.toString());
+
+            assertEquals(1, aeronArchive.listRecordingsForUri(
+                0, Integer.MAX_VALUE, "snapshot-id:", result1.streamId(), collector.reset()));
+
+            assertEquals(1, collector.descriptors().size());
+            recordingDescriptor = collector.descriptors().get(0);
+
+            assertThat(recordingDescriptor.originalChannel(), containsString("snapshot-id:10"));
+        }
+    }
+
+    @Test
+    @InterruptAfter(5)
+    void shouldFailToUpdateChannelForARecordingThatDoesntExist()
+    {
+        try (AeronArchive aeronArchive = AeronArchive.connect(TestContexts.ipcAeronArchive()))
+        {
+            final ArchiveSystemTests.RecordingResult result1 = recordData(
+                aeronArchive, 1, "snapshot-id-in-progress:10;complete=true;");
+
+            final RecordingDescriptorCollector collector = new RecordingDescriptorCollector(10);
+
+            assertEquals(1, aeronArchive.listRecordingsForUri(
+                0, Integer.MAX_VALUE, "snapshot-id-in-progress:", result1.streamId(), collector.reset()));
+
+            assertEquals(1, collector.descriptors().size());
+            final RecordingDescriptor recordingDescriptor = collector.descriptors().get(0);
+
+            final ChannelUri channel = ChannelUri.parse(recordingDescriptor.originalChannel());
+            channel.put(CommonContext.ALIAS_PARAM_NAME, "snapshot-id:10;");
+
+            final long invalidRecordingId = 98273498273498723L;
+
+            final ArchiveException archiveException = assertThrows(
+                ArchiveException.class,
+                () -> aeronArchive.updateChannel(invalidRecordingId, channel.toString()));
+            assertThat(archiveException.getMessage(), containsString("RECORDING_UNKNOWN"));
+        }
+    }
+
+    @Test
+    @InterruptAfter(15)
+    @SlowTest
+    void shouldFailToUpdateChannelWhileARecordingListingIsRunning()
+    {
+        try (AeronArchive aeronArchive = AeronArchive.connect(TestContexts.ipcAeronArchive()))
+        {
+            final ArchiveSystemTests.RecordingResult result1 = recordData(
+                aeronArchive, 1, "alias=original");
+
+            final RecordingDescriptorCollector collector = new RecordingDescriptorCollector(10);
+
+            assertEquals(1, aeronArchive.listRecordingsForUri(
+                0, Integer.MAX_VALUE, "alias=original", result1.streamId(), collector.reset()));
+
+            assertEquals(1, collector.descriptors().size());
+            final RecordingDescriptor recordingDescriptor = collector.descriptors().get(0);
+
+            final List<ArchiveSystemTests.RecordingResult> results = new ArrayList<>();
+            for (int i = 0; i < 150; i++)
+            {
+                results.add(recordData(aeronArchive, 1, "snapshot-id:" + (i + 1)));
+            }
+
+            assertTrue(aeronArchive.archiveProxy().listRecordings(
+                0,
+                Integer.MAX_VALUE,
+                aeronArchive.context().aeron().nextCorrelationId(),
+                aeronArchive.controlSessionId()));
+
+            final ChannelUri channel = ChannelUri.parse(recordingDescriptor.originalChannel());
+            channel.put(CommonContext.ALIAS_PARAM_NAME, "alias=update");
+
+            final ArchiveException archiveException = assertThrows(
+                ArchiveException.class,
+                () -> aeronArchive.updateChannel(recordingDescriptor.recordingId(), channel.toString()));
+            assertThat(archiveException.getMessage(), containsString("active listing already in progress"));
         }
     }
 }


### PR DESCRIPTION
- Uses `Catalog.replaceRecording` to rewrite the `originalChannel` and `strippedChannel` for a recording.
- Will look up the recording for the catalog to preserve the existing properties so it is treated like a listing request and won't be run concurrently with existing listing operations.