### PR TITLE
Fixed MappedRawLog.sliceTerms bug

### DIFF
--- a/aeron-driver/src/main/java/io/aeron/driver/buffer/MappedRawLog.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/buffer/MappedRawLog.java
@@ -42,7 +42,6 @@ import static org.agrona.BitUtil.align;
  */
 class MappedRawLog implements RawLog
 {
-    private static final int ONE_GIG = 1 << 30;
     private static final EnumSet<StandardOpenOption> FILE_OPTIONS = EnumSet.of(CREATE_NEW, READ, WRITE);
     private static final EnumSet<StandardOpenOption> SPARSE_FILE_OPTIONS = EnumSet.of(CREATE_NEW, READ, WRITE, SPARSE);
 
@@ -191,7 +190,7 @@ class MappedRawLog implements RawLog
     {
         final ByteBuffer[] terms = new ByteBuffer[PARTITION_COUNT];
 
-        if (termLength < ONE_GIG)
+        if (mappedBuffers.length == 1)
         {
             final MappedByteBuffer buffer = mappedBuffers[0];
             for (int i = 0; i < PARTITION_COUNT; i++)


### PR DESCRIPTION
The constructor and the sliceTerms do not share the same condition to decide single buffer or multi buffer. So the sliceTerms can take the single buffer path while the constructor decided multi buffer and vice versa.

Concrete example.

Term length = 900 mb

Log length = 2.7 GB,

So constructor will decide multibuffer since  log lenght > 2 GB.

But sliceTerms will decide single buffer path since termLength < 1 GB.