### PR TITLE
aeron_alloc_aligned posix_memalign bug

### DIFF
--- a/aeron-client/src/main/c/aeron_alloc.c
+++ b/aeron-client/src/main/c/aeron_alloc.c
@@ -62,8 +62,9 @@ int aeron_alloc_aligned(void **ptr, size_t *offset, size_t size, size_t alignmen
 
 #ifdef HAVE_POSIX_MEMALIGN
     int rc = posix_memalign(ptr, alignment, size);
-    if (rc < 0)
+    if (rc != 0)
     {
+        // any non zero value is a failure.
         AERON_SET_ERR(rc, "Failed to allocate %" PRIu64 " bytes, alignment %" PRIu64, (uint64_t)size, (uint64_t)alignment);
         return -1;
     }


### PR DESCRIPTION
The error handling of the posix_memalign call is incorrect because it will never get triggered. It only fails if the rc < 0, but the return value is the error code and always positive:

- EINVAL: 22
- ENOMEM: 12

https://man7.org/linux/man-pages/man3/posix_memalign.3.html

When the posix_memalign fails, ptr is undefined. And because after the posix_memalign call a memset is done on an undefined ptr, you run into UB.

