### PR TITLE
[Java] Remove high explicit idleSleepDurationNs from tests.

### DIFF
--- a/aeron-system-tests/src/test/java/io/aeron/PubAndSubTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/PubAndSubTest.java
@@ -92,8 +92,7 @@ class PubAndSubTest
         .timerIntervalNs(MILLISECONDS.toNanos(100));
 
     private final Aeron.Context clientContext = new Aeron.Context()
-        .resourceLingerDurationNs(MILLISECONDS.toNanos(200))
-        .idleSleepDurationNs(MILLISECONDS.toNanos(100));
+        .resourceLingerDurationNs(MILLISECONDS.toNanos(200));
 
     private Aeron publishingClient;
     private Aeron subscribingClient;

--- a/aeron-system-tests/src/test/java/io/aeron/PublicationRevokeTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/PublicationRevokeTest.java
@@ -74,8 +74,7 @@ class PublicationRevokeTest
         .threadingMode(ThreadingMode.SHARED);
 
     private final Aeron.Context clientContext = new Aeron.Context()
-        .resourceLingerDurationNs(MILLISECONDS.toNanos(200))
-        .idleSleepDurationNs(MILLISECONDS.toNanos(100));
+        .resourceLingerDurationNs(MILLISECONDS.toNanos(200));
 
     private Aeron client;
     private TestMediaDriver driver;


### PR DESCRIPTION
It doesn't seem necessary, and removing it makes the tests much faster (timings from my laptop):

PubAndSubTest 29s to 17s
PublicationRevokeTest 5s to 3s