### PR TITLE
Fix aeron_log_buffer.c mem leak

### DIFF
--- a/aeron-client/src/main/c/aeron_log_buffer.c
+++ b/aeron-client/src/main/c/aeron_log_buffer.c
@@ -37,6 +37,7 @@ int aeron_log_buffer_create(
     if (aeron_raw_log_map_existing(&_log_buffer->mapped_raw_log, log_file, pre_touch) < 0)
     {
         AERON_APPEND_ERR("Unable to map raw log for log buffer, correlation_id: %" PRId64, correlation_id);
+        aeron_free(_log_buffer);
         return -1;
     }
 


### PR DESCRIPTION
If the memory mapping fails, then the memory allocated for the logbuffer, is not freed whch causes a memory leak.