### PR TITLE
Optimized register allocation aeron_atomic64_gcc_x86_64h

### DIFF
--- a/aeron-client/src/main/c/concurrent/aeron_atomic64_gcc_x86_64.h
+++ b/aeron-client/src/main/c/concurrent/aeron_atomic64_gcc_x86_64.h
@@ -62,7 +62,7 @@ inline bool aeron_cas_int64(volatile int64_t *dst, int64_t expected, int64_t des
     __asm__ volatile(
         "lock; cmpxchgq %2, %1"
         : "=a"(original), "+m"(*dst)
-        : "q"(desired), "0"(expected));
+        : "r"(desired), "0"(expected));
 
     return original == expected;
 }
@@ -73,7 +73,7 @@ inline bool aeron_cas_uint64(volatile uint64_t *dst, uint64_t expected, uint64_t
     __asm__ volatile(
         "lock; cmpxchgq %2, %1"
         : "=a"(original), "+m"(*dst)
-        : "q"(desired), "0"(expected));
+        : "r"(desired), "0"(expected));
 
     return original == expected;
 }
@@ -84,7 +84,7 @@ inline bool aeron_cas_int32(volatile int32_t *dst, int32_t expected, int32_t des
     __asm__ volatile(
         "lock; cmpxchgl %2, %1"
         : "=a"(original), "+m"(*dst)
-        : "q"(desired), "0"(expected));
+        : "r"(desired), "0"(expected));
 
     return original == expected;
 }


### PR DESCRIPTION
There was a mixture of r and q registers being used.

`q` registers are less flexible because there are only 4: rax...rdx
or their 32 bit counter parts: eax...edx

The `r` registers contain all the `q` registers, plus 12 extra; making 16 in total (32 with Intel APX)

So with more registers that can be used by the compiler, there will be less register spilling. Although I doubt it will make a significant performance different due to the cost of the atomic operations themselves, there is no point in making code more restrictive than it needs to be. Also the inconsistency isn't improving maintainability.

note:
`r`/`q` doesn't mean 32/64 bit.

Functionally there is no difference.