### PR TITLE
Fixed aeron_strerror_r

### DIFF
--- a/aeron-client/src/main/c/util/aeron_error.c
+++ b/aeron-client/src/main/c/util/aeron_error.c
@@ -36,7 +36,7 @@
 const char *aeron_strerror_r(int errcode, char *buffer, size_t length)
 {
     int result = strerror_r(errcode, buffer, length);
-    if (result < 0)
+    if (result != 0)
     {
         return AERON_ERR_DESCRIPTION_UNAVAILABLE;
     }


### PR DESCRIPTION
if there is no problem, the strerror_r will return 0 and anything else indicates failure.

The XI compliant strerror_r is used and documentation can be found here:

https://linux.die.net/man/3/strerror_r

With the old code, if there is a failure and a positive error code is returned, it isn't detected and buffer isn't updated and can be filled with random data.

This can lead to problems down the line where a \0 terminated string is expected.