### PR TITLE
Replaced the AtomicCounter.getWeak usages by getPlain.

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/RecordingSession.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/RecordingSession.java
@@ -145,7 +145,7 @@ class RecordingSession implements Session
 
             if (null != recordingEventsProxy)
             {
-                recordingEventsProxy.stopped(recordingId, image.joinPosition(), position.getWeak());
+                recordingEventsProxy.stopped(recordingId, image.joinPosition(), position.getPlain());
             }
         }
 

--- a/aeron-archive/src/test/java/io/aeron/archive/RecordingSessionTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/RecordingSessionTest.java
@@ -86,7 +86,7 @@ class RecordingSessionTest
     @BeforeEach
     void before() throws Exception
     {
-        when(mockPosition.getWeak()).then((invocation) -> positionLong);
+        when(mockPosition.getPlain()).then((invocation) -> positionLong);
         when(mockPosition.get()).then((invocation) -> positionLong);
         doAnswer(
             (invocation) ->

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -381,7 +381,7 @@ final class ConsensusModuleAgent
             ctx.countedErrorHandler());
 
         final long lastLeadershipTermId = recoveryPlan.lastLeadershipTermId;
-        final long commitPosition = this.commitPosition.getWeak();
+        final long commitPosition = this.commitPosition.getPlain();
         final long appendedPosition = recoveryPlan.appendedLogPosition;
         logNewElection(memberId, lastLeadershipTermId, commitPosition, appendedPosition, "node started");
 
@@ -1171,7 +1171,7 @@ final class ConsensusModuleAgent
                 " memberId=" + memberId +
                 " this.leadershipTermId=" + this.leadershipTermId +
                 " this.leaderMemberId=" + leaderMember.id() +
-                " this.commitPosition=" + this.commitPosition.getWeak() +
+                " this.commitPosition=" + this.commitPosition.getPlain() +
                 " this.appendPosition=" +
                 (null != appendPosition ? appendPosition.getWeak() : NULL_POSITION) +
                 " newLeadershipTermId=" + leadershipTermId +
@@ -1926,7 +1926,7 @@ final class ConsensusModuleAgent
             logAdapter.poll(stopPosition);
             final long position = logAdapter.position();
 
-            if (commitPosition.getWeak() < position)
+            if (commitPosition.getPlain() < position)
             {
                 commitPosition.setRelease(position);
                 workCount++;
@@ -2080,7 +2080,7 @@ final class ConsensusModuleAgent
             ConsensusModule.State.ACTIVE == state)
         {
             throw new ClusterEvent(
-                "no catchup progress commitPosition=" + commitPosition.getWeak() + " limitPosition=" + limitPosition +
+                "no catchup progress commitPosition=" + commitPosition.getPlain() + " limitPosition=" + limitPosition +
                 " lastAppendPosition=" + lastAppendPosition +
                 " appendPosition=" + (null != appendPosition ? appendPosition.get() : NULL_POSITION) +
                 " logPosition=" + election.logPosition());
@@ -3310,7 +3310,7 @@ final class ConsensusModuleAgent
         thisMember.logPosition(position).timeOfLastAppendPositionNs(nowNs);
         final long commitPosition = Math.min(quorumPosition(), position);
 
-        if (commitPosition > this.commitPosition.getWeak() ||
+        if (commitPosition > this.commitPosition.getPlain() ||
             nowNs >= (timeOfLastLogUpdateNs + leaderHeartbeatIntervalNs))
         {
             publishCommitPosition(commitPosition);
@@ -3474,7 +3474,7 @@ final class ConsensusModuleAgent
             termEntry.termBaseLogPosition : recoveryPlan.lastTermBaseLogPosition;
         final long appendedPosition = null != appendPosition ?
             appendPosition.get() : Math.max(recoveryPlan.appendedLogPosition, logRecordingStopPosition);
-        final long commitPosition = this.commitPosition.getWeak();
+        final long commitPosition = this.commitPosition.getPlain();
 
         logNewElection(memberId, leadershipTermId, commitPosition, appendedPosition, reason);
         ctx.countedErrorHandler().onError(new ClusterEvent(reason));

--- a/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
@@ -252,7 +252,7 @@ class Election
     void handleError(final long nowNs, final Throwable ex)
     {
         ctx.countedErrorHandler().onError(ex);
-        logPosition = ctx.commitPositionCounter().getWeak();
+        logPosition = ctx.commitPositionCounter().getPlain();
         state(INIT, nowNs, ex.getMessage());
 
         if (ex instanceof AgentTerminationException || ex instanceof InterruptedException)
@@ -437,7 +437,7 @@ class Election
                         logLeadershipTermId,
                         this.leadershipTermId,
                         candidateTermId,
-                        ctx.commitPositionCounter().getWeak(),
+                        ctx.commitPositionCounter().getPlain(),
                         this.logPosition,
                         appendPosition,
                         logPosition,
@@ -1026,7 +1026,7 @@ class Election
             workCount++;
         }
 
-        final long position = ctx.commitPositionCounter().getWeak();
+        final long position = ctx.commitPositionCounter().getPlain();
         if (position >= catchupJoinPosition &&
             position >= catchupCommitPosition &&
             null == consensusModuleAgent.catchupLogDestination() &&

--- a/aeron-cluster/src/main/java/io/aeron/cluster/PendingServiceMessageTracker.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/PendingServiceMessageTracker.java
@@ -256,7 +256,7 @@ final class PendingServiceMessageTracker
         final int timestampOffset = headerOffset + SessionMessageHeaderDecoder.timestampEncodingOffset();
         final long appendPosition = buffer.getLong(timestampOffset, SessionMessageHeaderDecoder.BYTE_ORDER);
 
-        if (commitPosition.getWeak() >= appendPosition)
+        if (commitPosition.getPlain() >= appendPosition)
         {
             logServiceSessionId = buffer.getLong(clusterSessionIdOffset, SessionMessageHeaderDecoder.BYTE_ORDER);
             --uncommittedMessages;

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverNameResolver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverNameResolver.java
@@ -310,7 +310,7 @@ final class DriverNameResolver implements AutoCloseable, UdpNameResolutionTransp
         }
 
         final int neighborCount = neighborList.size();
-        if (neighborsCounter.getWeak() != neighborCount)
+        if (neighborsCounter.getPlain() != neighborCount)
         {
             neighborsCounter.setRelease(neighborCount);
         }

--- a/aeron-driver/src/test/java/io/aeron/driver/PublicationImageTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/PublicationImageTest.java
@@ -236,7 +236,7 @@ class PublicationImageTest
         final InetSocketAddress srcAddress = mock(InetSocketAddress.class);
         final int packetLength = HEADER_LENGTH;
         final AtomicCounter heartBeatsCounter = ctx.systemCounters().get(SystemCounterDescriptor.HEARTBEATS_RECEIVED);
-        final long oldHeartBeatCount = heartBeatsCounter.getWeak();
+        final long oldHeartBeatCount = heartBeatsCounter.getPlain();
 
         final int bytes = image.insertPacket(termId, termOffset, buffer, packetLength, TRANSPORT_INDEX, srcAddress);
 
@@ -244,7 +244,7 @@ class PublicationImageTest
         final int positionBitsToShift = positionBitsToShift(TERM_LENGTH);
         final long packetPosition = computePosition(termId, termOffset, positionBitsToShift, INITIAL_TERM_ID);
         assertEquals(packetPosition, hwmPosition.get());
-        assertEquals(oldHeartBeatCount + 1, heartBeatsCounter.getWeak());
+        assertEquals(oldHeartBeatCount + 1, heartBeatsCounter.getPlain());
         final UnsafeBuffer activeTermBuffer =
             rawLog.termBuffers()[indexByPosition(packetPosition, positionBitsToShift)];
         for (int i = 0; i < packetLength; i++)


### PR DESCRIPTION
The getWeak are the old methods; getPlain are the new. The getWeak is even using the getPlain:

    public long getWeak()
    {
        return getPlain();
    }

So the replacement is legal.