### PR TITLE
[Java] Introduce `maxPayloadLength` method to `ClientSession`

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ClientSession.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ClientSession.java
@@ -131,4 +131,22 @@ public interface ClientSession
      * @see BufferClaim#abort()
      */
     long tryClaim(int length, BufferClaim bufferClaim);
+
+    /**
+     * Get the maximum payload length that can be sent in a single message via {@link #tryClaim(int, BufferClaim)}.
+     * <p>
+     * This allows service implementations to determine the maximum message size enabling them to choose between
+     * {@link #tryClaim(int, BufferClaim)} for small messages (zero-copy) and {@link #offer(DirectBuffer, int, int)}
+     * for larger messages (automatic fragmentation).
+     *
+     * @return the maximum payload length in bytes.
+     */
+    int maxPayloadLength();
+
+    /**
+     * Get the maximum message length that can be sent in a single message via {@link #offer(DirectBuffer, int, int)}.
+     *
+     * @return the maximum message length in bytes.
+     */
+    int maxMessageLength();
 }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ContainerClientSession.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ContainerClientSession.java
@@ -24,6 +24,8 @@ import org.agrona.*;
 
 import java.util.Arrays;
 
+import static io.aeron.cluster.client.AeronCluster.SESSION_HEADER_LENGTH;
+
 final class ContainerClientSession implements ClientSession
 {
     private final long id;
@@ -34,6 +36,8 @@ final class ContainerClientSession implements ClientSession
     private final ClusteredServiceAgent clusteredServiceAgent;
     private Publication responsePublication;
     private boolean isClosing;
+    private int maxPayloadLength;
+    private int maxMessageLength;
 
     ContainerClientSession(
         final long sessionId,
@@ -98,6 +102,16 @@ final class ContainerClientSession implements ClientSession
         return clusteredServiceAgent.tryClaim(id, responsePublication, length, bufferClaim);
     }
 
+    public int maxPayloadLength()
+    {
+        return maxPayloadLength;
+    }
+
+    public int maxMessageLength()
+    {
+        return maxMessageLength;
+    }
+
     void connect(final Aeron aeron)
     {
         try
@@ -105,6 +119,8 @@ final class ContainerClientSession implements ClientSession
             if (null == responsePublication)
             {
                 responsePublication = aeron.addPublication(responseChannel, responseStreamId);
+                maxPayloadLength = responsePublication.maxPayloadLength() - SESSION_HEADER_LENGTH;
+                maxMessageLength = responsePublication.maxMessageLength() - SESSION_HEADER_LENGTH;
             }
         }
         catch (final RegistrationException ex)


### PR DESCRIPTION
This allows service implementations to determine the maximum message size
enabling them to choose between tryClaim() for small messages (zero-copy)
and offer() for larger messages (automatic fragmentation).
