### PR TITLE
fix: double free in aeron_archive_context_t

### DIFF
--- a/aeron-archive/src/main/c/client/aeron_archive_context.c
+++ b/aeron-archive/src/main/c/client/aeron_archive_context.c
@@ -259,6 +259,8 @@ int aeron_archive_context_duplicate(aeron_archive_context_t **dest_p, aeron_arch
         return -1;
     }
 
+    _ctx->owns_idle_strategy = false;
+
     *dest_p = _ctx;
 
     return 0;
@@ -443,6 +445,7 @@ error:
     if (ctx->owns_aeron_client && NULL != ctx->aeron)
     {
         aeron_close(ctx->aeron);
+        ctx->aeron = NULL;
     }
 
     return -1;


### PR DESCRIPTION
Calling `aeron_archive_context_duplicate` on a context where `_ctx->owns_idle_strategy == true` will result in a context that also attempts to own the idle strategy. This results in a double free when calling `aeron_archive_context_close`.