### PR TITLE
Restores old behaviour around single-node cluster timeouts.

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -2562,7 +2562,8 @@ final class ConsensusModuleAgent
                     workCount += processPendingSessions(pendingBackupSessions, rejectedBackupSessions, nowNs);
                     workCount += checkSessions(sessions, nowNs);
 
-                    if (!ClusterMember.hasActiveQuorum(activeMembers, nowNs, leaderHeartbeatTimeoutNs))
+                    if (activeMembers.length > 1 &&
+                        !ClusterMember.hasActiveQuorum(activeMembers, nowNs, leaderHeartbeatTimeoutNs))
                     {
                         enterElection(false, "inactive follower quorum");
                         workCount += 1;


### PR DESCRIPTION
In b999d5d9 we started to allow a single-node cluster to time itself out and enter an election. This behaviour change caused some tests to fail in downstream systems, due to assumptions around when an election would occur. In this commit, we revert the behaviour change and add a (slightly racey) test that asserts another election is not entered.