### PR TITLE
[Java] Fix single-node cluster leader re-election.

### DIFF
--- a/aeron-cluster/src/test/java/io/aeron/cluster/ElectionTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ElectionTest.java
@@ -152,6 +152,7 @@ class ElectionTest
         election.doWork(clock.nanoTime());
         election.doWork(clock.nanoTime());
         election.doWork(clock.nanoTime());
+        election.doWork(clock.nanoTime());
 
         verify(consensusModuleAgent).joinLogAsLeader(eq(newLeadershipTermId), eq(logPosition), anyInt(), eq(true));
         verify(electionStateCounter).setRelease(ElectionState.LEADER_READY.code());

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/OffsetMillisecondClusterClock.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/OffsetMillisecondClusterClock.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Adaptive Financial Consulting Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.cluster;
+
+import io.aeron.cluster.service.ClusterClock;
+import org.agrona.concurrent.EpochClock;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+
+final class OffsetMillisecondClusterClock implements ClusterClock
+{
+    private static final VarHandle OFFSET_VH;
+
+    static
+    {
+        try
+        {
+            OFFSET_VH = MethodHandles.lookup()
+                .findVarHandle(OffsetMillisecondClusterClock.class, "offset", long.class);
+        }
+        catch (final ReflectiveOperationException ex)
+        {
+            throw new ExceptionInInitializerError(ex);
+        }
+    }
+
+    private final EpochClock epochClock;
+    @SuppressWarnings("unused")
+    private volatile long offset;
+
+    OffsetMillisecondClusterClock(final EpochClock epochClock)
+    {
+        this.epochClock = epochClock;
+    }
+
+    public long time()
+    {
+        return epochClock.time() + (long)OFFSET_VH.getAcquire(this);
+    }
+
+    void addOffset(final long deltaMs)
+    {
+        OFFSET_VH.getAndAddRelease(this, deltaMs);
+    }
+}

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/OffsetMillisecondClusterClockTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/OffsetMillisecondClusterClockTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Adaptive Financial Consulting Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.cluster;
+
+import org.agrona.collections.MutableLong;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class OffsetMillisecondClusterClockTest
+{
+    @Test
+    void shouldOffsetDelegateTime()
+    {
+        final MutableLong time = new MutableLong(1000);
+        final OffsetMillisecondClusterClock clock = new OffsetMillisecondClusterClock(time::get);
+        assertEquals(TimeUnit.MILLISECONDS, clock.timeUnit());
+        assertEquals(1000, clock.time());
+        clock.addOffset(7);
+        assertEquals(1007, clock.time());
+        time.increment();
+        assertEquals(1008, clock.time());
+        clock.addOffset(3);
+        time.increment();
+        assertEquals(1012, clock.time());
+    }
+}

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
@@ -50,6 +50,7 @@ import io.aeron.cluster.codecs.MessageHeaderDecoder;
 import io.aeron.cluster.codecs.NewLeadershipTermEventDecoder;
 import io.aeron.cluster.codecs.SessionMessageHeaderDecoder;
 import io.aeron.cluster.service.Cluster;
+import io.aeron.cluster.service.ClusterClock;
 import io.aeron.driver.Configuration;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ReceiveChannelEndpointSupplier;
@@ -197,6 +198,7 @@ public final class TestCluster implements AutoCloseable
     private Supplier<ConsensusModuleExtension> extensionSupplier;
     private IntFunction<SendChannelEndpointSupplier> sendChannelEndpointSupplier;
     private IntFunction<ReceiveChannelEndpointSupplier> receiveChannelEndpointSupplier;
+    private ClusterClock clusterClock;
 
     private TestCluster(
         final int clusterId,
@@ -448,6 +450,7 @@ public final class TestCluster implements AutoCloseable
                 .controlResponseChannel(ARCHIVE_LOCAL_CONTROL_CHANNEL))
             .sessionTimeoutNs(sessionTimeoutNs)
             .totalSnapshotDurationThresholdNs(TimeUnit.MILLISECONDS.toNanos(100))
+            .clusterClock(clusterClock)
             .authenticatorSupplier(authenticationSupplier)
             .authorisationServiceSupplier(authorisationServiceSupplier)
             .timerServiceSupplier(timerServiceSupplier)
@@ -2269,6 +2272,7 @@ public final class TestCluster implements AutoCloseable
         private List<String> hostnames;
         private Function<Aeron, Counter> errorCounterSupplier;
         private Function<Aeron, Counter> snapshotCounterSupplier;
+        private ClusterClock clusterClock;
         private long leaderHeartbeatTimeoutNs = LEADER_HEARTBEAT_TIMEOUT_NS;
         private long leaderHeartbeatIntervalNs = LEADER_HEARTBEAT_INTERVAL_NS;
         private long electionTimeoutNs = ELECTION_TIMEOUT_NS;
@@ -2478,6 +2482,12 @@ public final class TestCluster implements AutoCloseable
             return this;
         }
 
+        public Builder withClusterClock(final ClusterClock clusterClock)
+        {
+            this.clusterClock = clusterClock;
+            return this;
+        }
+
         public TestCluster start()
         {
             return start(nodeCount);
@@ -2525,6 +2535,7 @@ public final class TestCluster implements AutoCloseable
             testCluster.snapshotCounterSupplier = snapshotCounterSupplier;
             testCluster.sendChannelEndpointSupplier = sendChannelEndpointSupplier;
             testCluster.receiveChannelEndpointSupplier = receiveChannelEndpointSupplier;
+            testCluster.clusterClock = clusterClock;
 
             try
             {


### PR DESCRIPTION
Single-node cluster leader can enter an election after the startup one only in strange error conditions.

If shouldEnterElectionWhenRecordingStopsUnexpectedlyOnLeader() tests unexpected stop of a log recording works in a 3-node cluster, I think it should work in a single-node cluster too, so I added shouldEnterElectionWhenRecordingStopsUnexpectedlyOnLeaderOfSingleNodeCluster().

b999d5d91d147f4722412650a67f61573e6246aa made it possible for a single-node cluster leader to lose quorum, i.e. timeout itself, this is what the newly added shouldEnterElectionWhenLosesQuorumUnexpectedlyOnLeaderOfSingleNodeCluster() tries to test. Additionally, closes a session in the same duty cycle to make things more interesting.

Previously, Election for a single-node cluster would skip the INIT state, now it doesn't. On startup, the behavior is equivalent.
On subsequent elections, it allows the node to clean up and prepare for the new term.