### PR TITLE
Fix DNS re-resolution on dynamic MDC publication change

### DIFF
--- a/aeron-driver/src/main/c/media/aeron_receive_channel_endpoint.c
+++ b/aeron-driver/src/main/c/media/aeron_receive_channel_endpoint.c
@@ -607,9 +607,8 @@ int aeron_receive_channel_endpoint_on_setup(
 {
     aeron_setup_header_t *setup_header = (aeron_setup_header_t *)buffer;
 
-    aeron_receive_destination_update_last_activity_ns(
-        destination, aeron_clock_cached_nano_time(endpoint->cached_clock));
-
+    // Do not update `destination->time_of_last_activity_ns` because it will
+    // prevent DNS re-resolution checks.
     return aeron_data_packet_dispatcher_on_setup(
         &endpoint->dispatcher, endpoint, destination, setup_header, buffer, length, addr);
 }

--- a/aeron-driver/src/main/java/io/aeron/driver/media/ReceiveChannelEndpoint.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/ReceiveChannelEndpoint.java
@@ -733,7 +733,8 @@ public class ReceiveChannelEndpoint extends ReceiveChannelEndpointRhsPadding
         final InetSocketAddress srcAddress,
         final int transportIndex)
     {
-        updateTimeOfLastActivityNs(cachedNanoClock.nanoTime(), transportIndex);
+        // Do not update `timeOfLastActivityNs` because it will prevent DNS
+        // re-resolution checks.
         dispatcher.onSetupMessage(this, header, srcAddress, transportIndex);
     }
 


### PR DESCRIPTION
Do not update the time of last activity field of a receiver on SETUP messages.

Fixes #1913