### PR TITLE
[WIP] Fixes false sharing on mpsc and spsc queue.

### DIFF
--- a/aeron-client/src/main/c/concurrent/aeron_mpsc_concurrent_array_queue.h
+++ b/aeron-client/src/main/c/concurrent/aeron_mpsc_concurrent_array_queue.h
@@ -22,22 +22,25 @@
 
 typedef struct aeron_mpsc_concurrent_array_queue_stct
 {
-    int8_t padding[AERON_CACHE_LINE_LENGTH - sizeof(uint64_t)];
+    int8_t padding1[AERON_CACHE_LINE_LENGTH];
+
     struct
     {
         volatile uint64_t tail;
         uint64_t head_cache;
         volatile uint64_t shared_head_cache;
-        int8_t padding[AERON_CACHE_LINE_LENGTH - (3 * sizeof(uint64_t))];
     }
     producer;
+
+    int8_t padding2[AERON_CACHE_LINE_LENGTH];
 
     struct
     {
         volatile uint64_t head;
-        int8_t padding[AERON_CACHE_LINE_LENGTH - sizeof(uint64_t)];
     }
     consumer;
+
+    int8_t padding3[AERON_CACHE_LINE_LENGTH];
 
     size_t capacity;
     size_t mask;

--- a/aeron-client/src/main/c/concurrent/aeron_spsc_concurrent_array_queue.h
+++ b/aeron-client/src/main/c/concurrent/aeron_spsc_concurrent_array_queue.h
@@ -22,21 +22,25 @@
 
 typedef struct aeron_spsc_concurrent_array_queue_stct
 {
-    int8_t padding[AERON_CACHE_LINE_LENGTH - sizeof(uint64_t)];
+
+    int8_t padding1[AERON_CACHE_LINE_LENGTH];
+
     struct
     {
         volatile uint64_t tail;
         uint64_t head_cache;
-        int8_t padding[AERON_CACHE_LINE_LENGTH - (2 * sizeof(uint64_t))];
     }
     producer;
+
+    int8_t padding2[AERON_CACHE_LINE_LENGTH];
 
     struct
     {
         volatile uint64_t head;
-        int8_t padding[AERON_CACHE_LINE_LENGTH - sizeof(uint64_t)];
     }
     consumer;
+
+    int8_t padding3[AERON_CACHE_LINE_LENGTH];
 
     size_t capacity;
     size_t mask;


### PR DESCRIPTION
There is a false sharing problem in the mpsc and the spsc queues

```
typedef struct aeron_mpsc_concurrent_array_queue_stct
{
    int8_t padding[AERON_CACHE_LINE_LENGTH - sizeof(uint64_t)];
    struct
    {
        volatile uint64_t tail;
        uint64_t head_cache;
        volatile uint64_t shared_head_cache;
        int8_t padding[AERON_CACHE_LINE_LENGTH - (3 * sizeof(uint64_t))];
    }
    producer;

    struct
    {
        volatile uint64_t head;
        int8_t padding[AERON_CACHE_LINE_LENGTH - sizeof(uint64_t)];
    }
    consumer;

    size_t capacity;
    size_t mask;
    void * volatile *buffer;
}
```

For discussion sake, lets assume that tail starts at address 632.

head_cache can start at address 640.

shared_head_cache can start at 648.

Then there will be will be 64-24=40 bytes of padding.

And head will start at 648+8+40=696.

Each cacheline is 64 bytes, and therefor the head_cache (address 640) starts at the beginning of a new cacheline.

This cache line contains bytes 640-703.

So we have the head_cache and shared_head_cache (producer side) sitting on the same cache line as the (head) consumer side and as a consequence this code can suffer from false sharing.

I have run a small benchmark with and without the padding fix:

without padding fix
```
items=800000000 queue=16384 prod_cpu=2 cons_cpu=14
time=28.938893 s  throughput=27644458.057 ops/s  ns/op=36.174  sum=320000000400000000
```
with padding fix
```
items=800000000 queue=16384 prod_cpu=2 cons_cpu=14
time=1.236327 s  throughput=647078061.826 ops/s  ns/op=1.545  sum=320000000400000000
```

This is done on my AMD laptop with pretty low core to core latency. But on Intel machines or multi socket machines, the performance difference could be lot bigger.


Currently the solution is implemented with alignas; but there are some sharp corners. If you would use malloc or create an array of queues, the alignment could be ignored. So perhaps stuffing a cacheline of padding is a more reliable approach. I'm open for suggestions.