### PR TITLE
Replaced Counter.getAndAddOrdered by getAndAddRelease.

### DIFF
--- a/aeron-driver/src/main/java/io/aeron/driver/Receiver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Receiver.java
@@ -320,7 +320,7 @@ public final class Receiver implements Agent
                 pending.transportIndex() == transportIndex)
             {
                 pending.controlAddress(newAddress);
-                resolutionChanges.getAndAddOrdered(1);
+                resolutionChanges.getAndAddRelease(1);
             }
         }
 

--- a/aeron-driver/src/main/java/io/aeron/driver/Sender.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Sender.java
@@ -210,7 +210,7 @@ public final class Sender extends SenderRhsPadding implements Agent
         final SendChannelEndpoint channelEndpoint, final String endpoint, final InetSocketAddress newAddress)
     {
         channelEndpoint.resolutionChange(endpoint, newAddress);
-        resolutionChanges.getAndAddOrdered(1);
+        resolutionChanges.getAndAddRelease(1);
     }
 
     private int doSend(final long nowNs)
@@ -235,7 +235,7 @@ public final class Sender extends SenderRhsPadding implements Agent
             bytesSent += publications[i].send(nowNs);
         }
 
-        totalBytesSent.getAndAddOrdered(bytesSent);
+        totalBytesSent.getAndAddRelease(bytesSent);
 
         return bytesSent;
     }

--- a/aeron-driver/src/main/java/io/aeron/driver/buffer/MappedRawLog.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/buffer/MappedRawLog.java
@@ -121,7 +121,7 @@ class MappedRawLog implements RawLog
                     preTouchPages(termBuffers, termLength, filePageSize);
                 }
 
-                mappedBytesCounter.getAndAddOrdered(logLength);
+                mappedBytesCounter.getAndAddRelease(logLength);
             }
         }
         catch (final IOException ex)
@@ -147,7 +147,7 @@ class MappedRawLog implements RawLog
                 BufferUtil.free(mappedBuffers[i]);
             }
 
-            mappedBytesCounter.getAndAddOrdered(-logLength);
+            mappedBytesCounter.getAndAddRelease(-logLength);
 
             logMetaDataBuffer.wrap(0, 0);
             for (int i = 0; i < termBuffers.length; i++)


### PR DESCRIPTION
The first methods are the deprecated ones and are replaced by the getAndAddRelease.