### PR TITLE
Fix incorrect header values in controlled fragment assemblers after aborting fragmented message

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -4,6 +4,7 @@
 
 === Changelog
 
+* Fixed a bug in the controlled fragment assemblers where their handler after aborting on a fragmented message would receive on subsequent calls for that message a header with invalid position and fragmented frame length.
 * **[Cluster]** Enforce a maximum service count of 10. This limit has always existed in Cluster
 but is now explicitly enforced via the ClusteredServiceContainer.Configuration.MAX_SERVICE_COUNT setting.
 * **[Cluster]** Fix single-node cluster leader re-election which could happen after a stall or a time jump.

--- a/aeron-client/src/main/c/aeron_fragment_assembler.h
+++ b/aeron-client/src/main/c/aeron_fragment_assembler.h
@@ -29,6 +29,7 @@ typedef struct aeron_buffer_builder_stct
     size_t buffer_length;
     size_t limit;
     int32_t next_term_offset;
+    int32_t first_frame_length;
     aeron_header_t header;
 }
 aeron_buffer_builder_t;
@@ -100,6 +101,7 @@ inline void aeron_buffer_builder_capture_header(aeron_buffer_builder_t *buffer_b
 {
     buffer_builder->header.initial_term_id = header->initial_term_id;
     buffer_builder->header.position_bits_to_shift = header->position_bits_to_shift;
+    buffer_builder->first_frame_length = header->frame->frame_header.frame_length;
     memcpy(buffer_builder->header.frame, header->frame, sizeof(aeron_data_header_t));
 }
 
@@ -108,7 +110,7 @@ inline aeron_header_t* aeron_buffer_builder_complete_header(aeron_buffer_builder
     buffer_builder->header.context = header->context;
     aeron_frame_header_t *frame_header = &buffer_builder->header.frame->frame_header;
 
-    int32_t max_payload_length = frame_header->frame_length - (int32_t)AERON_DATA_HEADER_LENGTH;
+    int32_t max_payload_length = buffer_builder->first_frame_length - (int32_t)AERON_DATA_HEADER_LENGTH;
     int32_t fragmented_frame_length = (int32_t)aeron_logbuffer_compute_fragmented_length(
         buffer_builder->limit, max_payload_length);
     buffer_builder->header.fragmented_frame_length = fragmented_frame_length;

--- a/aeron-client/src/main/java/io/aeron/BufferBuilder.java
+++ b/aeron-client/src/main/java/io/aeron/BufferBuilder.java
@@ -46,6 +46,7 @@ public final class BufferBuilder
     private final boolean isDirect;
     private int limit;
     private int nextTermOffset = NULL_VALUE;
+    private int firstFrameLength;
     private final UnsafeBuffer buffer = new UnsafeBuffer();
     final UnsafeBuffer headerBuffer = new UnsafeBuffer();
     final Header completeHeader = new Header(0, 0);
@@ -230,6 +231,8 @@ public final class BufferBuilder
             .offset(0)
             .buffer(headerBuffer);
 
+        firstFrameLength = header.frameLength();
+
         headerBuffer.putBytes(0, header.buffer(), header.offset(), HEADER_LENGTH);
         return this;
     }
@@ -243,7 +246,7 @@ public final class BufferBuilder
      */
     public Header completeHeader(final Header header)
     {
-        final int firstFrameLength = headerBuffer.getInt(FRAME_LENGTH_FIELD_OFFSET, LITTLE_ENDIAN);
+        // compute the `fragmented frame length` of the complete message
         final int fragmentedFrameLength = computeFragmentedFrameLength(limit, firstFrameLength - HEADER_LENGTH);
         completeHeader
             .context(header.context())
@@ -252,7 +255,6 @@ public final class BufferBuilder
         headerBuffer.putInt(FRAME_LENGTH_FIELD_OFFSET, HEADER_LENGTH + limit, LITTLE_ENDIAN);
         // compute complete flags
         headerBuffer.putByte(FLAGS_OFFSET, (byte)(headerBuffer.getByte(FLAGS_OFFSET) | header.flags()));
-        // compute the `fragmented frame length` of the complete message
 
         return completeHeader;
     }

--- a/aeron-client/src/test/c/aeron_controlled_image_fragment_assembler_test.cpp
+++ b/aeron-client/src/test/c/aeron_controlled_image_fragment_assembler_test.cpp
@@ -412,3 +412,39 @@ TEST_F(ControlledImageFragmentAssemblerTest, shouldAbortReassembly)
     EXPECT_EQ(AERON_ACTION_ABORT, handle_fragment(handler, fragmentLength));
     EXPECT_TRUE(isCalled);
 }
