### PR TITLE
[Java] Avoid bind conflicts when removing and adding a subscription to the same channel.

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -9,6 +9,8 @@ message would receive on subsequent calls for that message a header with invalid
 * **[Driver/C]** Fix data corruption resulting from `aeron_append_block` ignoring `term_offset`.  (https://github.com/aeron-io/aeron/issues/1944[#1944])
 * **[Driver]** Process pending loss without delays in case of an unreliable subscriber (`reliable=false`), i.e. do not
 apply NAK delay if no recovery will be attempted. (https://github.com/aeron-io/aeron/issues/1946[#1946])
+* **[Driver/Java]** Now replies with a `RESOURCE_TEMPORARILY_UNAVAILABLE` error when the endpoint is mid-closing (as in the C driver) when reuse would be unsafe and new endpoint/socket creation would lead to a bind error.
+* **[Cluster Client/Java]** Now retries when a `RESOURCE_TEMPORARILY_UNAVAILABLE` error is encountered when creating an egress subscription.
 * **[Cluster]** Enforce a maximum service count of 10. This limit has always existed in Cluster
 but is now explicitly enforced via the ClusteredServiceContainer.Configuration.MAX_SERVICE_COUNT setting.
 * **[Cluster]** Restores old behaviour around single-node cluster liveness timeouts. (https://github.com/aeron-io/aeron/pull/1947[#1947])

--- a/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
@@ -21,6 +21,7 @@ import io.aeron.ChannelUri;
 import io.aeron.CommonContext;
 import io.aeron.ControlledFragmentAssembler;
 import io.aeron.DirectBufferVector;
+import io.aeron.ErrorCode;
 import io.aeron.FragmentAssembler;
 import io.aeron.Image;
 import io.aeron.Publication;
@@ -2327,7 +2328,20 @@ public final class AeronCluster implements AutoCloseable
                 egressRegistrationId = ctx.aeron().asyncAddSubscription(ctx.egressChannel(), ctx.egressStreamId());
             }
 
-            egressSubscription = ctx.aeron().getSubscription(egressRegistrationId);
+            try
+            {
+                egressSubscription = ctx.aeron().getSubscription(egressRegistrationId);
+            }
+            catch (final RegistrationException ex)
+            {
+                egressRegistrationId = NULL_VALUE;
+
+                if (ErrorCode.RESOURCE_TEMPORARILY_UNAVAILABLE != ex.errorCode())
+                {
+                    throw ex;
+                }
+            }
+
             if (null != egressSubscription)
             {
                 egressPoller = new EgressPoller(egressSubscription, FRAGMENT_LIMIT);

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -16,6 +16,7 @@
 package io.aeron.driver;
 
 import io.aeron.ChannelUri;
+import io.aeron.ErrorCode;
 import io.aeron.driver.MediaDriver.Context;
 import io.aeron.driver.buffer.LogFactory;
 import io.aeron.driver.buffer.RawLog;
@@ -968,6 +969,7 @@ public final class DriverConductor implements Agent
     {
         if (channelEndpoint.shouldBeClosed())
         {
+            channelEndpoint.indicateClosing();
             receiverProxy.closeReceiveChannelEndpoint(channelEndpoint);
         }
     }
@@ -1179,6 +1181,16 @@ public final class DriverConductor implements Agent
 
                 final ReceiveChannelEndpoint channelEndpoint = getOrCreateReceiveChannelEndpoint(
                     params, udpChannel, registrationId);
+
+                if (ChannelEndpointStatus.CLOSING == channelEndpoint.status())
+                {
+                    clientProxy.onError(
+                        registrationId,
+                        ErrorCode.RESOURCE_TEMPORARILY_UNAVAILABLE,
+                        "ReceiveChannelEndpoint found in CLOSING state, please retry"
+                    );
+                    return;
+                }
 
                 final NetworkSubscriptionLink subscription = new NetworkSubscriptionLink(
                     registrationId, channelEndpoint, streamId, channel, getOrAddClient(clientId), params);

--- a/aeron-driver/src/main/java/io/aeron/driver/media/ReceiveChannelEndpoint.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/ReceiveChannelEndpoint.java
@@ -52,7 +52,6 @@ import java.util.concurrent.TimeUnit;
 import static io.aeron.driver.status.SystemCounterDescriptor.POSSIBLE_TTL_ASYMMETRY;
 import static io.aeron.driver.status.SystemCounterDescriptor.SHORT_SENDS;
 import static io.aeron.protocol.StatusMessageFlyweight.SEND_SETUP_FLAG;
-import static io.aeron.status.ChannelEndpointStatus.status;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 
 abstract class ReceiveChannelEndpointLhsPadding extends UdpChannelTransport
@@ -268,8 +267,8 @@ public class ReceiveChannelEndpoint extends ReceiveChannelEndpointRhsPadding
         final long currentStatus = statusIndicator.get();
         if (currentStatus != ChannelEndpointStatus.INITIALIZING)
         {
-            throw new AeronException(
-                "channel cannot be registered unless INITIALIZING: status=" + status(currentStatus));
+            throw new AeronException("channel cannot be registered unless INITIALIZING: status=" +
+                ChannelEndpointStatus.status(currentStatus));
         }
 
         if (null == multiRcvDestination)
@@ -280,6 +279,26 @@ public class ReceiveChannelEndpoint extends ReceiveChannelEndpointRhsPadding
         }
 
         statusIndicator.setRelease(ChannelEndpointStatus.ACTIVE);
+    }
+
+    /**
+     * Indicate that the channel is closing and should not be used for new subscriptions.
+     */
+    public void indicateClosing()
+    {
+        statusIndicator.setRelease(ChannelEndpointStatus.CLOSING);
+    }
+
+    /**
+     * The {@link ChannelEndpointStatus} value for the channel.
+     *
+     * <p>Must not be called after calling {@link #close()}, as it accesses a counter.</p>
+     *
+     * @return the {@link ChannelEndpointStatus} value for the channel.
+     */
+    public long status()
+    {
+        return statusIndicator.getAcquire();
     }
 
     /**

--- a/aeron-driver/src/test/java/io/aeron/driver/DriverConductorTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/DriverConductorTest.java
@@ -361,6 +361,36 @@ class DriverConductorTest
     }
 
     @Test
+    void shouldEventuallyAddSubscriptionMatchingAClosedSubscriptionChannel()
+    {
+        final long id1 = driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
+        driverProxy.removeSubscription(id1);
+
+        driverConductor.doWork();
+        driverConductor.doWork();
+
+        verify(receiverProxy).registerReceiveChannelEndpoint(any());
+        final ArgumentCaptor<ReceiveChannelEndpoint> captor = ArgumentCaptor.forClass(ReceiveChannelEndpoint.class);
+        verify(receiverProxy).closeReceiveChannelEndpoint(captor.capture());
+
+        final long id2 = driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
+
+        driverConductor.doWork();
+        driverConductor.doWork();
+
+        verify(mockClientProxy, times(1)).onError(id2, ErrorCode.RESOURCE_TEMPORARILY_UNAVAILABLE,
+            "ReceiveChannelEndpoint found in CLOSING state, please retry");
+
+        driverConductor.receiveChannelEndpointClosed(captor.getValue());
+
+        final long id3 = driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        verify(mockClientProxy, times(1)).onSubscriptionReady(eq(id3), anyInt());
+    }
+
+    @Test
     void shouldBeAbleToAddMultipleStreams()
     {
         driverProxy.addPublication(CHANNEL_4001, STREAM_ID_1);

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/MethodCallBlocker.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/MethodCallBlocker.java
@@ -38,6 +38,7 @@ import net.bytebuddy.matcher.ElementMatchers;
 import net.bytebuddy.utility.JavaModule;
 
 import java.lang.instrument.Instrumentation;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -107,7 +108,8 @@ public final class MethodCallBlocker
         try (DynamicType.Unloaded<Object> adviceType = createAdviceType(adviceClassName))
         {
             final Class<?> dynamicAdviceClass = adviceType
-                .load(MethodCallBlocker.class.getClassLoader(), ClassLoadingStrategy.Default.INJECTION)
+                .load(MethodCallBlocker.class.getClassLoader(), ClassLoadingStrategy.UsingLookup.of(
+                    MethodHandles.privateLookupIn(MethodCallBlocker.class, MethodHandles.lookup())))
                 .getLoaded();
 
             final MethodCallHandler methodCallHandler = new MethodCallHandler();
@@ -131,6 +133,10 @@ public final class MethodCallBlocker
             methodCallHandler.transformer(transformer);
 
             return methodCallHandler;
+        }
+        catch (final IllegalAccessException exception)
+        {
+            throw new RuntimeException(exception);
         }
     }
 

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/SingleNodeTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/SingleNodeTest.java
@@ -18,17 +18,23 @@ package io.aeron.cluster;
 import io.aeron.archive.Archive;
 import io.aeron.archive.ArchivingMediaDriver;
 import io.aeron.archive.client.AeronArchive;
+import io.aeron.cluster.client.AeronCluster;
 import io.aeron.cluster.service.Cluster;
+import io.aeron.driver.DriverConductorProxy;
 import io.aeron.driver.MediaDriver;
+import io.aeron.driver.ThreadingMode;
 import io.aeron.samples.archive.RecordingDescriptor;
 import io.aeron.samples.archive.RecordingDescriptorCollector;
 import io.aeron.test.EventLogExtension;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SlowTest;
 import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.TestContexts;
 import io.aeron.test.cluster.TestCluster;
 import io.aeron.test.cluster.TestNode;
+import io.aeron.test.driver.TestMediaDriver;
+import org.agrona.CloseHelper;
 import org.agrona.concurrent.SystemEpochClock;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -168,6 +174,64 @@ class SingleNodeTest
         cluster.startStaticNode(0, false);
         final TestNode newLeader = cluster.awaitLeader();
         cluster.awaitServiceMessageCount(newLeader, largeMessageCount);
+    }
+
+    @Test
+    @SlowTest
+    @InterruptAfter(20)
+    void shouldReattemptEgressSubscriptionCreationOnTransientError()
+    {
+        TestMediaDriver.notSupportedOnCMediaDriver("uses instrumentation to simulate race condition");
+
+        final MethodCallBlocker methodCallBlocker = new MethodCallBlocker();
+
+        try
+        {
+            final TestCluster cluster = aCluster().withStaticNodes(1).start();
+            systemTestWatcher.cluster(cluster);
+
+            final TestNode leader = cluster.awaitLeader();
+
+            assertEquals(0, leader.index());
+            assertEquals(Cluster.Role.LEADER, leader.role());
+
+            cluster.clientThreadingMode(ThreadingMode.DEDICATED);
+            cluster.egressChannel("aeron:udp?term-length=128k|endpoint=localhost:30000|alias=egress");
+            final AeronCluster client = cluster.connectClient();
+
+            final MethodCallBlocker.Controller receiveChannelEndpointClosedController =
+                methodCallBlocker.getControllerFor(
+                    DriverConductorProxy.class.getCanonicalName(),
+                    "receiveChannelEndpointClosed",
+                    "receiver"
+                );
+
+            receiveChannelEndpointClosedController.blockNextEntry();
+            client.close();
+            receiveChannelEndpointClosedController.awaitBlocked();
+
+            final TestMediaDriver clientDriver = cluster.startClientMediaDriver();
+            final AeronCluster.Context context = cluster.clientCtx()
+                .aeronDirectoryName(clientDriver.aeronDirectoryName());
+            try (AeronCluster.AsyncConnect asyncConnect = AeronCluster.asyncConnect(context))
+            {
+                AeronCluster client2;
+                int iterations = 0;
+                while (null == (client2 = asyncConnect.poll()))
+                {
+                    if (++iterations == 10)
+                    {
+                        receiveChannelEndpointClosedController.release();
+                    }
+                    Thread.yield();
+                }
+                CloseHelper.close(client2);
+            }
+        }
+        finally
+        {
+            methodCallBlocker.removeInstrumentation();
+        }
     }
 
     private void truncateRecordingToTermLength(final String aeronDirectoryName, final File archiveDir)

--- a/aeron-system-tests/src/test/java/io/aeron/driver/SocketLifecycleTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/driver/SocketLifecycleTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2014-2025 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.driver;
+
+import io.aeron.Aeron;
+import io.aeron.AeronCounters;
+import io.aeron.CommonContext;
+import io.aeron.ErrorCode;
+import io.aeron.Subscription;
+import io.aeron.exceptions.RegistrationException;
+import io.aeron.test.EventLogExtension;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SystemTestWatcher;
+import io.aeron.test.Tests;
+import io.aeron.test.driver.TestMediaDriver;
+import org.agrona.concurrent.NoOpIdleStrategy;
+import org.agrona.concurrent.SleepingMillisIdleStrategy;
+import org.agrona.concurrent.status.CountersReader;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+@ExtendWith({ EventLogExtension.class, InterruptingTestCallback.class })
+class SocketLifecycleTest
+{
+    private static final int TEST_ITERATION_COUNT = 10;
+
+    @RegisterExtension
+    final SystemTestWatcher systemTestWatcher = new SystemTestWatcher();
+
+    @Test
+    @InterruptAfter(10)
+    void supportsClosingOpeningSubscriptionWithSameChannelUri0()
+    {
+        try (TestMediaDriver driver = launchDriver();
+            Aeron aeron = Aeron.connect(new Aeron.Context().aeronDirectoryName(driver.aeronDirectoryName())))
+        {
+            final CountersReader countersReader = aeron.countersReader();
+
+            for (int i = 0; i < TEST_ITERATION_COUNT; i++)
+            {
+                final Subscription subscription = aeron.addSubscription(
+                    "aeron:udp?endpoint=localhost:10000", 1000);
+                final int counterId = subscription.channelStatusId();
+                final long registrationId = countersReader.getCounterRegistrationId(counterId);
+                assertEquals(subscription.registrationId(), registrationId);
+                subscription.close();
+                while (registrationId == countersReader.getCounterRegistrationId(counterId) &&
+                    CountersReader.RECORD_ALLOCATED == countersReader.getCounterState(counterId))
+                {
+                    Tests.yield();
+                }
+            }
+
+            assertEquals(0, errorCount(aeron));
+        }
+    }
+
+    @Test
+    @InterruptAfter(10)
+    void supportsClosingOpeningSubscriptionWithSameChannelUri1()
+    {
+        int unavailableCount = 0;
+        try (TestMediaDriver driver = launchDriver();
+            Aeron aeron = Aeron.connect(new Aeron.Context().aeronDirectoryName(driver.aeronDirectoryName())))
+        {
+            for (int i = 0; i < TEST_ITERATION_COUNT; i++)
+            {
+                Subscription subscription = null;
+                while (null == subscription)
+                {
+                    try
+                    {
+                        subscription = aeron.addSubscription("aeron:udp?endpoint=localhost:10000", 1000);
+                    }
+                    catch (final RegistrationException exception)
+                    {
+                        if (ErrorCode.RESOURCE_TEMPORARILY_UNAVAILABLE == exception.errorCode())
+                        {
+                            ++unavailableCount;
+                            Tests.yield();
+                        }
+                        else
+                        {
+                            throw exception;
+                        }
+                    }
+                }
+                subscription.close();
+            }
+
+            assumeTrue(unavailableCount > 0, "Expected at least one RESOURCE_TEMPORARILY_UNAVAILABLE exception");
+            assertEquals(0, errorCount(aeron));
+        }
+    }
+
+    private TestMediaDriver launchDriver()
+    {
+        TestMediaDriver.notSupportedOnCMediaDriver("C Media Driver requires more work");
+
+        final String aeronDirectoryName = CommonContext.generateRandomDirName();
+
+        final MediaDriver.Context driverCtx = new MediaDriver.Context()
+            .aeronDirectoryName(aeronDirectoryName)
+            .termBufferSparseFile(true)
+            .threadingMode(ThreadingMode.DEDICATED)
+            .dirDeleteOnStart(true)
+            .conductorIdleStrategy(new NoOpIdleStrategy())
+            .receiverIdleStrategy(new SleepingMillisIdleStrategy(2))
+            .senderIdleStrategy(new SleepingMillisIdleStrategy(2));
+
+        final TestMediaDriver driver = TestMediaDriver.launch(driverCtx, systemTestWatcher);
+
+        systemTestWatcher.dataCollector().add(driver.context().aeronDirectory());
+
+        return driver;
+    }
+
+    private static long errorCount(final Aeron aeron)
+    {
+        final CountersReader countersReader = aeron.countersReader();
+        final int counterId = countersReader.findByTypeIdAndRegistrationId(
+            AeronCounters.DRIVER_SYSTEM_COUNTER_TYPE_ID,
+            AeronCounters.SYSTEM_COUNTER_ID_ERRORS);
+        return countersReader.getCounterValue(counterId);
+    }
+}

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
@@ -192,6 +192,7 @@ public final class TestCluster implements AutoCloseable
     private SendChannelEndpointSupplier clientSendChannelEndpointSupplier;
     private ReceiveChannelEndpointSupplier clientReceiveChannelEndpointSupplier;
     private long clientImageLivenessTimeoutNs = Configuration.imageLivenessTimeoutNs();
+    private ThreadingMode clientThreadingMode = ThreadingMode.SHARED;
     private TestMediaDriver clientMediaDriver;
     private AeronCluster client;
     private TestBackupNode backupNode;
@@ -774,6 +775,11 @@ public final class TestCluster implements AutoCloseable
         this.clientImageLivenessTimeoutNs = clientImageLivenessTimeoutNs;
     }
 
+    public void clientThreadingMode(final ThreadingMode threadingMode)
+    {
+        this.clientThreadingMode = threadingMode;
+    }
+
     public AeronCluster client()
     {
         return client;
@@ -914,7 +920,7 @@ public final class TestCluster implements AutoCloseable
         dataCollector.add(Paths.get(aeronDirName));
 
         return new MediaDriver.Context()
-            .threadingMode(ThreadingMode.SHARED)
+            .threadingMode(clientThreadingMode)
             .dirDeleteOnStart(true)
             .dirDeleteOnShutdown(true)
             .aeronDirectoryName(aeronDirName)


### PR DESCRIPTION
CHANGE TO SUBSCRIPTIONS
-----------------------

In 1.49, we started to align the socket opening with the C driver, by moving the socket opening onto the conductor thread, but we left socket closing on the receiver thread. Therefore, it was possible that a REMOVE_SUBSCRIPTION command was not "finished" by the time the conductor started to process the subsequent ADD_SUBSCRIPTION and could result in a bind error.  In a recent commit, we started to align the Java driver with the C driver. It now opens and closes sockets within the conductor agent. As discussed in the previous commit, the flow now looks like this:

```
Client -> Conductor: Remove Subscription
Conductor -> Receiver: Stop using associated sockets
Receiver -> Conductor: I've stopped using the associated sockets
Conductor -> Receiver: Stop using associated sockets
Receiver -> Conductor: I've stopped using the associated sockets
Conductor: closes sockets
Conductor: closes status indicator
Conductor -> Client: operation completed
```

However, this change was not sufficient to prevent bind conflicts, as it was possible to see commands like ADD_SUBSCRIPTION interleaved. For example:

```
Client -> Conductor: Remove Subscription
Conductor -> Receiver: Stop using associated sockets
Client -> Conductor: Add Subscription
Conductor: bind exception
```

In the Java driver, we now set the endpoints statusIndictor counter's to CLOSING to indicate that it should not be reused. The driver also detects this state when adding a subscription and sends a RESOURCE_TEMPORARILY_UNAVAILABLE error back to the client. This matches the C driver behaviour.

```
Client -> Conductor: Remove Subscription
Conductor: Send endpoint status to CLOSING
Conductor -> Receiver: Stop using associated sockets
Client -> Conductor: Add Subscription
		 FAILURE when opening socket with same port
Conductor: Find endpoint with CLOSING status.
Conductor -> Client: Error RESOURCE_TEMPORARILY_UNAVAILABLE
```

There are now two ways to safely close and reopen a subscription for the same channel:

1. Wait for the Subscription's channel status indicator to disappear after closing, before reopening. N.b., this only works when the closed subscription is the sole user of the endpoint.

2. Catch `RegistrationException` when opening a subscription and retry on `errorCode == RESOURCE_TEMPORARILY_UNAVAILABLE`.

Ideally, it would be possible to hide this complexity from the user, but that would be a far more involved change.

---

CHANGE TO AERON CLUSTER CLIENTS
-------------------------------

One place where users are likely to run into this issue is when creating a new AeronCluster session, for example, after a session timeout. To improve usability of AeronCluster, we now handle
RESOURCE_TEMPORARILY_UNAVAILABLE when creating the egress publication.

---

PUBLICATIONS NOT FIXED
----------------------

There are similar problems around publications in the Java media driver; however, these are harder to fix, due to the way the endpoint enters the equivalent CLOSING state on a time event, rather than due to a publication removal.

There are also complications when it comes to recreating a publication with the same explicit session-id, as one needs to consider the lifetime of the entries in the collection used to prevent session clashes.

---

OTHER TIDBITS
-------------

We discovered some issues/surprises on our journey:

1. The channel status indicator counter is created the first time an endpoint is created with the registrationId of its initial resource, but the endpoint could be reused and the initial resource may be closed; therefore, it is not obviously correct to look up the channel status indicator by registrationId, as we do in some places. Instead, one should use Subscription#channelStatusId to get the relevant counter identifier.

2. There are still conflicts when removing and adding MDS destinations that map onto the same socket bind address.

3. The C driver uses different channel endpoint status indicator values.