### PR TITLE
Added missing break to dissect_cmd_in.

### DIFF
--- a/aeron-driver/src/main/c/agent/aeron_driver_agent.c
+++ b/aeron-driver/src/main/c/agent/aeron_driver_agent.c
@@ -1738,6 +1738,7 @@ static const char *dissect_cmd_in(int64_t cmd_id, const void *message, size_t le
                 command->position,
                 command->reason_length,
                 command->reason_text);
+            break;
         }
 
         default:


### PR DESCRIPTION
The AERON_COMMAND_REJECT_IMAGE doesn't have a break at the end and relies on the default (which also does a break).

This is not a bug fix, just a minor code cleanup.