### PR TITLE
mpsc scan_back_to_confirm_still_zeroed underflow UB bug

### DIFF
--- a/aeron-client/src/main/c/concurrent/aeron_mpsc_rb.c
+++ b/aeron-client/src/main/c/concurrent/aeron_mpsc_rb.c
@@ -364,6 +364,11 @@ inline static bool scan_back_to_confirm_still_zeroed(const uint8_t *buffer, size
             break;
         }
 
+        if (i < AERON_RB_ALIGNMENT)
+        {
+            break;
+        }
+
         i -= AERON_RB_ALIGNMENT;
     }
 


### PR DESCRIPTION
It can happen that `i` can underflow and wraps around to a huge value:

```
i -= AERON_RB_ALIGNMENT
```

E.g. if `i` is 66 and AERON_RB_ALIGNMENT is 64, then after the first round `i` will be 2. After the second round `i` will be `SIZE_MAX-62`.

At that point you run into UB.

Currently is fixed by adding a guard before the decrement of `i`.