### PR TITLE
[Java] AeronCluster client requires explicit Aeron client when MediaDriver running in INVOKER threading mode

### DIFF
--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
@@ -753,14 +753,11 @@ public final class TestCluster implements AutoCloseable
         return client;
     }
 
-    public TestMediaDriver startClientMediaDriver()
+    public MediaDriver.Context clientMediaDriverCtx()
     {
-        if (null == clientMediaDriver)
-        {
-            final String aeronDirName = CommonContext.generateRandomDirName();
-            dataCollector.add(Paths.get(aeronDirName));
+        final String aeronDirName = CommonContext.generateRandomDirName();
 
-            final MediaDriver.Context ctx = new MediaDriver.Context()
+        final MediaDriver.Context ctx = new MediaDriver.Context()
                 .threadingMode(ThreadingMode.SHARED)
                 .dirDeleteOnStart(true)
                 .dirDeleteOnShutdown(true)
@@ -771,6 +768,16 @@ public final class TestCluster implements AutoCloseable
                 .sendChannelEndpointSupplier(clientSendChannelEndpointSupplier)
                 .receiveChannelEndpointSupplier(clientReceiveChannelEndpointSupplier)
                 .imageLivenessTimeoutNs(clientImageLivenessTimeoutNs);
+
+        return ctx;
+    }
+
+    public TestMediaDriver startClientMediaDriver()
+    {
+        if (null == clientMediaDriver)
+        {
+            final MediaDriver.Context ctx = clientMediaDriverCtx();
+            dataCollector.add(Paths.get(ctx.aeronDirectoryName()));
 
             clientMediaDriver = TestMediaDriver.launch(ctx, clientDriverOutputConsumer(dataCollector));
         }


### PR DESCRIPTION
Hi,

I upgraded Aeron from 1.48.2-> 1.49.0 and I noticed that the behavior has changed around cluster client connectivity. It seems that it is not possible to run media driver in the INVOKER threading mode and use implicit `io.aeron.Aeron` client.

Please see `shouldAsyncConnectWhenMediaDriverUsesInvokerModeAndUsesImplicitAeronClient` test case. Similar test would have passed in older versions (e.g. 1.48.2).

The solution is to provide external `io.aeron.Aeron` client explicitly that uses driver agent invoker.

I had a look through recent release notes and I didn't see anything that would clearly indicate that this behavior has changed and I don't see test cases covering it. Was it intentional?