+
+TEST_F(ControlledImageFragmentAssemblerTest, testHeaderAfterAbortingFragmentedMessage)
+{
+    m_header.initial_term_id = INITIAL_TERM_ID;
+    m_header.position_bits_to_shift = POSITION_BITS_TO_SHIFT;
+
+    uint64_t callCount = 0;
+    size_t fragmentLength = MTU_LENGTH - AERON_DATA_HEADER_LENGTH;
+    auto handler = [&](const uint8_t *buffer, size_t length, aeron_header_t *header)
+    {
+        callCount++;
+        EXPECT_EQ(length, fragmentLength * 2);
+        aeron_header_values_t header_values;
+        EXPECT_EQ(0, aeron_header_values(header, &header_values));
+        EXPECT_EQ(ACTIVE_TERM_ID, header_values.frame.term_id);
+        EXPECT_EQ(0, header_values.frame.term_offset);
+        EXPECT_EQ(INITIAL_TERM_ID, header->initial_term_id);
+        EXPECT_EQ(POSITION_BITS_TO_SHIFT, header->position_bits_to_shift);
+        EXPECT_EQ(AERON_DATA_HEADER_LENGTH + 2 * fragmentLength, header_values.frame.frame_length);
+        EXPECT_EQ(((ACTIVE_TERM_ID - INITIAL_TERM_ID) * TERM_LENGTH) + 2 * MTU_LENGTH, aeron_header_position(header));
+        EXPECT_EQ(SESSION_ID, header_values.frame.session_id);
+        EXPECT_EQ(AERON_DATA_HEADER_UNFRAGMENTED, header_values.frame.flags & AERON_DATA_HEADER_UNFRAGMENTED);
+        return AERON_ACTION_ABORT;
+    };
+
+    int32_t termOffset = 0;
+    fillFrame(AERON_DATA_HEADER_BEGIN_FLAG, termOffset, fragmentLength, 0);
+    EXPECT_EQ(AERON_ACTION_CONTINUE, handle_fragment(handler, fragmentLength));
+
+    termOffset += MTU_LENGTH;
+    fillFrame(AERON_DATA_HEADER_END_FLAG, termOffset, fragmentLength, fragmentLength % 256);
+    EXPECT_EQ(AERON_ACTION_ABORT, handle_fragment(handler, fragmentLength));
+    EXPECT_EQ(AERON_ACTION_ABORT, handle_fragment(handler, fragmentLength));
+
+    EXPECT_EQ(2, callCount);
+}

