### PR TITLE
aeron_atomic64_gcc_x86_64.h acquire/release simplification

### DIFF
--- a/aeron-client/src/main/c/concurrent/aeron_atomic64_gcc_x86_64.h
+++ b/aeron-client/src/main/c/concurrent/aeron_atomic64_gcc_x86_64.h
@@ -91,14 +91,11 @@ inline bool aeron_cas_int32(volatile int32_t *dst, int32_t expected, int32_t des
 
 inline void aeron_acquire(void)
 {
-    volatile int64_t *dummy;
-    __asm__ volatile("movq 0(%%rsp), %0" : "=r"(dummy) : : "memory");
+    __asm__ volatile("" ::: "memory");
 }
 
 inline void aeron_release(void)
 {
-    volatile int64_t dummy = 0;
-    (void)dummy;
     __asm__ volatile("" ::: "memory");
 }
 


### PR DESCRIPTION
On the X86, every store has release semantics and every load has acquire semantics.

The only thing that needs to be controlled is the compiler and that can be done using the compiler barrier:

```
__asm__ volatile("" ::: "memory");
```

This is inline with Linux:

https://github.com/torvalds/linux/blob/master/arch/x86/include/asm/barrier.h

```
#define __dma_rmb()	barrier()
#define __smp_rmb()	dma_rmb()
#define __smp_wmb()	barrier()
```

The __smp_wmp is the release and the __smp_rmb is the acquire. So both wmp and rmp are purely implemented using the barrier.

And the barrier is defined here:

https://github.com/torvalds/linux/blob/master/include/linux/compiler.h

```
/* The "volatile" is due to gcc bugs */
# define barrier() __asm__ __volatile__("": : :"memory")
```

Perhaps a good idea if we add the `__volatile__` as well.

So there is no need for a fake volatile load or store in combination with a compiler barrier. It is sufficient to only have the compiler barrier.