### PR TITLE
[Java/C] Allow to specify network interface name in the interface channel parameter.

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,5 +1,18 @@
 = Aeron Releases
 
+== 1.50.0 (????-??-??)
+
+=== New & Noteworthy
+
+* The `interface` channel parameter now accepts network interface names in the `\{interface}` format, e.g. `interface=\{eth0}`.
++
+When used with multicast channels, it specifies the interface to join with and send on.
++
+The `interface` parameter might sometimes be used with non-multicast channels to control the local address of a socket.
+In those cases, the socket will be bound to an address of an appropriate family assigned to the named interface.
+If there are multiple matching addresses available, it's unspecified which one will be used.
+It's also possible to specify the port used with the resolved address by using the `\{interface}:port` format.
+
 == 1.49.2 (2025-11-24)
 
 * **[C]** Do not resolve `endpoint` with ephemeral port for MDS subscription. Copy original channel as-is if no

--- a/aeron-client/src/main/c/util/aeron_netutil.h
+++ b/aeron-client/src/main/c/util/aeron_netutil.h
@@ -75,7 +75,8 @@ uint32_t aeron_ipv4_netmask_from_prefixlen(size_t prefixlen);
 
 size_t aeron_ipv6_netmask_to_prefixlen(struct in6_addr *netmask);
 
-int aeron_find_interface(const char *interface_str, struct sockaddr_storage *if_addr, unsigned int *if_index);
+int aeron_find_interface(
+    int family, const char *interface_str, struct sockaddr_storage *if_addr, unsigned int *if_index);
 
 int aeron_find_unicast_interface(
     int family, const char *interface_str, struct sockaddr_storage *interface_addr, unsigned int *interface_index);