--- a/aeron-system-tests/src/test/java/io/aeron/ControlledAssemblyTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ControlledAssemblyTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2026 Adaptive Financial Consulting Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron;
+
+import io.aeron.driver.MediaDriver;
+import io.aeron.driver.ThreadingMode;
+import io.aeron.logbuffer.ControlledFragmentHandler;
+import io.aeron.logbuffer.ControlledFragmentHandler.Action;
+import io.aeron.logbuffer.Header;
+import io.aeron.logbuffer.LogBufferDescriptor;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
+import io.aeron.test.Tests;
+import io.aeron.test.driver.TestMediaDriver;
+import org.agrona.CloseHelper;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+import static io.aeron.Aeron.NULL_VALUE;
+import static io.aeron.CommonContext.IPC_CHANNEL;
+import static io.aeron.logbuffer.ControlledFragmentHandler.Action.ABORT;
+import static io.aeron.logbuffer.ControlledFragmentHandler.Action.CONTINUE;
+import static io.aeron.protocol.DataHeaderFlyweight.HEADER_LENGTH;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(InterruptingTestCallback.class)
+class ControlledAssemblyTest
+{
+    private static final int STREAM_ID = 1001;
+
+    @RegisterExtension
+    final SystemTestWatcher testWatcher = new SystemTestWatcher();
+
+    private final MediaDriver.Context driverContext = new MediaDriver.Context()
+        .publicationTermBufferLength(LogBufferDescriptor.TERM_MIN_LENGTH)
+        .errorHandler(Tests::onError)
+        .threadingMode(ThreadingMode.SHARED);
+
+    private TestMediaDriver driver;
+
+    private Aeron aeron;
+
+    @BeforeEach
+    void setUp()
+    {
+        driver = TestMediaDriver.launch(driverContext, testWatcher);
+        testWatcher.dataCollector().add(driver.context().aeronDirectory());
+
+        aeron = Aeron.connect();
+    }
+
+    @AfterEach
+    void after()
+    {
+        CloseHelper.closeAll(aeron, driver);
+    }
+
+    @Test
+    @InterruptAfter(10)
+    void testHeaderInRepeatedCallbacksAfterAborting()
+    {
+        try (Subscription subscription1 = aeron.addSubscription(IPC_CHANNEL, STREAM_ID);
+            Subscription subscription2 = aeron.addSubscription(IPC_CHANNEL, STREAM_ID);
+            ExclusivePublication publication = aeron.addExclusivePublication(IPC_CHANNEL, STREAM_ID))
+        {
+            final UnsafeBuffer buffer = new UnsafeBuffer(new byte[publication.maxPayloadLength() + 1]);
+
+            Tests.awaitConnected(subscription1);
+            Tests.awaitConnected(subscription2);
+
+            final int length1 = 17;
+            final long position1 = offer(publication, buffer, length1);
+
+            final int length2 = buffer.capacity();
+            final long position2 = offer(publication, buffer, length2);
+
+            final int length3 = 64;
+            final long position3 = offer(publication, buffer, length3);
+
+            final TestHandler subscriptionHandler = new TestHandler();
+            final ControlledFragmentAssembler subscriptionAssembler =
+                new ControlledFragmentAssembler(subscriptionHandler);
+
+            final Image image = subscription2.imageAtIndex(0);
+            final TestHandler imageHandler = new TestHandler();
+            final ImageControlledFragmentAssembler imageAssembler = new ImageControlledFragmentAssembler(imageHandler);
+
+            final BiConsumer<Action, Integer> pollUntilActionReturnedNTimes = (action, n) ->
+            {
+                subscriptionHandler.action = action;
+                final int subscriptionExpected = subscriptionHandler.fragments.size() + n;
+                while (subscriptionHandler.fragments.size() < subscriptionExpected)
+                {
+                    if (subscription1.controlledPoll(subscriptionAssembler, 1) == 0)
+                    {
+                        Tests.yield();
+                    }
+                }
+
+                imageHandler.action = action;
+                final int imageExpected = imageHandler.fragments.size() + n;
+                while (imageHandler.fragments.size() < imageExpected)
+                {
+                    if (image.controlledPoll(imageAssembler, 1) == 0)
+                    {
+                        Tests.yield();
+                    }
+                }
+            };
+
+            pollUntilActionReturnedNTimes.accept(ABORT, 1);
+            pollUntilActionReturnedNTimes.accept(CONTINUE, 1);
+            pollUntilActionReturnedNTimes.accept(ABORT, 2);
+            pollUntilActionReturnedNTimes.accept(CONTINUE, 2);
+
+            assertEquals(List.of(
+                new Fragment(length1, length1 + HEADER_LENGTH, NULL_VALUE, position1),
+                new Fragment(length1, length1 + HEADER_LENGTH, NULL_VALUE, position1),
+                new Fragment(length2, length2 + HEADER_LENGTH, (int)(position2 - position1), position2),
+                new Fragment(length2, length2 + HEADER_LENGTH, (int)(position2 - position1), position2),
+                new Fragment(length2, length2 + HEADER_LENGTH, (int)(position2 - position1), position2),
+                new Fragment(length3, length3 + HEADER_LENGTH, NULL_VALUE, position3)
+            ), subscriptionHandler.fragments);
+
+            assertEquals(subscriptionHandler.fragments, imageHandler.fragments);
+        }
+    }
+
+    private static long offer(final Publication publication, final DirectBuffer buffer, final int length)
+    {
+        while (true)
+        {
+            final long position = publication.offer(buffer, 0, length);
+            if (position > 0)
+            {
+                return position;
+            }
+            Tests.yield();
+        }
+    }
+
+    private static final class TestHandler implements ControlledFragmentHandler
+    {
+        private final List<Fragment> fragments = new ArrayList<>();
+        private Action action;
+
+        public Action onFragment(final DirectBuffer buffer, final int offset, final int length, final Header header)
+        {
+            fragments.add(new Fragment(
+                length,
+                header.frameLength(),
+                header.fragmentedFrameLength(),
+                header.position()));
+
+            return action;
+        }
+    }
+
+    private record Fragment(int length, int frameLength, int fragmentedFrameLength, long position)
+    {
+    }
+}


### PR DESCRIPTION
Completing a header in the buffer builders was not idempotent. They changed the value used for calculations, making them invalid on repeated calls.