### PR TITLE
[Java] Get rid of excessive allocations in AeronCluster.AsyncConnect.awaitPublicationConnected

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
@@ -2155,6 +2155,7 @@ public final class AeronCluster implements AutoCloseable
         private long egressRegistrationId = NULL_VALUE;
         private Int2ObjectHashMap<MemberIngress> memberByIdMap;
         private long ingressRegistrationId = NULL_VALUE;
+        private String responseChannel;
         private Publication ingressPublication;
 
         AsyncConnect(final Context ctx, final long deadlineNs)
@@ -2383,7 +2384,11 @@ public final class AeronCluster implements AutoCloseable
 
         private void awaitPublicationConnected()
         {
-            final String responseChannel = egressSubscription.tryResolveChannelEndpointPort();
+            if (null == responseChannel)
+            {
+                responseChannel = egressSubscription.tryResolveChannelEndpointPort();
+            }
+
             if (null != responseChannel)
             {
                 if (null == ingressPublication)


### PR DESCRIPTION
Currently AeronCluster makes allocations on each invocation of AeronCluster.AsyncConnect#poll while in `AWAIT_PUBLICATION_CONNECTED`. This creates massive GC pressure when Aeron Cluster does not respond in time. This PR fixes this by caching `egressSubscription.tryResolveChannelEndpointPort()` result.

One thing I am not 100% sure - whether `egressSubscription.tryResolveChannelEndpointPort()` call should be extracted into a separate step like `AWAIT_EGRESS_CHANNEL_ENDPOINT_RESOLVED`. Let me know. 