@@ -91,5 +92,14 @@ int aeron_format_source_identity(char *buffer, size_t length, struct sockaddr_st
 int aeron_netutil_get_so_buf_lengths(size_t *default_so_rcvbuf, size_t *default_so_sndbuf);
 
 int aeron_sockaddr_storage_cmp(struct sockaddr_storage *a, struct sockaddr_storage *b, bool *result);
+
+typedef struct aeron_named_interface_stct
+{
+    char name[IF_NAMESIZE];
+    int port;
+}
+aeron_named_interface_t;
+
+int aeron_parse_named_interface(const char *interface_str, aeron_named_interface_t *out);
 
 #endif //AERON_NETUTIL_H

--- a/aeron-driver/src/main/c/aeronmd.h
+++ b/aeron-driver/src/main/c/aeronmd.h
@@ -760,7 +760,7 @@ const char *aeron_driver_context_get_resolver_name(aeron_driver_context_t *conte
 /**
 * The interface of the MediaDriver for name resolver purposes.
 *
-* The format is hostname:port and follows the URI format for the interface parameter.
+* The format is hostname:port.
 */
 #define AERON_DRIVER_RESOLVER_INTERFACE_ENV_VAR "AERON_DRIVER_RESOLVER_INTERFACE"
 

--- a/aeron-driver/src/main/c/media/aeron_udp_channel.c
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel.c
@@ -139,7 +139,8 @@ int aeron_find_multicast_interface(
 {
     char *wildcard_str = AF_INET6 == family ? "[0::]/0" : "0.0.0.0/0";
 
-    return aeron_find_interface(NULL == interface_str ? wildcard_str : interface_str, interface_addr, interface_index);
+    return aeron_find_interface(
+        family, NULL == interface_str ? wildcard_str : interface_str, interface_addr, interface_index);
 }
 
 static int32_t unique_canonical_form_value = 0;

--- a/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
@@ -3317,12 +3317,10 @@ public final class MediaDriver implements AutoCloseable
         /**
          * Get the interface of the {@link MediaDriver} for name resolver purposes.
          * <p>
-         * The format is hostname:port and follows the URI format for the interface parameter. If set to null,
-         * then the name resolver will not be used.
+         * The format is {@code hostname:port}. If set to null, then the name resolver will not be used.
          *
          * @return interface of the {@link MediaDriver}.
          * @see Configuration#RESOLVER_INTERFACE_PROP_NAME
-         * @see CommonContext#INTERFACE_PARAM_NAME
          */
         @Config
         public String resolverInterface()
@@ -3333,13 +3331,11 @@ public final class MediaDriver implements AutoCloseable
         /**
          * Set the interface of the {@link MediaDriver} for name resolver purposes.
          * <p>
-         * The format is hostname:port and follows the URI format for the interface parameter. If set to null,
-         * then the name resolver will not be used.
+         * The format is {@code hostname:port}. If set to null, then the name resolver will not be used.
          *
          * @param resolverInterface to use for the name resolver.
          * @return this for fluent API.
          * @see Configuration#RESOLVER_INTERFACE_PROP_NAME
-         * @see CommonContext#INTERFACE_PARAM_NAME
          */
         public Context resolverInterface(final String resolverInterface)
         {
@@ -3350,7 +3346,7 @@ public final class MediaDriver implements AutoCloseable
         /**
          * Get the bootstrap neighbor of the {@link MediaDriver} for name resolver purposes.
          * <p>
-         * The format is comma separated list of {@code hostname:port} pairs. and follows the URI format for the
+         * The format is comma separated list of {@code hostname:port} pairs and follows the URI format for the
          * endpoint parameter.
          *
          * @return bootstrap neighbor of the {@link MediaDriver}.
@@ -3366,7 +3362,8 @@ public final class MediaDriver implements AutoCloseable
         /**
          * Set the bootstrap neighbor of the {@link MediaDriver} for name resolver purposes.
          * <p>
-         * The format is hostname:port and follows the URI format for the endpoint parameter.
+         * The format is comma separated list of {@code hostname:port} pairs and follows the URI format for the
+         * endpoint parameter.
          *
          * @param resolverBootstrapNeighbor to use for the name resolver.
          * @return this for fluent API.

--- a/aeron-driver/src/main/java/io/aeron/driver/media/NamedInterface.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/NamedInterface.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2025 Adaptive Financial Consulting Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.driver.media;
+
+import org.agrona.Strings;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.InterfaceAddress;
+import java.net.NetworkInterface;
+import java.net.ProtocolFamily;
+import java.net.SocketException;
+
+import static io.aeron.driver.media.NetworkUtil.getProtocolFamily;
+
+record NamedInterface(String name, int port) implements UnresolvedInterface
+{
+    static final char OPENING_CHAR = '{';
+
+    public ResolvedInterface resolve(final boolean multicast, final ProtocolFamily protocolFamily)
+        throws SocketException
+    {
+        final NetworkInterface localInterface = NetworkInterface.getByName(name);
+        if (null == localInterface)
+        {
+            throw new IllegalArgumentException("unknown interface " + name);
+        }
+        final InetSocketAddress address = resolveToFirstAddressOfFamily(localInterface, protocolFamily);
+        return new ResolvedInterface(localInterface, address);
+    }
+
+    private InetSocketAddress resolveToFirstAddressOfFamily(
+        final NetworkInterface localInterface,
+        final ProtocolFamily protocolFamily)
+    {
+        for (final InterfaceAddress interfaceAddress : localInterface.getInterfaceAddresses())
+        {
+            final InetAddress address = interfaceAddress.getAddress();
+            if (getProtocolFamily(address) == protocolFamily)
+            {
+                return new InetSocketAddress(address, port);
+            }
+        }
+
+        throw new IllegalStateException(
+            "no " + protocolFamily + " addresses found on interface " + localInterface.getName());
+    }
+
+    static NamedInterface parse(final String str)
+    {
+        if (Strings.isEmpty(str) || str.charAt(0) != OPENING_CHAR)
+        {
+            throw parseException(str);
+        }
+
+        final int nameEnd = str.lastIndexOf('}');
+        if (nameEnd <= 1)
+        {
+            throw parseException(str);
+        }
+        final String name = str.substring(1, nameEnd);
+
+        int port = 0;
+        final int trailing = str.length() - nameEnd - 1;
+        if (trailing > 0)
+        {
+            if (trailing == 1 || str.charAt(nameEnd + 1) != ':')
+            {
+                throw parseException(str);
+            }
+
+            try
+            {
+                port = Integer.parseUnsignedInt(str, nameEnd + 2, str.length(), 10);
+            }
+            catch (final NumberFormatException e)
+            {
+                throw parseException(str, e);
+            }
+
+            if (port > 0xFFFF)
+            {
+                throw parseException("port out of range: " + port);
+            }
+        }
+
+        return new NamedInterface(name, port);
+    }
+
+    private static IllegalArgumentException parseException(final String str)
+    {
+        return parseException(str, null);
+    }
+
+    private static IllegalArgumentException parseException(final String str, final Throwable cause)
+    {
+        return new IllegalArgumentException(
+            "expected format is '{interface_name}' or '{interface_name}:port', but got " +
+            (str == null ? null : '\'' + str + '\''),
+            cause);
+    }
+}

--- a/aeron-driver/src/main/java/io/aeron/driver/media/ResolvedInterface.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/ResolvedInterface.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 Adaptive Financial Consulting Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.driver.media;
+
+import java.net.InetSocketAddress;
+import java.net.NetworkInterface;
+
+import static java.util.Objects.requireNonNull;
+
+record ResolvedInterface(NetworkInterface localInterface, InetSocketAddress address)
+{
+    ResolvedInterface
+    {
+        requireNonNull(address, "address must not be null");
+    }
+}

--- a/aeron-driver/src/main/java/io/aeron/driver/media/UdpNameResolutionTransport.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/UdpNameResolutionTransport.java
@@ -155,7 +155,7 @@ public final class UdpNameResolutionTransport extends UdpChannelTransport
     {
         try
         {
-            return InterfaceSearchAddress.parse(addressAndPort).getAddress();
+            return InterfaceSearchAddress.parse(addressAndPort).address();
         }
         catch (final UnknownHostException ex)
         {

--- a/aeron-driver/src/main/java/io/aeron/driver/media/UnresolvedInterface.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/UnresolvedInterface.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 Adaptive Financial Consulting Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.driver.media;
+
+import org.agrona.Strings;
+
+import java.net.ProtocolFamily;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+
+/**
+ * Interface specification as found, for example, in the {@code interface=} channel parameter.
+ */
+sealed interface UnresolvedInterface permits InterfaceSearchAddress, NamedInterface
+{
+    ResolvedInterface resolve(boolean multicast, ProtocolFamily protocolFamily) throws SocketException;
+
+    static UnresolvedInterface parse(final String str) throws UnknownHostException
+    {
+        if (Strings.isEmpty(str))
+        {
+            throw new IllegalArgumentException("interface is null or empty");
+        }
+
+        if (str.charAt(0) == NamedInterface.OPENING_CHAR)
+        {
+            return NamedInterface.parse(str);
+        }
+        else
+        {
+            return InterfaceSearchAddress.parse(str);
+        }
+    }
+}

--- a/aeron-driver/src/test/java/io/aeron/driver/media/NamedInterfaceTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/media/NamedInterfaceTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2025 Adaptive Financial Consulting Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.driver.media;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class NamedInterfaceTest
+{
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {
+        " ",
+        "eth0",
+        "eth0:0",
+        "{eth0",
+        "{eth0}:",
+        "{eth0}0",
+        "{eth0}:-1000",
+        "{eth0};1000",
+        "{eth0}:1000:2000",
+        "{eth0}:65536",
+        "{}",
+    })
+    void shouldThrowIfParseInputIsInvalid(final String invalid)
+    {
+        assertThrows(IllegalArgumentException.class, () -> NamedInterface.parse(invalid));
+    }
+
+    static Stream<Arguments> validInputs()
+    {
+        return Stream.of(
+            arguments("{eth0}", "eth0", 0),
+            arguments("{eth0}:0", "eth0", 0),
+            arguments("{eth0}:1234", "eth0", 1234),
+            arguments("{eth0:0}:0", "eth0:0", 0),
+            arguments("{eth0:1}:2000", "eth0:1", 2000),
+            arguments("{eth0.100}:80", "eth0.100", 80),
+            arguments("{x}:5678", "x", 5678),
+            arguments("{lo}:65535", "lo", 65535),
+            arguments("{Ethernet 1}", "Ethernet 1", 0),
+            arguments("{ethernet_32768}", "ethernet_32768", 0),
+            arguments("{foo{bar-baz-12345}}:9999", "foo{bar-baz-12345}", 9999)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("validInputs")
+    void shouldParseValidInputs(final String str, final String name, final int port)
+    {
+        final NamedInterface namedInterface = NamedInterface.parse(str);
+        assertEquals(name, namedInterface.name());
+        assertEquals(port, namedInterface.port());
+    }
+}

--- a/aeron-driver/src/test/java/io/aeron/driver/media/UnresolvedInterfaceTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/media/UnresolvedInterfaceTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025 Adaptive Financial Consulting Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.driver.media;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class UnresolvedInterfaceTest
+{
+    @Test
+    void shouldParseValidInterfaceSpecifications() throws Exception
+    {
+        assertInstanceOf(InterfaceSearchAddress.class, UnresolvedInterface.parse("localhost"));
+        assertInstanceOf(InterfaceSearchAddress.class, UnresolvedInterface.parse("10.0.0.1"));
+        assertInstanceOf(InterfaceSearchAddress.class, UnresolvedInterface.parse("[2001:db8::1]"));
+        assertInstanceOf(NamedInterface.class, UnresolvedInterface.parse("{lo}"));
+    }
+
+    @Test
+    void shouldThrowOnInvalidInterfaceSpecifications()
+    {
+        assertThrows(IllegalArgumentException.class, () -> UnresolvedInterface.parse(null));
+        assertThrows(IllegalArgumentException.class, () -> UnresolvedInterface.parse(""));
+    }
+}

--- a/aeron-system-tests/src/test/java/io/aeron/ChannelInterfaceTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ChannelInterfaceTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2025 Adaptive Financial Consulting Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron;
+
+import io.aeron.driver.MediaDriver;
+import io.aeron.driver.ThreadingMode;
+import io.aeron.exceptions.RegistrationException;
+import io.aeron.logbuffer.FragmentHandler;
+import io.aeron.logbuffer.LogBufferDescriptor;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
+import io.aeron.test.Tests;
+import io.aeron.test.driver.TestMediaDriver;
+import org.agrona.CloseHelper;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.SystemUtil;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.Enumeration;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.agrona.BitUtil.SIZE_OF_LONG;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
+@ExtendWith(InterruptingTestCallback.class)
+class ChannelInterfaceTest
+{
+    private static final String LOOPBACK_INTERFACE = findLoopbackInterface();
+    private static final int STREAM_ID = 1001;
+
+    @RegisterExtension
+    final SystemTestWatcher watcher = new SystemTestWatcher();
+
+    private Aeron publishingClient;
+    private Aeron subscribingClient;
+    private TestMediaDriver driver;
+
+    @BeforeEach
+    void setUp()
+    {
+        final MediaDriver.Context driverContext = new MediaDriver.Context()
+            .dirDeleteOnStart(true)
+            .threadingMode(ThreadingMode.SHARED)
+            .publicationTermBufferLength(LogBufferDescriptor.TERM_MIN_LENGTH);
+
+        driver = TestMediaDriver.launch(driverContext, watcher);
+        watcher.dataCollector().add(driver.context().aeronDirectory());
+
+        subscribingClient = Aeron.connect();
+        publishingClient = Aeron.connect();
+    }
+
+    @AfterEach
+    void tearDown()
+    {
+        CloseHelper.closeAll(publishingClient, subscribingClient, driver);
+    }
+
+    @Test
+    @InterruptAfter(10)
+    void shouldAcceptInterfaceNameInUnicastChannels()
+    {
+        assumeNotNativeDriverOnWindows();
+
+        final String subChannel = "aeron:udp?endpoint=127.0.0.1:24325";
+        final String pubChannel = subChannel + "|interface={" + LOOPBACK_INTERFACE + "}:24324";
+
+        final Subscription subscription = subscribingClient.addSubscription(subChannel, STREAM_ID);
+        final Publication publication = publishingClient.addExclusivePublication(pubChannel, STREAM_ID);
+
+        passMessage(subscription, publication);
+
+        final String pubSocketAddress = publication.localSocketAddresses().get(0);
+        assertEquals("127.0.0.1:24324", pubSocketAddress);
+    }
+
+    @Test
+    @InterruptAfter(10)
+    void shouldAcceptInterfaceNameInMulticastChannels()
+    {
+        assumeNotNativeDriverOnWindows();
+
+        final String channel = "aeron:udp?endpoint=224.20.30.39:24326|interface={" + LOOPBACK_INTERFACE + "}|alias=foo";
+
+        final Subscription subscription = subscribingClient.addSubscription(channel, STREAM_ID);
+        final Publication publication = publishingClient.addExclusivePublication(channel, STREAM_ID);
+
+        passMessage(subscription, publication);
+    }
+
+    @ParameterizedTest
+    @InterruptAfter(10)
+    @ValueSource(strings = {
+        "aeron:udp?endpoint=localhost:24325|interface={does_not_exist}:24326",
+        "aeron:udp?endpoint=224.20.30.39:24325|interface={does_not_exist}",
+    })
+    void shouldThrowIfSpecifiedInterfaceDoesNotExist(final String channel)
+    {
+        final String expectedError = "unknown interface does_not_exist";
+        watcher.ignoreErrorsMatching((s) -> s.contains(expectedError));
+
+        final RegistrationException ex = assertThrows(RegistrationException.class,
+            () -> publishingClient.addPublication(channel, STREAM_ID));
+
+        assertThat(ex.getMessage(), containsString(expectedError));
+    }
+
+    private void passMessage(final Subscription subscription, final Publication publication)
+    {
+        final long payload = ThreadLocalRandom.current().nextLong();
+
+        final MutableDirectBuffer buffer = new UnsafeBuffer(new byte[SIZE_OF_LONG]);
+        buffer.putLong(0, payload);
+
+        while (0 > publication.offer(buffer))
+        {
+            Tests.yield();
+        }
+
+        final FragmentHandler fragmentHandler = (buf, off, len, hdr) ->
+            assertEquals(payload, buf.getLong(off));
+        while (0 == subscription.poll(fragmentHandler, 1))
+        {
+            Tests.yield();
+        }
+    }
+
+    private static String findLoopbackInterface()
+    {
+        try
+        {
+            final InetAddress home = InetAddress.getByName("127.0.0.1");
+            final Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();
+            while (networkInterfaces.hasMoreElements())
+            {
+                final NetworkInterface networkInterface = networkInterfaces.nextElement();
+                if (networkInterface.isLoopback() && networkInterface.inetAddresses().anyMatch(ia -> ia.equals(home)))
+                {
+                    return networkInterface.getName();
+                }
+            }
+        }
+        catch (final UnknownHostException | SocketException e)
+        {
+            throw new RuntimeException("failed to find loopback interface", e);
+        }
+
+        throw new RuntimeException("failed to find loopback interface");
+    }
+
+    private static void assumeNotNativeDriverOnWindows()
+    {
+        assumeFalse(SystemUtil.isWindows() && TestMediaDriver.shouldRunCMediaDriver(),
+            "we don't have access to the interface names used by the native MD on Windows");
+    }
+}


### PR DESCRIPTION
Format with curly braces chosen so that we can unambiguously tell it apart from hostnames.