### PR TITLE
[C] Improve loss detection and recovery

### DIFF
--- a/aeron-client/src/main/c/CMakeLists.txt
+++ b/aeron-client/src/main/c/CMakeLists.txt
@@ -120,6 +120,7 @@ set(SOURCE
     concurrent/aeron_mpsc_concurrent_array_queue.c
     concurrent/aeron_mpsc_rb.c
     concurrent/aeron_spsc_concurrent_array_queue.c
+    concurrent/aeron_spsc_concurrent_array_queue_elem.c
     concurrent/aeron_spsc_rb.c
     concurrent/aeron_term_gap_filler.c
     concurrent/aeron_term_gap_scanner.c

--- a/aeron-client/src/main/c/concurrent/aeron_spsc_concurrent_array_queue_elem.c
+++ b/aeron-client/src/main/c/concurrent/aeron_spsc_concurrent_array_queue_elem.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2014-2025 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "aeron_alloc.h"
+#include "concurrent/aeron_spsc_concurrent_array_queue_elem.h"
+
+int aeron_spsc_concurrent_array_queue_elem_init(aeron_spsc_concurrent_array_queue_elem_t *queue, size_t length, size_t elem_size)
+{
+    length = (size_t)aeron_find_next_power_of_two((int32_t)length);
+
+    if (aeron_alloc((void **)&queue->buffer, length * elem_size) < 0)
+    {
+        return -1;
+    }
+
+    memset((void *)queue->buffer, 0, length * elem_size);
+
+    queue->capacity = length;
+    queue->mask = length - 1;
+    queue->elem_size = elem_size;
+    queue->producer.head_cache = 0;
+    AERON_SET_RELEASE(queue->producer.tail, (uint64_t)0);
+    AERON_SET_RELEASE(queue->consumer.head, (uint64_t)0);
+
+    return 0;
+}
+
+int aeron_spsc_concurrent_array_queue_elem_close(aeron_spsc_concurrent_array_queue_elem_t *queue)
+{
+    aeron_free((void *)queue->buffer);
+    return 0;
+}
+
+extern aeron_queue_offer_result_t aeron_spsc_concurrent_array_queue_elem_offer(
+    aeron_spsc_concurrent_array_queue_elem_t *queue, void *element);
+
+extern bool aeron_spsc_concurrent_array_queue_elem_poll(aeron_spsc_concurrent_array_queue_elem_t *queue, void *dest);
+
+extern size_t aeron_spsc_concurrent_array_queue_elem_drain(
+    aeron_spsc_concurrent_array_queue_elem_t *queue, aeron_queue_drain_func_t func, void *clientd, size_t limit);
+
+extern size_t aeron_spsc_concurrent_array_queue_elem_drain_all(
+    aeron_spsc_concurrent_array_queue_elem_t *queue, aeron_queue_drain_func_t func, void *clientd);
+
+extern size_t aeron_spsc_concurrent_array_queue_elem_size(aeron_spsc_concurrent_array_queue_elem_t *queue);

--- a/aeron-client/src/main/c/concurrent/aeron_spsc_concurrent_array_queue_elem.h
+++ b/aeron-client/src/main/c/concurrent/aeron_spsc_concurrent_array_queue_elem.h
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2014-2025 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef AERON_SPSC_CONCURRENT_ARRAY_QUEUE_ELEM_H
+#define AERON_SPSC_CONCURRENT_ARRAY_QUEUE_ELEM_H
+
+#include <string.h>
+
+#include "util/aeron_bitutil.h"
+#include "aeron_atomic.h"
+#include "aeron_concurrent_array_queue.h"
+
+typedef struct aeron_spsc_concurrent_array_queue_elem_stct
+{
+
+    int8_t padding1[AERON_CACHE_LINE_LENGTH];
+
+    struct
+    {
+        volatile uint64_t tail;
+        uint64_t head_cache;
+    } producer;
+
+    int8_t padding2[AERON_CACHE_LINE_LENGTH];
+
+    struct
+    {
+        volatile uint64_t head;
+    } consumer;
+
+    int8_t padding3[AERON_CACHE_LINE_LENGTH];
+
+    size_t capacity;
+    size_t mask;
+    size_t elem_size;
+    uint8_t *buffer;
+} aeron_spsc_concurrent_array_queue_elem_t;
+
+int aeron_spsc_concurrent_array_queue_elem_init(aeron_spsc_concurrent_array_queue_elem_t *queue, size_t length, size_t elem_size);
+
+int aeron_spsc_concurrent_array_queue_elem_close(aeron_spsc_concurrent_array_queue_elem_t *queue);
+
+inline aeron_queue_offer_result_t aeron_spsc_concurrent_array_queue_elem_offer(
+    aeron_spsc_concurrent_array_queue_elem_t *queue, void *element)
+{
+    if (NULL == element)
+    {
+        return AERON_OFFER_ERROR;
+    }
+
+    uint64_t current_head = queue->producer.head_cache;
+    uint64_t buffer_limit = current_head + queue->capacity;
+    uint64_t current_tail = queue->producer.tail;
+
+    if (current_tail >= buffer_limit)
+    {
+        AERON_GET_ACQUIRE(current_head, queue->consumer.head);
+        buffer_limit = current_head + queue->capacity;
+
+        if (current_tail >= buffer_limit)
+        {
+            return AERON_OFFER_FULL;
+        }
+
+        queue->producer.head_cache = current_head;
+    }
+
+    const size_t index = (size_t)(current_tail & queue->mask);
+
+    memcpy((void *)(queue->buffer + index * queue->elem_size), element, queue->elem_size);
+    AERON_SET_RELEASE(queue->producer.tail, current_tail + 1);
+
+    return AERON_OFFER_SUCCESS;
+}
+
+inline bool aeron_spsc_concurrent_array_queue_elem_poll(aeron_spsc_concurrent_array_queue_elem_t *queue, void *dest)
+{
+    const uint64_t current_head = queue->consumer.head;
+
+    uint64_t current_tail;
+    AERON_GET_ACQUIRE(current_tail, queue->producer.tail);
+
+    if (current_tail <= current_head)
+    {
+        return false;
+    }
+
+    const size_t index = (size_t)(current_head & queue->mask);
+
+    memcpy(dest, (void *)(queue->buffer + index * queue->elem_size), queue->elem_size);
+    AERON_SET_RELEASE(queue->consumer.head, current_head + 1);
+
+    return true;
+}
+
+inline size_t aeron_spsc_concurrent_array_queue_elem_drain(
+    aeron_spsc_concurrent_array_queue_elem_t *queue, aeron_queue_drain_func_t func, void *clientd, size_t limit)
+{
+    const uint64_t current_head = queue->consumer.head;
+    uint64_t current_tail;
+    AERON_GET_ACQUIRE(current_tail, queue->producer.tail);
+
+    const uint64_t limit_sequence = current_tail - current_head > limit ? current_head + limit : current_tail;
+
+    for (uint64_t next_sequence = current_head; next_sequence < limit_sequence;)
+    {
+        const size_t index = (size_t)(next_sequence & queue->mask);
+
+        func(clientd, (void *)(queue->buffer + index * queue->elem_size));
+
+        next_sequence++;
+        AERON_SET_RELEASE(queue->consumer.head, next_sequence);
+    }
+
+    return limit_sequence - current_head;
+}
+
+inline size_t aeron_spsc_concurrent_array_queue_elem_drain_all(
+    aeron_spsc_concurrent_array_queue_elem_t *queue, aeron_queue_drain_func_t func, void *clientd)
+{
+    return aeron_spsc_concurrent_array_queue_elem_drain(queue, func, clientd, SIZE_MAX);
+}
+
+inline size_t aeron_spsc_concurrent_array_queue_elem_size(aeron_spsc_concurrent_array_queue_elem_t *queue)
+{
+    uint64_t current_head_before;
+    uint64_t current_tail;
+    uint64_t current_head_after;
+
+    AERON_GET_ACQUIRE(current_head_after, queue->consumer.head);
+
+    do
+    {
+        current_head_before = current_head_after;
+        AERON_GET_ACQUIRE(current_tail, queue->producer.tail);
+        AERON_GET_ACQUIRE(current_head_after, queue->consumer.head);
+    } while (current_head_after != current_head_before);
+
+    size_t size = (size_t)(current_tail - current_head_after);
+    if ((int64_t)size < 0)
+    {
+        return 0;
+    }
+    else if (size > queue->capacity)
+    {
+        return queue->capacity;
+    }
+
+    return size;
+}
+
+#endif // AERON_SPSC_CONCURRENT_ARRAY_QUEUE_ELEM_H

--- a/aeron-client/src/main/c/concurrent/aeron_term_gap_scanner.c
+++ b/aeron-client/src/main/c/concurrent/aeron_term_gap_scanner.c
@@ -18,8 +18,6 @@
 
 extern int32_t aeron_term_gap_scanner_scan_for_gap(
     const uint8_t *buffer,
-    int32_t term_id,
-    int32_t term_offset,
+    int32_t offset,
     int32_t limit_offset,
-    aeron_term_gap_scanner_on_gap_detected_func_t on_gap_detected,
-    void *clientd);
+    int32_t *gap_length);

--- a/aeron-client/src/main/c/concurrent/aeron_term_gap_scanner.h
+++ b/aeron-client/src/main/c/concurrent/aeron_term_gap_scanner.h
@@ -21,37 +21,35 @@
 #include "util/aeron_bitutil.h"
 #include "aeron_logbuffer_descriptor.h"
 
-typedef void (*aeron_term_gap_scanner_on_gap_detected_func_t)(void *clientd, int32_t term_id, int32_t term_offset, size_t length);
-
 inline int32_t aeron_term_gap_scanner_scan_for_gap(
     const uint8_t *buffer,
-    int32_t term_id,
-    int32_t term_offset,
+    int32_t offset,
     int32_t limit_offset,
-    aeron_term_gap_scanner_on_gap_detected_func_t on_gap_detected,
-    void *clientd)
+    int32_t *gap_length)
 {
-    int32_t offset = term_offset;
-
     do
     {
         aeron_frame_header_t *hdr = (aeron_frame_header_t *)(buffer + offset);
         int32_t frame_length;
 
         AERON_GET_ACQUIRE(frame_length, hdr->frame_length);
-        if (frame_length <= 0)
+        if (frame_length == 0)
         {
             break;
         }
 
+        if (frame_length < 0)
+        {
+            frame_length = -frame_length;
+        }
+
         offset += AERON_ALIGN(frame_length, AERON_LOGBUFFER_FRAME_ALIGNMENT);
-    }
-    while (offset < limit_offset);
+    } while (offset < limit_offset);
 
     const int32_t gap_begin_offset = offset;
-    if (offset < limit_offset)
+    if (gap_begin_offset < limit_offset)
     {
-        offset += AERON_DATA_HEADER_LENGTH;
+        offset = gap_begin_offset + AERON_DATA_HEADER_LENGTH;
         while (offset < limit_offset)
         {
             aeron_frame_header_t *hdr = (aeron_frame_header_t *)(buffer + offset);
@@ -65,11 +63,35 @@ inline int32_t aeron_term_gap_scanner_scan_for_gap(
             offset += AERON_DATA_HEADER_LENGTH;
         }
 
-        const size_t gap_length = offset - gap_begin_offset;
-        on_gap_detected(clientd, term_id, gap_begin_offset, gap_length);
+        const int32_t next_frame_offset = offset;
+
+        // we loop again to make sure this is indeed the next frame header
+
+        offset = gap_begin_offset + AERON_DATA_HEADER_LENGTH;
+        while (offset < limit_offset)
+        {
+            aeron_frame_header_t *hdr = (aeron_frame_header_t *)(buffer + offset);
+            int32_t frame_length;
+            AERON_GET_ACQUIRE(frame_length, hdr->frame_length);
+
+            if (0 != frame_length)
+            {
+                break;
+            }
+            offset += AERON_DATA_HEADER_LENGTH;
+        }
+
+        if (next_frame_offset != offset)
+        {
+            // we failed to find next_frame_offset due to concurrent changes
+            // will try next time
+            return -1;
+        }
+
+        *gap_length = next_frame_offset - gap_begin_offset;
     }
 
     return gap_begin_offset;
 }
 
-#endif //AERON_TERM_GAP_SCANNER_H
+#endif // AERON_TERM_GAP_SCANNER_H

--- a/aeron-client/src/main/c/concurrent/aeron_term_rebuilder.h
+++ b/aeron-client/src/main/c/concurrent/aeron_term_rebuilder.h
@@ -20,22 +20,34 @@
 #include <string.h>
 #include "protocol/aeron_udp_protocol.h"
 #include "aeron_atomic.h"
+#include "aeron_logbuffer_descriptor.h"
 
 inline void aeron_term_rebuilder_insert(uint8_t *dest, const uint8_t *src, size_t length)
 {
-    aeron_data_header_t *hdr_dest = (aeron_data_header_t *)dest;
-    aeron_data_header_as_longs_t *dest_hdr_as_longs = (aeron_data_header_as_longs_t *)dest;
-    aeron_data_header_as_longs_t *src_hdr_as_longs = (aeron_data_header_as_longs_t *)src;
-
-    if (0 == hdr_dest->frame_header.frame_length)
+    for (size_t offset = 0; offset < length;)
     {
-        memcpy(dest + AERON_DATA_HEADER_LENGTH, src + AERON_DATA_HEADER_LENGTH, length - AERON_DATA_HEADER_LENGTH);
+        aeron_data_header_t *src_hdr = (aeron_data_header_t *)(src + offset);
+        aeron_data_header_t *dest_hdr = (aeron_data_header_t *)(dest + offset);
+        aeron_data_header_as_longs_t *src_hdr_as_longs = (aeron_data_header_as_longs_t *)(src + offset);
+        aeron_data_header_as_longs_t *dest_hdr_as_longs = (aeron_data_header_as_longs_t *)(dest + offset);
 
-        dest_hdr_as_longs->hdr[3] = src_hdr_as_longs->hdr[3];
-        dest_hdr_as_longs->hdr[2] = src_hdr_as_longs->hdr[2];
-        dest_hdr_as_longs->hdr[1] = src_hdr_as_longs->hdr[1];
+        int32_t frame_length = src_hdr->frame_header.frame_length;
 
-        AERON_SET_RELEASE(dest_hdr_as_longs->hdr[0], src_hdr_as_longs->hdr[0]);
+        if (0 == dest_hdr->frame_header.frame_length)
+        {
+            AERON_SET_RELEASE(dest_hdr->frame_header.frame_length, (-(int32_t)frame_length));
+            aeron_release();
+
+            memcpy(dest + offset + AERON_DATA_HEADER_LENGTH, src + offset + AERON_DATA_HEADER_LENGTH, frame_length - AERON_DATA_HEADER_LENGTH);
+
+            dest_hdr_as_longs->hdr[3] = src_hdr_as_longs->hdr[3];
+            dest_hdr_as_longs->hdr[2] = src_hdr_as_longs->hdr[2];
+            dest_hdr_as_longs->hdr[1] = src_hdr_as_longs->hdr[1];
+
+            AERON_SET_RELEASE(dest_hdr_as_longs->hdr[0], src_hdr_as_longs->hdr[0]);
+        }
+
+        offset += AERON_ALIGN(frame_length, AERON_LOGBUFFER_FRAME_ALIGNMENT);
     }
 }
 

--- a/aeron-client/src/test/c/CMakeLists.txt
+++ b/aeron-client/src/test/c/CMakeLists.txt
@@ -51,6 +51,7 @@ if (AERON_UNIT_TESTS)
     set_tests_properties(distinct_error_log_test PROPERTIES RUN_SERIAL TRUE)
 
     aeron_c_client_test(spsc_concurrent_array_queue_test concurrent/aeron_spsc_concurrent_array_queue_test.cpp)
+    aeron_c_client_test(spsc_concurrent_array_queue_elem_test concurrent/aeron_spsc_concurrent_array_queue_elem_test.cpp)
     aeron_c_client_test(mpsc_concurrent_array_queue_test concurrent/aeron_mpsc_concurrent_array_queue_test.cpp)
     aeron_c_client_test(linked_queue_test collections/aeron_linked_queue_test.cpp)
     aeron_c_client_test(blocking_linked_queue_test concurrent/aeron_blocking_linked_queue_test.cpp)

--- a/aeron-client/src/test/c/concurrent/aeron_spsc_concurrent_array_queue_elem_test.cpp
+++ b/aeron-client/src/test/c/concurrent/aeron_spsc_concurrent_array_queue_elem_test.cpp
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2014-2025 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <array>
+#include <cstdint>
+#include <thread>
+#include <atomic>
+#include <functional>
+
+#include <gtest/gtest.h>
+
+extern "C"
+{
+#include "concurrent/aeron_spsc_concurrent_array_queue_elem.h"
+}
+
+#define CAPACITY (8u)
+
+struct elem_t
+{
+    int32_t a;
+    int64_t b;
+};
+
+
+class SpscQueueElemTest : public testing::Test
+{
+public:
+    SpscQueueElemTest()
+    {
+        if (aeron_spsc_concurrent_array_queue_elem_init(&m_q, CAPACITY, sizeof(elem_t)) < 0)
+        {
+            throw std::runtime_error("could not init q");
+        }
+    }
+
+    ~SpscQueueElemTest() override
+    {
+        aeron_spsc_concurrent_array_queue_elem_close(&m_q);
+    }
+
+    static void drain_func(void *clientd, void *element)
+    {
+        auto *t = (SpscQueueElemTest *)clientd;
+
+        (*t).m_drain(element);
+    }
+
+    void fillQueue()
+    {
+        for (size_t i = 1; i <= CAPACITY; i++)
+        {
+            elem_t elem = { .a = (int32_t) i, .b = (int64_t) i * 7 };
+            ASSERT_EQ(aeron_spsc_concurrent_array_queue_elem_offer(&m_q, &elem), AERON_OFFER_SUCCESS);
+        }
+    }
+
+protected:
+    aeron_spsc_concurrent_array_queue_elem_t m_q = {};
+    std::function<void(volatile void *)> m_drain;
+};
+
+TEST_F(SpscQueueElemTest, shouldGetSizeWhenEmpty)
+{
+    EXPECT_EQ(aeron_spsc_concurrent_array_queue_elem_size(&m_q), 0u);
+}
+
+TEST_F(SpscQueueElemTest, shouldReturnErrorWhenNullOffered)
+{
+    EXPECT_EQ(aeron_spsc_concurrent_array_queue_elem_offer(&m_q, nullptr), AERON_OFFER_ERROR);
+}
+
+TEST_F(SpscQueueElemTest, shouldOfferAndDrainToEmptyQueue)
+{
+    elem_t element = { .a = 1, .b = 2 };
+
+    EXPECT_EQ(aeron_spsc_concurrent_array_queue_elem_offer(&m_q, (void *)&element), AERON_OFFER_SUCCESS);
+    EXPECT_EQ(aeron_spsc_concurrent_array_queue_elem_size(&m_q), 1u);
+
+    m_drain =
+        [&](volatile void *e)
+        {
+            elem_t* actual = (elem_t*) e;
+            ASSERT_EQ(actual->a, element.a);
+            ASSERT_EQ(actual->b, element.b);
+        };
+
+    EXPECT_EQ(aeron_spsc_concurrent_array_queue_elem_drain(&m_q, SpscQueueElemTest::drain_func, this, UINT64_MAX), 1u);
+}
+
+TEST_F(SpscQueueElemTest, shouldFailToOfferToFullQueue)
+{
+    elem_t element;
+
+    fillQueue();
+    EXPECT_EQ(aeron_spsc_concurrent_array_queue_elem_size(&m_q), CAPACITY);
+    EXPECT_EQ(aeron_spsc_concurrent_array_queue_elem_offer(&m_q, (void *)&element), AERON_OFFER_FULL);
+}
+
+TEST_F(SpscQueueElemTest, shouldDrainSingleElementFromFullQueue)
+{
+    fillQueue();
+
+    m_drain =
+        [&](volatile void *e)
+        {
+            elem_t* element = (elem_t*) e;
+            ASSERT_EQ(element->a, 1);
+            ASSERT_EQ(element->b, 7);
+        };
+
+    EXPECT_EQ(aeron_spsc_concurrent_array_queue_elem_drain(&m_q, SpscQueueElemTest::drain_func, this, 1), 1u);
+    EXPECT_EQ(aeron_spsc_concurrent_array_queue_elem_size(&m_q), CAPACITY - 1);
+}
+
+TEST_F(SpscQueueElemTest, shouldDrainNothingFromEmptyQueue)
+{
+    m_drain =
+        [&](volatile void *e)
+        {
+            FAIL();
+        };
+
+    EXPECT_EQ(aeron_spsc_concurrent_array_queue_elem_drain(&m_q, SpscQueueElemTest::drain_func, this, UINT64_MAX), 0u);
+}
+
+TEST_F(SpscQueueElemTest, shouldDrainFullQueue)
+{
+    fillQueue();
+
+    int64_t counter = 1;
+    m_drain =
+        [&](volatile void *e)
+        {
+            elem_t* element = (elem_t*) e;
+            ASSERT_EQ(element->a, counter);
+            ASSERT_EQ(element->b, counter * 7);
+            counter++;
+        };
+
+    EXPECT_EQ(aeron_spsc_concurrent_array_queue_elem_drain(&m_q, SpscQueueElemTest::drain_func, this, UINT64_MAX), CAPACITY);
+    EXPECT_EQ(aeron_spsc_concurrent_array_queue_elem_size(&m_q), 0u);
+}
+
+TEST_F(SpscQueueElemTest, shouldDrainingFullQueueWithLimit)
+{
+    size_t limit = CAPACITY / 2;
+    fillQueue();
+
+    int64_t counter = 1;
+    m_drain =
+        [&](volatile void *e)
+        {
+            elem_t* element = (elem_t*) e;
+            ASSERT_EQ(element->a, counter);
+            ASSERT_EQ(element->b, counter * 7);
+            counter++;
+        };
+
+    EXPECT_EQ(aeron_spsc_concurrent_array_queue_elem_drain(&m_q, SpscQueueElemTest::drain_func, this, limit), limit);
+    EXPECT_EQ(aeron_spsc_concurrent_array_queue_elem_size(&m_q), CAPACITY - limit);
+}
+
+#define NUM_MESSAGES (10 * 1000 * 1000)
+
+static void spsc_queue_concurrent_elem_handler(void *clientd, void *element)
+{
+    auto *counts = (size_t *)clientd;
+    auto elem = (elem_t*)element;
+
+    EXPECT_EQ(++(*counts), (size_t)elem->b);
+}
+
+TEST(SpscQueueElemConcurrentTest, shouldExchangeMessages)
+{
+    aeron_spsc_concurrent_array_queue_elem_t q;
+    ASSERT_EQ(aeron_spsc_concurrent_array_queue_elem_init(&q, CAPACITY, sizeof(elem_t)), 0);
+
+    std::atomic<int> countDown(1);
+
+    std::vector<std::thread> threads;
+    size_t msgCount = 0;
+    size_t counts = 0;
+
+    threads.push_back(std::thread(
+        [&]()
+        {
+            countDown--;
+            while (countDown > 0)
+            {
+                std::this_thread::yield();
+            }
+
+            for (uint64_t m = 1; m <= NUM_MESSAGES; m++)
+            {
+                elem_t e = { .b = (int64_t) m };
+                while (AERON_OFFER_SUCCESS != aeron_spsc_concurrent_array_queue_elem_offer(&q, (void *)&e))
+                {
+                    std::this_thread::yield();
+                }
+            }
+        }));
+
+    while (msgCount < NUM_MESSAGES)
+    {
+        const size_t drainCount = aeron_spsc_concurrent_array_queue_elem_drain_all(
+            &q, spsc_queue_concurrent_elem_handler, &counts);
+
+        if (0 == drainCount)
+        {
+            std::this_thread::yield();
+        }
+
+        msgCount += drainCount;
+    }
+
+    for (std::thread &t: threads)
+    {
+        if (t.joinable())
+        {
+            t.join();
+        }
+    }
+
+    aeron_spsc_concurrent_array_queue_elem_close(&q);
+}

--- a/aeron-driver/src/main/c/CMakeLists.txt
+++ b/aeron-driver/src/main/c/CMakeLists.txt
@@ -157,6 +157,7 @@ SET(C_CLIENT_SOURCE
     ${AERON_C_CLIENT_SOURCE_PATH}/concurrent/aeron_mpsc_concurrent_array_queue.c
     ${AERON_C_CLIENT_SOURCE_PATH}/concurrent/aeron_mpsc_rb.c
     ${AERON_C_CLIENT_SOURCE_PATH}/concurrent/aeron_spsc_concurrent_array_queue.c
+    ${AERON_C_CLIENT_SOURCE_PATH}/concurrent/aeron_spsc_concurrent_array_queue_elem.c
     ${AERON_C_CLIENT_SOURCE_PATH}/concurrent/aeron_spsc_rb.c
     ${AERON_C_CLIENT_SOURCE_PATH}/concurrent/aeron_term_gap_filler.c
     ${AERON_C_CLIENT_SOURCE_PATH}/concurrent/aeron_term_gap_scanner.c

--- a/aeron-driver/src/main/c/aeron_loss_detector.c
+++ b/aeron-driver/src/main/c/aeron_loss_detector.c
@@ -24,27 +24,104 @@
 #include "aeronmd.h"
 #include "aeron_windows.h"
 #include "aeron_loss_detector.h"
+#include "aeron_alloc.h"
+#include "util/aeron_error.h"
 
 int aeron_loss_detector_init(
     aeron_loss_detector_t *detector,
     aeron_feedback_delay_generator_state_t *feedback_delay_state,
-    aeron_term_gap_scanner_on_gap_detected_func_t on_gap_detected,
+    aeron_loss_detector_on_gap_detected_func_t on_gap_detected,
     void *on_gap_detected_clientd)
 {
     detector->on_gap_detected = on_gap_detected;
     detector->on_gap_detected_clientd = on_gap_detected_clientd;
-    detector->expiry_ns = AERON_LOSS_DETECTOR_TIMER_INACTIVE;
-    detector->active_gap.term_offset = -1;
-    detector->scanned_gap.term_offset = -1;
     detector->feedback_delay_state = feedback_delay_state;
+    detector->gaps = NULL;
+    detector->gaps_count = 0;
+    detector->tmp_gaps = NULL;
+
+    if (aeron_alloc((void **)&detector->gaps, AERON_LOSS_DETECTOR_MAX_LOSSES * sizeof(aeron_loss_detector_gap_t)) < 0)
+    {
+        AERON_APPEND_ERR("%s", "Unable to alloc gaps");
+        goto error;
+    }
+
+    if (aeron_alloc((void **)&detector->tmp_gaps, AERON_LOSS_DETECTOR_MAX_LOSSES * sizeof(aeron_loss_detector_gap_t)) < 0)
+    {
+        AERON_APPEND_ERR("%s", "Unable to alloc tmp_gaps");
+        goto error;
+    }
 
     return 0;
+
+error:
+    aeron_free(detector->gaps);
+    aeron_free(detector->tmp_gaps);
+
+    return -1;
 }
 
-int32_t aeron_loss_detector_scan(
+static void aeron_loss_detector_check_timer_expiry(aeron_loss_detector_t *detector, aeron_loss_detector_gap_t *gap, int64_t now_ns);
+
+void aeron_loss_detector_close(aeron_loss_detector_t *detector)
+{
+    aeron_free(detector->gaps);
+    aeron_free(detector->tmp_gaps);
+}
+
+static inline int64_t aeron_loss_detector_scan_for_first_gap_position(
+    const uint8_t *buffer,
+    const uint8_t *next_buffer,
+    int64_t rebuild_position,
+    int64_t hwm_position,
+    size_t term_length_mask,
+    size_t position_bits_to_shift,
+    int32_t initial_term_id,
+    int32_t *gap_length)
+{
+    const int32_t rebuild_term_count = (int32_t)(rebuild_position >> position_bits_to_shift);
+    const int32_t hwm_term_count = (int32_t)(hwm_position >> position_bits_to_shift);
+
+    const int32_t rebuild_term_offset = (int32_t)(rebuild_position & term_length_mask);
+    const int32_t hwm_term_offset = (int32_t)(hwm_position & term_length_mask);
+
+    const int32_t limit_offset = rebuild_term_count == hwm_term_count ? hwm_term_offset : (int32_t)(term_length_mask + 1);
+
+    int32_t gap_start_offset = aeron_term_gap_scanner_scan_for_gap(
+        buffer,
+        rebuild_term_offset,
+        limit_offset,
+        gap_length);
+
+    if (gap_start_offset < 0)
+    {
+        return (int64_t)gap_start_offset;
+    }
+
+    if (gap_start_offset != limit_offset || rebuild_term_count == hwm_term_count)
+    {
+        return (((int64_t)rebuild_term_count) << position_bits_to_shift) + gap_start_offset;
+    }
+
+    gap_start_offset = aeron_term_gap_scanner_scan_for_gap(
+        next_buffer,
+        0,
+        hwm_term_offset,
+        gap_length);
+
+    if (gap_start_offset < 0)
+    {
+        return (int64_t)gap_start_offset;
+    }
+
+    return (((int64_t)hwm_term_count) << position_bits_to_shift) + gap_start_offset;
+}
+
+int64_t aeron_loss_detector_scan(
     aeron_loss_detector_t *detector,
     bool *loss_found,
     const uint8_t *buffer,
+    const uint8_t *next_buffer,
     int64_t rebuild_position,
     int64_t hwm_position,
     int64_t now_ns,
@@ -53,39 +130,111 @@ int32_t aeron_loss_detector_scan(
     int32_t initial_term_id)
 {
     *loss_found = false;
-    int32_t rebuild_offset = (int32_t)(rebuild_position & term_length_mask);
 
-    if (rebuild_position < hwm_position)
+    if (rebuild_position >= hwm_position)
     {
-        const int32_t rebuild_term_count = (int32_t)(rebuild_position >> position_bits_to_shift);
-        const int32_t hwm_term_count = (int32_t)(hwm_position >> position_bits_to_shift);
-
-        const int32_t rebuild_term_id = aeron_add_wrap_i32(initial_term_id, rebuild_term_count);
-        const int32_t hwm_term_offset = (int32_t)(hwm_position & term_length_mask);
-        const int32_t limit_offset = rebuild_term_count == hwm_term_count ?
-            hwm_term_offset : (int32_t)(term_length_mask + 1);
-
-        rebuild_offset = aeron_term_gap_scanner_scan_for_gap(
-            buffer,
-            rebuild_term_id,
-            rebuild_offset,
-            limit_offset,
-            aeron_loss_detector_on_gap,
-            detector);
-
-        if (rebuild_offset < limit_offset)
-        {
-            if (!aeron_loss_detector_gaps_match(detector))
-            {
-                aeron_loss_detector_activate_gap(detector, now_ns);
-                *loss_found = true;
-            }
-
-            aeron_loss_detector_check_timer_expiry(detector, now_ns);
-        }
+        return rebuild_position;
     }
 
-    return rebuild_offset;
+    int32_t gap_length;
+    int64_t first_gap_position = aeron_loss_detector_scan_for_first_gap_position(
+        buffer,
+        next_buffer,
+        rebuild_position,
+        hwm_position,
+        term_length_mask,
+        position_bits_to_shift,
+        initial_term_id,
+        &gap_length);
+
+    if (first_gap_position < 0)
+    {
+        return rebuild_position;
+    }
+
+    const int32_t rebuild_term_count = (int32_t)(rebuild_position >> position_bits_to_shift);
+    const int32_t hwm_term_count = (int32_t)(hwm_position >> position_bits_to_shift);
+    const int32_t hwm_term_offset = (int32_t)(hwm_position & term_length_mask);
+
+    int32_t gaps_count = 0;
+    int32_t gap_index = 0;
+
+    for (int64_t position = first_gap_position; position < hwm_position && gaps_count < AERON_LOSS_DETECTOR_MAX_LOSSES;)
+    {
+        const int32_t term_count = (int32_t)(position >> position_bits_to_shift);
+        const int32_t term_id = aeron_add_wrap_i32(initial_term_id, term_count);
+        const int32_t term_offset = (int32_t)(position & term_length_mask);
+
+        aeron_loss_detector_gap_t *tmp_gap = &detector->tmp_gaps[gaps_count];
+        tmp_gap->term_id = term_id;
+        tmp_gap->term_offset = term_offset;
+        tmp_gap->length = gap_length;
+
+        while (gap_index < detector->gaps_count)
+        {
+            aeron_loss_detector_gap_t *gap = &detector->gaps[gaps_count];
+            if (term_id == gap->term_id && term_offset < gap->term_offset + gap->length)
+            {
+                break;
+            }
+            gap_index++;
+        }
+
+        if (gap_index < detector->gaps_count)
+        {
+            aeron_loss_detector_gap_t *gap = &detector->gaps[gaps_count];
+            if (term_offset + gap_length <= gap->term_offset + gap->length)
+            {
+                tmp_gap->expiry_ns = gap->expiry_ns;
+            }
+            else
+            {
+                tmp_gap->expiry_ns = now_ns + detector->feedback_delay_state->delay_generator(detector->feedback_delay_state, false);
+                *loss_found = true;
+            }
+        }
+        else
+        {
+            tmp_gap->expiry_ns = now_ns + detector->feedback_delay_state->delay_generator(detector->feedback_delay_state, false);
+            *loss_found = true;
+        }
+
+        aeron_loss_detector_check_timer_expiry(detector, tmp_gap, now_ns);
+
+        gaps_count++;
+
+        const int64_t next_scan_position = position + gap_length;
+        if (next_scan_position >= hwm_position)
+        {
+            break;
+        }
+
+        const int32_t next_scan_term_count = (int32_t)(next_scan_position >> position_bits_to_shift);
+        const int32_t next_scan_term_offset = (int32_t)(next_scan_position & term_length_mask);
+        const int32_t next_scan_limit_offset = next_scan_term_count == hwm_term_count ? hwm_term_offset : (int32_t)(term_length_mask + 1);
+        const uint8_t *next_scan_buffer = next_scan_term_count == rebuild_term_count ? buffer : next_buffer;
+
+        int32_t next_offset = aeron_term_gap_scanner_scan_for_gap(
+            next_scan_buffer,
+            next_scan_term_offset,
+            next_scan_limit_offset,
+            &gap_length);
+
+        if (next_offset < 0)
+        {
+            break;
+        }
+
+        position = (((int64_t)next_scan_term_count) << position_bits_to_shift) + next_offset;
+    }
+
+    // swap the buffers
+    aeron_loss_detector_gap_t *t = detector->tmp_gaps;
+    detector->tmp_gaps = detector->gaps;
+    detector->gaps = t;
+    detector->gaps_count = gaps_count;
+
+    return first_gap_position;
 }
 
 int aeron_feedback_delay_state_init(
@@ -125,7 +274,17 @@ int64_t aeron_loss_detector_nak_multicast_delay_generator(aeron_feedback_delay_g
 }
 
 extern int64_t aeron_loss_detector_nak_unicast_delay_generator(aeron_feedback_delay_generator_state_t *state, bool retry);
-extern void aeron_loss_detector_on_gap(void *clientd, int32_t term_id, int32_t term_offset, size_t length);
-extern bool aeron_loss_detector_gaps_match(aeron_loss_detector_t *detector);
-extern void aeron_loss_detector_activate_gap(aeron_loss_detector_t *detector, int64_t now_ns);
-extern void aeron_loss_detector_check_timer_expiry(aeron_loss_detector_t *detector, int64_t now_ns);
+
+static void aeron_loss_detector_check_timer_expiry(aeron_loss_detector_t *detector, aeron_loss_detector_gap_t *gap, int64_t now_ns)
+{
+    if (now_ns >= gap->expiry_ns)
+    {
+        detector->on_gap_detected(
+            detector->on_gap_detected_clientd,
+            gap->term_id,
+            gap->term_offset,
+            gap->length);
+
+        gap->expiry_ns = now_ns + detector->feedback_delay_state->delay_generator(detector->feedback_delay_state, true);
+    }
+}

--- a/aeron-driver/src/main/c/aeron_loss_detector.h
+++ b/aeron-driver/src/main/c/aeron_loss_detector.h
@@ -24,33 +24,38 @@ typedef struct aeron_loss_detector_gap_stct
 {
     int32_t term_id;
     int32_t term_offset;
-    size_t length;
-}
-aeron_loss_detector_gap_t;
+    int32_t length;
+    int64_t expiry_ns;
+} aeron_loss_detector_gap_t;
 
 #define AERON_LOSS_DETECTOR_TIMER_INACTIVE (-1)
+#define AERON_LOSS_DETECTOR_MAX_LOSSES (4096)
+
+typedef void (*aeron_loss_detector_on_gap_detected_func_t)(void *clientd, int32_t term_id, int32_t term_offset, size_t length);
 
 typedef struct aeron_loss_detector_stct
 {
-    aeron_term_gap_scanner_on_gap_detected_func_t on_gap_detected;
+    aeron_loss_detector_on_gap_detected_func_t on_gap_detected;
     aeron_feedback_delay_generator_state_t *feedback_delay_state;
     void *on_gap_detected_clientd;
-    aeron_loss_detector_gap_t scanned_gap;
-    aeron_loss_detector_gap_t active_gap;
-    int64_t expiry_ns;
-}
-aeron_loss_detector_t;
+    aeron_loss_detector_gap_t *gaps;
+    aeron_loss_detector_gap_t *tmp_gaps;
+    int32_t gaps_count;
+} aeron_loss_detector_t;
 
 int aeron_loss_detector_init(
     aeron_loss_detector_t *detector,
     aeron_feedback_delay_generator_state_t *feedback_delay_state,
-    aeron_term_gap_scanner_on_gap_detected_func_t on_gap_detected,
+    aeron_loss_detector_on_gap_detected_func_t on_gap_detected,
     void *on_gap_detected_clientd);
 
-int32_t aeron_loss_detector_scan(
+void aeron_loss_detector_close(aeron_loss_detector_t *detector);
+
+int64_t aeron_loss_detector_scan(
     aeron_loss_detector_t *detector,
     bool *loss_found,
     const uint8_t *buffer,
+    const uint8_t *next_buffer,
     int64_t rebuild_position,
     int64_t hwm_position,
     int64_t now_ns,
@@ -84,42 +89,4 @@ int aeron_feedback_delay_state_init(
 
 int64_t aeron_loss_detector_nak_multicast_delay_generator(aeron_feedback_delay_generator_state_t *state, bool retry);
 
-inline void aeron_loss_detector_on_gap(void *clientd, int32_t term_id, int32_t term_offset, size_t length)
-{
-    aeron_loss_detector_t *detector = (aeron_loss_detector_t *)clientd;
-
-    detector->scanned_gap.term_id = term_id;
-    detector->scanned_gap.term_offset = term_offset;
-    detector->scanned_gap.length = length;
-}
-
-inline bool aeron_loss_detector_gaps_match(aeron_loss_detector_t *detector)
-{
-    return detector->active_gap.term_id == detector->scanned_gap.term_id &&
-        detector->active_gap.term_offset == detector->scanned_gap.term_offset &&
-        detector->active_gap.length == detector->scanned_gap.length;
-}
-
-inline void aeron_loss_detector_activate_gap(aeron_loss_detector_t *detector, int64_t now_ns)
-{
-    detector->active_gap.term_id = detector->scanned_gap.term_id;
-    detector->active_gap.term_offset = detector->scanned_gap.term_offset;
-    detector->active_gap.length = detector->scanned_gap.length;
-
-    detector->expiry_ns = now_ns + detector->feedback_delay_state->delay_generator(detector->feedback_delay_state, false);
-}
-
-inline void aeron_loss_detector_check_timer_expiry(aeron_loss_detector_t *detector, int64_t now_ns)
-{
-    if (now_ns >= detector->expiry_ns)
-    {
-        detector->on_gap_detected(
-            detector->on_gap_detected_clientd,
-            detector->active_gap.term_id,
-            detector->active_gap.term_offset,
-            detector->active_gap.length);
-        detector->expiry_ns = now_ns + detector->feedback_delay_state->delay_generator(detector->feedback_delay_state, true);
-    }
-}
-
-#endif //AERON_LOSS_DETECTOR_H
+#endif // AERON_LOSS_DETECTOR_H

--- a/aeron-driver/src/main/c/aeron_publication_image.c
+++ b/aeron-driver/src/main/c/aeron_publication_image.c
@@ -25,6 +25,7 @@
 #include "util/aeron_parse_util.h"
 
 #define AERON_PUBLICATION_RESPONSE_NULL_RESPONSE_SESSION_ID INT64_C(0xF000000000000000)
+#define NAKS_SENT_PER_ITERATION (5)
 
 static void aeron_publication_image_connection_set_control_address(
     aeron_publication_image_connection_t *connection, const struct sockaddr_storage *control_address)
@@ -388,12 +389,11 @@ int aeron_publication_image_create(
         active_term_id, initial_term_offset, _image->position_bits_to_shift, initial_term_id);
     const int64_t now_ns = aeron_clock_cached_nano_time(context->cached_clock);
 
-    _image->begin_loss_change = 0;
-    _image->end_loss_change = 0;
-    _image->last_loss_change_number = 0;
-    _image->loss_term_id = active_term_id;
-    _image->loss_term_offset = initial_term_offset;
-    _image->loss_length = 0;
+    if (aeron_spsc_concurrent_array_queue_elem_init(&_image->pending_losses, AERON_LOSS_DETECTOR_MAX_LOSSES, sizeof(aeron_publication_image_pending_loss_t)) < 0)
+    {
+        AERON_APPEND_ERR("%s", "failed to init pending_losses");
+        goto error;
+    }
 
     _image->begin_sm_change = 0;
     _image->end_sm_change = 0;
@@ -443,6 +443,8 @@ int aeron_publication_image_close(aeron_counters_manager_t *counters_manager, ae
 
         aeron_free(subscribable->array);
         aeron_free(image->connections.array);
+        aeron_spsc_concurrent_array_queue_elem_close(&image->pending_losses);
+        aeron_loss_detector_close(&image->loss_detector);
 
         image->congestion_control->fini(image->congestion_control);
     }
@@ -501,16 +503,14 @@ void aeron_publication_image_clean_buffer_to(aeron_publication_image_t *image, i
 void aeron_publication_image_on_gap_detected(void *clientd, int32_t term_id, int32_t term_offset, size_t length)
 {
     aeron_publication_image_t *image = (aeron_publication_image_t *)clientd;
-    const int64_t change_number = image->begin_loss_change + 1;
 
-    AERON_SET_RELEASE(image->begin_loss_change, change_number);
-    aeron_release();
+    aeron_publication_image_pending_loss_t loss = {
+        term_id,
+        term_offset,
+        length,
+    };
 
-    image->loss_term_id = term_id;
-    image->loss_term_offset = term_offset;
-    image->loss_length = length;
-
-    AERON_SET_RELEASE(image->end_loss_change, change_number);
+    aeron_spsc_concurrent_array_queue_elem_offer(&image->pending_losses, &loss);
 
     size_t loss_report_end_offset;
     if (term_id != image->conductor_fields.loss_report_term_id ||
@@ -555,24 +555,21 @@ void aeron_publication_image_track_rebuild(aeron_publication_image_t *image, int
             return;
         }
 
-        const int64_t rebuild_position = *image->rcv_pos_position.value_addr > max_sub_pos ?
-            *image->rcv_pos_position.value_addr : max_sub_pos;
+        const int64_t rebuild_position = *image->rcv_pos_position.value_addr > max_sub_pos ? *image->rcv_pos_position.value_addr : max_sub_pos;
 
         bool loss_found = false;
         const size_t index = aeron_logbuffer_index_by_position(rebuild_position, image->position_bits_to_shift);
-        const int32_t rebuild_offset = aeron_loss_detector_scan(
+        const int64_t new_rebuild_position = aeron_loss_detector_scan(
             &image->loss_detector,
             &loss_found,
             image->mapped_raw_log.term_buffers[index].addr,
+            image->mapped_raw_log.term_buffers[(index + 1) % AERON_LOGBUFFER_PARTITION_COUNT].addr,
             rebuild_position,
             hwm_position,
             now_ns,
             (size_t)image->term_length_mask,
             image->position_bits_to_shift,
             image->initial_term_id);
-
-        const int32_t rebuild_term_offset = (int32_t)(rebuild_position & image->term_length_mask);
-        const int64_t new_rebuild_position = (rebuild_position - rebuild_term_offset) + rebuild_offset;
 
         aeron_counter_propose_max_release(image->rcv_pos_position.value_addr, new_rebuild_position);
 
@@ -935,72 +932,66 @@ int aeron_publication_image_send_pending_loss(aeron_publication_image_t *image)
     }
 
     int work_count = 0;
+    aeron_publication_image_pending_loss_t pending_loss;
 
-    int64_t change_number;
-    AERON_GET_ACQUIRE(change_number, image->end_loss_change);
-
-    if (change_number != image->last_loss_change_number)
+    for (int i = 0; i < NAKS_SENT_PER_ITERATION; i++)
     {
-        const int32_t term_id = image->loss_term_id;
-        const int32_t term_offset = image->loss_term_offset;
-        const size_t length = image->loss_length;
-
-        aeron_acquire();
-
-        int64_t begin_change_number;
-        AERON_GET_ACQUIRE(begin_change_number, image->begin_loss_change);
-
-        if (change_number == begin_change_number)
+        if (!aeron_spsc_concurrent_array_queue_elem_poll(&image->pending_losses, (void *)&pending_loss))
         {
-            if (image->conductor_fields.is_reliable)
+            break;
+        }
+
+        const int32_t term_id = pending_loss.term_id;
+        const int32_t term_offset = pending_loss.term_offset;
+        const size_t length = pending_loss.length;
+
+        if (image->conductor_fields.is_reliable)
+        {
+            const int64_t now_ns = aeron_clock_cached_nano_time(image->cached_clock);
+
+            for (size_t i = 0, len = image->connections.length; i < len; i++)
             {
-                const int64_t now_ns = aeron_clock_cached_nano_time(image->cached_clock);
+                aeron_publication_image_connection_t *connection = &image->connections.array[i];
 
-                for (size_t i = 0, len = image->connections.length; i < len; i++)
+                if (aeron_publication_image_connection_is_alive(connection, now_ns))
                 {
-                    aeron_publication_image_connection_t *connection = &image->connections.array[i];
+                    int send_nak_result = aeron_receive_channel_endpoint_send_nak(
+                        image->endpoint,
+                        connection->destination,
+                        connection->control_addr,
+                        image->stream_id,
+                        image->session_id,
+                        term_id,
+                        term_offset,
+                        (int32_t)length);
 
-                    if (aeron_publication_image_connection_is_alive(connection, now_ns))
+                    if (send_nak_result < 0)
                     {
-                        int send_nak_result = aeron_receive_channel_endpoint_send_nak(
-                            image->endpoint,
-                            connection->destination,
-                            connection->control_addr,
-                            image->stream_id,
-                            image->session_id,
-                            term_id,
-                            term_offset,
-                            (int32_t)length);
-
-                        if (send_nak_result < 0)
-                        {
-                            work_count = send_nak_result;
-                            break;
-                        }
-
-                        work_count++;
-                        aeron_counter_increment_release(image->nak_messages_sent_counter);
-                        aeron_counter_increment_release(image->rcv_naks_sent.value_addr);
+                        work_count = send_nak_result;
+                        goto done;
                     }
+
+                    work_count++;
+                    aeron_counter_increment_release(image->nak_messages_sent_counter);
+                    aeron_counter_increment_release(image->rcv_naks_sent.value_addr);
                 }
             }
-            else
+        }
+        else
+        {
+            const size_t index = aeron_logbuffer_index_by_term(image->initial_term_id, term_id);
+            uint8_t *buffer = image->mapped_raw_log.term_buffers[index].addr;
+
+            if (aeron_term_gap_filler_try_fill_gap(image->log_meta_data, buffer, term_id, term_offset, length))
             {
-                const size_t index = aeron_logbuffer_index_by_term(image->initial_term_id, term_id);
-                uint8_t *buffer = image->mapped_raw_log.term_buffers[index].addr;
-
-                if (aeron_term_gap_filler_try_fill_gap(image->log_meta_data, buffer, term_id, term_offset, length))
-                {
-                    aeron_counter_increment_release(image->loss_gap_fills_counter);
-                }
-
-                work_count = 1;
+                aeron_counter_increment_release(image->loss_gap_fills_counter);
             }
 
-            image->last_loss_change_number = change_number;
+            work_count++;
         }
     }
 
+done:
     return work_count;
 }
 

--- a/aeron-driver/src/main/c/aeron_publication_image.h
+++ b/aeron-driver/src/main/c/aeron_publication_image.h
@@ -22,6 +22,7 @@
 #include "aeron_congestion_control.h"
 #include "aeron_loss_detector.h"
 #include "reports/aeron_loss_reporter.h"
+#include "concurrent/aeron_spsc_concurrent_array_queue_elem.h"
 
 typedef enum aeron_publication_image_state_enum
 {
@@ -47,6 +48,13 @@ typedef struct aeron_publication_image_connection_stct
     uint8_t padding_after[AERON_CACHE_LINE_LENGTH];
 }
 aeron_publication_image_connection_t;
+
+typedef struct aeron_publication_image_pending_loss_stct
+{
+    int32_t term_id;
+    int32_t term_offset;
+    size_t length;
+} aeron_publication_image_pending_loss_t;
 
 typedef struct aeron_publication_image_stct
 {
@@ -121,12 +129,7 @@ typedef struct aeron_publication_image_stct
         aeron_driver_publication_image_revoke_func_t publication_image_revoke;
     } log;
 
-    volatile int64_t begin_loss_change;
-    volatile int64_t end_loss_change;
-    int64_t last_loss_change_number;
-    int32_t loss_term_id;
-    int32_t loss_term_offset;
-    size_t loss_length;
+    aeron_spsc_concurrent_array_queue_elem_t pending_losses;
 
     volatile int64_t begin_sm_change;
     volatile int64_t end_sm_change;

--- a/aeron-driver/src/test/c/aeron_data_packet_dispatcher_test.cpp
+++ b/aeron-driver/src/test/c/aeron_data_packet_dispatcher_test.cpp
@@ -90,6 +90,7 @@ TEST_F(DataPacketDispatcherTest, shouldInsertDataInputSubscribedPublicationImage
 
     aeron_data_header_t *data_header = dataPacket(data_buffer, stream_id, session_id);
     size_t len = sizeof(aeron_data_header_t) + 8;
+    data_header->frame_header.frame_length = len;
 
     ASSERT_EQ(0, aeron_data_packet_dispatcher_add_subscription(m_dispatcher, stream_id));
     ASSERT_EQ(0, aeron_data_packet_dispatcher_add_publication_image(m_dispatcher, image));
@@ -118,6 +119,7 @@ TEST_F(DataPacketDispatcherTest, shouldNotInsertDataInputWithNoSubscription)
     aeron_publication_image_t *image = createImage(stream_id, session_id);
     aeron_data_header_t *data_header = dataPacket(data_buffer, stream_id, session_id);
     size_t len = sizeof(aeron_data_header_t) + 8;
+    data_header->frame_header.frame_length = len;
 
     int32_t other_stream_id = stream_id + 1;
 
@@ -150,6 +152,7 @@ TEST_F(DataPacketDispatcherTest, shouldElicitSetupMessageForSubscriptionWithoutI
 
     aeron_data_header_t *data_header = dataPacket(data_buffer, stream_id, session_id);
     size_t len = sizeof(aeron_data_header_t) + 8;
+    data_header->frame_header.frame_length = len;
 
     // No publication added...
     ASSERT_EQ(0, aeron_data_packet_dispatcher_add_subscription(m_dispatcher, stream_id));

--- a/aeron-driver/src/test/c/aeron_loss_detector_test.cpp
+++ b/aeron-driver/src/test/c/aeron_loss_detector_test.cpp
@@ -37,8 +37,7 @@ typedef std::array<std::uint8_t, CAPACITY> buffer_t;
 class TermGapScannerTest : public testing::Test
 {
 public:
-    TermGapScannerTest() :
-        m_ptr(m_buffer.data())
+    TermGapScannerTest() : m_ptr(m_buffer.data())
     {
         m_buffer.fill(0);
     }
@@ -64,20 +63,10 @@ TEST_F(TermGapScannerTest, shouldReportGapAtBeginningOfBuffer)
 
     hdr->frame_length = AERON_DATA_HEADER_LENGTH;
 
-    bool on_gap_detected_called = false;
-    m_on_gap_detected =
-        [&](int32_t term_id, int32_t term_offset, size_t length)
-        {
-            EXPECT_EQ(term_id, TERM_ID);
-            EXPECT_EQ(term_offset, 0);
-            EXPECT_EQ(length, (size_t)frame_offset);
-            on_gap_detected_called = true;
-        };
+    int32_t gap_length;
 
-    ASSERT_EQ(aeron_term_gap_scanner_scan_for_gap(
-        m_ptr, TERM_ID, 0, high_water_mark, TermGapScannerTest::on_gap_detected, this), 0);
-
-    EXPECT_TRUE(on_gap_detected_called);
+    ASSERT_EQ(aeron_term_gap_scanner_scan_for_gap(m_ptr, 0, high_water_mark, &gap_length), 0);
+    EXPECT_EQ(gap_length, (size_t)frame_offset);
 }
 
 TEST_F(TermGapScannerTest, shouldReportSingleGapWhenBufferNotFull)
@@ -96,20 +85,10 @@ TEST_F(TermGapScannerTest, shouldReportSingleGapWhenBufferNotFull)
     hdr = (aeron_frame_header_t *)(m_ptr + high_water_mark - (AERON_ALIGN(AERON_DATA_HEADER_LENGTH, AERON_LOGBUFFER_FRAME_ALIGNMENT)));
     hdr->frame_length = AERON_DATA_HEADER_LENGTH;
 
-    bool on_gap_detected_called = false;
-    m_on_gap_detected =
-        [&](int32_t term_id, int32_t term_offset, size_t length)
-        {
-            EXPECT_EQ(term_id, TERM_ID);
-            EXPECT_EQ(term_offset, tail);
-            EXPECT_EQ(length, (size_t)AERON_ALIGN(AERON_DATA_HEADER_LENGTH, AERON_LOGBUFFER_FRAME_ALIGNMENT));
-            on_gap_detected_called = true;
-        };
+    int32_t gap_length;
 
-    ASSERT_EQ(aeron_term_gap_scanner_scan_for_gap(
-        m_ptr, TERM_ID, tail, high_water_mark, TermGapScannerTest::on_gap_detected, this), tail);
-
-    EXPECT_TRUE(on_gap_detected_called);
+    ASSERT_EQ(aeron_term_gap_scanner_scan_for_gap(m_ptr, tail, high_water_mark, &gap_length), tail);
+    EXPECT_EQ(gap_length, (size_t)AERON_ALIGN(AERON_DATA_HEADER_LENGTH, AERON_LOGBUFFER_FRAME_ALIGNMENT));
 }
 
 TEST_F(TermGapScannerTest, shouldReportSingleGapWhenBufferIsFull)
@@ -128,20 +107,10 @@ TEST_F(TermGapScannerTest, shouldReportSingleGapWhenBufferIsFull)
     hdr = (aeron_frame_header_t *)(m_ptr + high_water_mark - (AERON_ALIGN(AERON_DATA_HEADER_LENGTH, AERON_LOGBUFFER_FRAME_ALIGNMENT)));
     hdr->frame_length = AERON_DATA_HEADER_LENGTH;
 
-    bool on_gap_detected_called = false;
-    m_on_gap_detected =
-        [&](int32_t term_id, int32_t term_offset, size_t length)
-        {
-            EXPECT_EQ(term_id, TERM_ID);
-            EXPECT_EQ(term_offset, tail);
-            EXPECT_EQ(length, (size_t)AERON_ALIGN(AERON_DATA_HEADER_LENGTH, AERON_LOGBUFFER_FRAME_ALIGNMENT));
-            on_gap_detected_called = true;
-        };
+    int32_t gap_length;
 
-    ASSERT_EQ(aeron_term_gap_scanner_scan_for_gap(
-        m_ptr, TERM_ID, tail, high_water_mark, TermGapScannerTest::on_gap_detected, this), tail);
-
-    EXPECT_TRUE(on_gap_detected_called);
+    ASSERT_EQ(aeron_term_gap_scanner_scan_for_gap(m_ptr, tail, high_water_mark, &gap_length), tail);
+    EXPECT_EQ(gap_length, (size_t)AERON_ALIGN(AERON_DATA_HEADER_LENGTH, AERON_LOGBUFFER_FRAME_ALIGNMENT));
 }
 
 TEST_F(TermGapScannerTest, shouldReportNoGapWhenHwmIsInPadding)
@@ -158,17 +127,9 @@ TEST_F(TermGapScannerTest, shouldReportNoGapWhenHwmIsInPadding)
     hdr = (aeron_frame_header_t *)(m_ptr + tail + AERON_DATA_HEADER_LENGTH);
     hdr->frame_length = 0;
 
-    bool on_gap_detected_called = false;
-    m_on_gap_detected =
-        [&](int32_t term_id, int32_t term_offset, size_t length)
-        {
-            on_gap_detected_called = true;
-        };
+    int32_t gap_length;
 
-    ASSERT_EQ(aeron_term_gap_scanner_scan_for_gap(
-        m_ptr, TERM_ID, tail, high_water_mark, TermGapScannerTest::on_gap_detected, this), CAPACITY);
-
-    EXPECT_FALSE(on_gap_detected_called);
+    ASSERT_EQ(aeron_term_gap_scanner_scan_for_gap(m_ptr, tail, high_water_mark, &gap_length), CAPACITY);
 }
 
 #define DATA_LENGTH (36)
@@ -178,9 +139,9 @@ TEST_F(TermGapScannerTest, shouldReportNoGapWhenHwmIsInPadding)
 class LossDetectorTest : public testing::Test
 {
 public:
-    LossDetectorTest() :
-        m_ptr(m_buffer.data()),
-        m_time(0)
+    LossDetectorTest() : m_ptr(m_buffer.data()),
+                         m_next_ptr(m_next_buffer.data()),
+                         m_time(0)
     {
         m_buffer.fill(0);
     }
@@ -216,7 +177,9 @@ public:
 
 protected:
     buffer_t m_buffer = {};
+    buffer_t m_next_buffer = {};
     uint8_t *m_ptr = nullptr;
+    uint8_t *m_next_ptr = nullptr;
     int64_t m_time = 0;
     aeron_loss_detector_t m_detector = {};
     aeron_feedback_delay_generator_state_t m_delay_generator_state = {};
@@ -231,23 +194,24 @@ TEST_F(LossDetectorTest, shouldNotSendNakWhenBufferIsEmpty)
 
     ASSERT_EQ(feedback_delay_state_init(true), 0);
     ASSERT_EQ(aeron_loss_detector_init(
-        &m_detector, &m_delay_generator_state, LossDetectorTest::on_gap_detected, this), 0);
+                  &m_detector, &m_delay_generator_state, LossDetectorTest::on_gap_detected, this),
+              0);
 
     m_on_gap_detected =
         [](int32_t term_id, int32_t term_offset, size_t length)
-        {
-            FAIL();
-        };
+    {
+        FAIL();
+    };
 
     ASSERT_EQ(aeron_loss_detector_scan(
-        &m_detector, &loss_found, m_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
-        hwm_position);
+                  &m_detector, &loss_found, m_ptr, m_next_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
+              hwm_position);
     EXPECT_FALSE(loss_found);
 
     m_time = 100 * 1000 * 1000L;
     ASSERT_EQ(aeron_loss_detector_scan(
-        &m_detector, &loss_found, m_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
-        hwm_position);
+                  &m_detector, &loss_found, m_ptr, m_next_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
+              hwm_position);
     EXPECT_FALSE(loss_found);
 }
 
@@ -263,23 +227,24 @@ TEST_F(LossDetectorTest, shouldNotNakIfNoMissingData)
 
     ASSERT_EQ(feedback_delay_state_init(true), 0);
     ASSERT_EQ(aeron_loss_detector_init(
-        &m_detector, &m_delay_generator_state, LossDetectorTest::on_gap_detected, this), 0);
+                  &m_detector, &m_delay_generator_state, LossDetectorTest::on_gap_detected, this),
+              0);
 
     m_on_gap_detected =
         [](int32_t term_id, int32_t term_offset, size_t length)
-        {
-            FAIL();
-        };
+    {
+        FAIL();
+    };
 
     ASSERT_EQ(aeron_loss_detector_scan(
-        &m_detector, &loss_found, m_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
-        hwm_position);
+                  &m_detector, &loss_found, m_ptr, m_next_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
+              hwm_position);
     EXPECT_FALSE(loss_found);
 
     m_time = 40 * 1000 * 1000L;
     ASSERT_EQ(aeron_loss_detector_scan(
-        &m_detector, &loss_found, m_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
-        hwm_position);
+                  &m_detector, &loss_found, m_ptr, m_next_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
+              hwm_position);
     EXPECT_FALSE(loss_found);
 }
 
@@ -295,27 +260,28 @@ TEST_F(LossDetectorTest, shouldNakMissingData)
 
     ASSERT_EQ(feedback_delay_state_init(false), 0);
     ASSERT_EQ(aeron_loss_detector_init(
-        &m_detector, &m_delay_generator_state, LossDetectorTest::on_gap_detected, this), 0);
+                  &m_detector, &m_delay_generator_state, LossDetectorTest::on_gap_detected, this),
+              0);
 
     m_on_gap_detected =
         [&](int32_t term_id, int32_t term_offset, size_t length)
-        {
-            EXPECT_EQ(term_id, TERM_ID);
-            EXPECT_EQ(term_offset, offset_of_message(1));
-            EXPECT_EQ(length, ALIGNED_FRAME_LENGTH);
-            called++;
-        };
+    {
+        EXPECT_EQ(term_id, TERM_ID);
+        EXPECT_EQ(term_offset, offset_of_message(1));
+        EXPECT_EQ(length, ALIGNED_FRAME_LENGTH);
+        called++;
+    };
 
     ASSERT_EQ(aeron_loss_detector_scan(
-        &m_detector, &loss_found, m_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
-        offset_of_message(1));
+                  &m_detector, &loss_found, m_ptr, m_next_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
+              offset_of_message(1));
     EXPECT_EQ(called, 0);
     EXPECT_TRUE(loss_found);
 
     m_time = 40 * 1000 * 1000L;
     ASSERT_EQ(aeron_loss_detector_scan(
-        &m_detector, &loss_found, m_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
-        offset_of_message(1));
+                  &m_detector, &loss_found, m_ptr, m_next_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
+              offset_of_message(1));
     EXPECT_EQ(called, 1);
     EXPECT_FALSE(loss_found);
 }
@@ -332,34 +298,35 @@ TEST_F(LossDetectorTest, shouldRetransmitNakForMissingData)
 
     ASSERT_EQ(feedback_delay_state_init(false), 0);
     ASSERT_EQ(aeron_loss_detector_init(
-        &m_detector, &m_delay_generator_state, LossDetectorTest::on_gap_detected, this), 0);
+                  &m_detector, &m_delay_generator_state, LossDetectorTest::on_gap_detected, this),
+              0);
 
     m_on_gap_detected =
         [&](int32_t term_id, int32_t term_offset, size_t length)
-        {
-            EXPECT_EQ(term_id, TERM_ID);
-            EXPECT_EQ(term_offset, offset_of_message(1));
-            EXPECT_EQ(length, ALIGNED_FRAME_LENGTH);
-            called++;
-        };
+    {
+        EXPECT_EQ(term_id, TERM_ID);
+        EXPECT_EQ(term_offset, offset_of_message(1));
+        EXPECT_EQ(length, ALIGNED_FRAME_LENGTH);
+        called++;
+    };
 
     ASSERT_EQ(aeron_loss_detector_scan(
-        &m_detector, &loss_found, m_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
-        offset_of_message(1));
+                  &m_detector, &loss_found, m_ptr, m_next_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
+              offset_of_message(1));
     EXPECT_EQ(called, 0);
     EXPECT_TRUE(loss_found);
 
     m_time = 30 * 1000 * 1000L;
     ASSERT_EQ(aeron_loss_detector_scan(
-        &m_detector, &loss_found, m_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
-        offset_of_message(1));
+                  &m_detector, &loss_found, m_ptr, m_next_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
+              offset_of_message(1));
     EXPECT_EQ(called, 1);
     EXPECT_FALSE(loss_found);
 
     m_time = 60 * 1000 * 1000L;
     ASSERT_EQ(aeron_loss_detector_scan(
-        &m_detector, &loss_found, m_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
-        offset_of_message(1));
+                  &m_detector, &loss_found, m_ptr, m_next_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
+              offset_of_message(1));
     EXPECT_EQ(called, 2);
     EXPECT_FALSE(loss_found);
 }
@@ -376,20 +343,21 @@ TEST_F(LossDetectorTest, shouldStopNakOnReceivingData)
 
     ASSERT_EQ(feedback_delay_state_init(false), 0);
     ASSERT_EQ(aeron_loss_detector_init(
-        &m_detector, &m_delay_generator_state, LossDetectorTest::on_gap_detected, this), 0);
+                  &m_detector, &m_delay_generator_state, LossDetectorTest::on_gap_detected, this),
+              0);
 
     m_on_gap_detected =
         [&](int32_t term_id, int32_t term_offset, size_t length)
-        {
-            EXPECT_EQ(term_id, TERM_ID);
-            EXPECT_EQ(term_offset, offset_of_message(1));
-            EXPECT_EQ(length, ALIGNED_FRAME_LENGTH);
-            called++;
-        };
+    {
+        EXPECT_EQ(term_id, TERM_ID);
+        EXPECT_EQ(term_offset, offset_of_message(1));
+        EXPECT_EQ(length, ALIGNED_FRAME_LENGTH);
+        called++;
+    };
 
     ASSERT_EQ(aeron_loss_detector_scan(
-        &m_detector, &loss_found, m_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
-        offset_of_message(1));
+                  &m_detector, &loss_found, m_ptr, m_next_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
+              offset_of_message(1));
     EXPECT_EQ(called, 0);
     EXPECT_TRUE(loss_found);
 
@@ -398,15 +366,15 @@ TEST_F(LossDetectorTest, shouldStopNakOnReceivingData)
     rebuild_position += (3 * ALIGNED_FRAME_LENGTH);
 
     ASSERT_EQ(aeron_loss_detector_scan(
-        &m_detector, &loss_found, m_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
-        hwm_position);
+                  &m_detector, &loss_found, m_ptr, m_next_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
+              hwm_position);
     EXPECT_EQ(called, 0);
     EXPECT_FALSE(loss_found);
 
     m_time = 100 * 1000 * 1000L;
     ASSERT_EQ(aeron_loss_detector_scan(
-        &m_detector, &loss_found, m_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
-        hwm_position);
+                  &m_detector, &loss_found, m_ptr, m_next_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
+              hwm_position);
     EXPECT_EQ(called, 0);
     EXPECT_FALSE(loss_found);
 }
@@ -425,52 +393,58 @@ TEST_F(LossDetectorTest, shouldHandleMoreThan2Gaps)
 
     ASSERT_EQ(feedback_delay_state_init(false), 0);
     ASSERT_EQ(aeron_loss_detector_init(
-        &m_detector, &m_delay_generator_state, LossDetectorTest::on_gap_detected, this), 0);
+                  &m_detector, &m_delay_generator_state, LossDetectorTest::on_gap_detected, this),
+              0);
 
     m_on_gap_detected =
         [&](int32_t term_id, int32_t term_offset, size_t length)
-        {
-            EXPECT_EQ(term_id, TERM_ID);
-            EXPECT_EQ(length, ALIGNED_FRAME_LENGTH);
-            called++;
+    {
+        EXPECT_EQ(term_id, TERM_ID);
+        EXPECT_EQ(length, ALIGNED_FRAME_LENGTH);
+        called++;
 
-            if (1 == called)
-            {
-                EXPECT_EQ(term_offset, offset_of_message(1));
-            }
-            else if (2 == called)
-            {
-                EXPECT_EQ(term_offset, offset_of_message(3));
-            }
-        };
+        if (1 == called)
+        {
+            EXPECT_EQ(term_offset, offset_of_message(1));
+        }
+        else if (2 == called)
+        {
+            EXPECT_EQ(term_offset, offset_of_message(3));
+        }
+        else if (3 == called)
+        {
+            EXPECT_EQ(term_offset, offset_of_message(5));
+        }
+    };
 
     ASSERT_EQ(aeron_loss_detector_scan(
-        &m_detector, &loss_found, m_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
-        offset_of_message(1));
+                  &m_detector, &loss_found, m_ptr, m_next_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
+              offset_of_message(1));
     EXPECT_EQ(called, 0);
     EXPECT_TRUE(loss_found);
 
     m_time = 40 * 1000 * 1000L;
     ASSERT_EQ(aeron_loss_detector_scan(
-        &m_detector, &loss_found, m_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
-        offset_of_message(1));
-    EXPECT_EQ(called, 1);
+                  &m_detector, &loss_found, m_ptr, m_next_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
+              offset_of_message(1));
+    EXPECT_EQ(called, 3);
     EXPECT_FALSE(loss_found);
 
     insert_frame(offset_of_message(1));
     rebuild_position += (3 * ALIGNED_FRAME_LENGTH);
 
+    called = 1;
     ASSERT_EQ(aeron_loss_detector_scan(
-        &m_detector, &loss_found, m_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
-        offset_of_message(3));
+                  &m_detector, &loss_found, m_ptr, m_next_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
+              offset_of_message(3));
     EXPECT_EQ(called, 1);
     EXPECT_TRUE(loss_found);
 
     m_time = 80 * 1000 * 1000L;
     ASSERT_EQ(aeron_loss_detector_scan(
-        &m_detector, &loss_found, m_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
-        offset_of_message(3));
-    EXPECT_EQ(called, 2);
+                  &m_detector, &loss_found, m_ptr, m_next_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
+              offset_of_message(3));
+    EXPECT_EQ(called, 3);
     EXPECT_FALSE(loss_found);
 }
 
@@ -486,27 +460,28 @@ TEST_F(LossDetectorTest, shouldReplaceOldNakWithNewNak)
 
     ASSERT_EQ(feedback_delay_state_init(false), 0);
     ASSERT_EQ(aeron_loss_detector_init(
-        &m_detector, &m_delay_generator_state, LossDetectorTest::on_gap_detected, this), 0);
+                  &m_detector, &m_delay_generator_state, LossDetectorTest::on_gap_detected, this),
+              0);
 
     m_on_gap_detected =
         [&](int32_t term_id, int32_t term_offset, size_t length)
-        {
-            EXPECT_EQ(term_id, TERM_ID);
-            EXPECT_EQ(length, ALIGNED_FRAME_LENGTH);
-            EXPECT_EQ(term_offset, offset_of_message(3));
-            called++;
-        };
+    {
+        EXPECT_EQ(term_id, TERM_ID);
+        EXPECT_EQ(length, ALIGNED_FRAME_LENGTH);
+        EXPECT_EQ(term_offset, offset_of_message(3));
+        called++;
+    };
 
     ASSERT_EQ(aeron_loss_detector_scan(
-        &m_detector, &loss_found, m_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
-        offset_of_message(1));
+                  &m_detector, &loss_found, m_ptr, m_next_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
+              offset_of_message(1));
     EXPECT_EQ(called, 0);
     EXPECT_TRUE(loss_found);
 
     m_time = 10 * 1000 * 1000L;
     ASSERT_EQ(aeron_loss_detector_scan(
-        &m_detector, &loss_found, m_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
-        offset_of_message(1));
+                  &m_detector, &loss_found, m_ptr, m_next_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
+              offset_of_message(1));
     EXPECT_EQ(called, 0);
     EXPECT_FALSE(loss_found);
 
@@ -516,15 +491,15 @@ TEST_F(LossDetectorTest, shouldReplaceOldNakWithNewNak)
     hwm_position = (ALIGNED_FRAME_LENGTH * 5);
 
     ASSERT_EQ(aeron_loss_detector_scan(
-        &m_detector, &loss_found, m_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
-        offset_of_message(3));
+                  &m_detector, &loss_found, m_ptr, m_next_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
+              offset_of_message(3));
     EXPECT_EQ(called, 0);
     EXPECT_TRUE(loss_found);
 
     m_time = 100 * 1000 * 1000L;
     ASSERT_EQ(aeron_loss_detector_scan(
-        &m_detector, &loss_found, m_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
-        offset_of_message(3));
+                  &m_detector, &loss_found, m_ptr, m_next_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
+              offset_of_message(3));
     EXPECT_EQ(called, 1);
     EXPECT_FALSE(loss_found);
 }
@@ -541,20 +516,21 @@ TEST_F(LossDetectorTest, shouldHandleImmediateNak)
 
     ASSERT_EQ(feedback_delay_state_init(true), 0);
     ASSERT_EQ(aeron_loss_detector_init(
-        &m_detector, &m_delay_generator_state, LossDetectorTest::on_gap_detected, this), 0);
+                  &m_detector, &m_delay_generator_state, LossDetectorTest::on_gap_detected, this),
+              0);
 
     m_on_gap_detected =
         [&](int32_t term_id, int32_t term_offset, size_t length)
-        {
-            EXPECT_EQ(term_id, TERM_ID);
-            EXPECT_EQ(term_offset, offset_of_message(1));
-            EXPECT_EQ(length, ALIGNED_FRAME_LENGTH);
-            called++;
-        };
+    {
+        EXPECT_EQ(term_id, TERM_ID);
+        EXPECT_EQ(term_offset, offset_of_message(1));
+        EXPECT_EQ(length, ALIGNED_FRAME_LENGTH);
+        called++;
+    };
 
     ASSERT_EQ(aeron_loss_detector_scan(
-        &m_detector, &loss_found, m_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
-        offset_of_message(1));
+                  &m_detector, &loss_found, m_ptr, m_next_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
+              offset_of_message(1));
     EXPECT_EQ(called, 1);
     EXPECT_TRUE(loss_found);
 }
@@ -571,20 +547,21 @@ TEST_F(LossDetectorTest, shouldNotNakImmediatelyByDefault)
 
     ASSERT_EQ(feedback_delay_state_init(false), 0);
     ASSERT_EQ(aeron_loss_detector_init(
-        &m_detector, &m_delay_generator_state, LossDetectorTest::on_gap_detected, this), 0);
+                  &m_detector, &m_delay_generator_state, LossDetectorTest::on_gap_detected, this),
+              0);
 
     m_on_gap_detected =
         [&](int32_t term_id, int32_t term_offset, size_t length)
-        {
-            EXPECT_EQ(term_id, TERM_ID);
-            EXPECT_EQ(term_offset, offset_of_message(1));
-            EXPECT_EQ(length, ALIGNED_FRAME_LENGTH);
-            called++;
-        };
+    {
+        EXPECT_EQ(term_id, TERM_ID);
+        EXPECT_EQ(term_offset, offset_of_message(1));
+        EXPECT_EQ(length, ALIGNED_FRAME_LENGTH);
+        called++;
+    };
 
     ASSERT_EQ(aeron_loss_detector_scan(
-        &m_detector, &loss_found, m_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
-        offset_of_message(1));
+                  &m_detector, &loss_found, m_ptr, m_next_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
+              offset_of_message(1));
     EXPECT_EQ(called, 0);
     EXPECT_TRUE(loss_found);
 }
@@ -601,25 +578,26 @@ TEST_F(LossDetectorTest, shouldOnlySendNaksOnceOnMultipleScans)
 
     ASSERT_EQ(feedback_delay_state_init(true), 0);
     ASSERT_EQ(aeron_loss_detector_init(
-        &m_detector, &m_delay_generator_state, LossDetectorTest::on_gap_detected, this), 0);
+                  &m_detector, &m_delay_generator_state, LossDetectorTest::on_gap_detected, this),
+              0);
 
     m_on_gap_detected =
         [&](int32_t term_id, int32_t term_offset, size_t length)
-        {
-            EXPECT_EQ(term_id, TERM_ID);
-            EXPECT_EQ(term_offset, offset_of_message(1));
-            EXPECT_EQ(length, ALIGNED_FRAME_LENGTH);
-            called++;
-        };
+    {
+        EXPECT_EQ(term_id, TERM_ID);
+        EXPECT_EQ(term_offset, offset_of_message(1));
+        EXPECT_EQ(length, ALIGNED_FRAME_LENGTH);
+        called++;
+    };
 
     ASSERT_EQ(aeron_loss_detector_scan(
-        &m_detector, &loss_found, m_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
-        offset_of_message(1));
+                  &m_detector, &loss_found, m_ptr, m_next_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
+              offset_of_message(1));
     EXPECT_EQ(called, 1);
     EXPECT_TRUE(loss_found);
     ASSERT_EQ(aeron_loss_detector_scan(
-        &m_detector, &loss_found, m_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
-        offset_of_message(1));
+                  &m_detector, &loss_found, m_ptr, m_next_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
+              offset_of_message(1));
     EXPECT_EQ(called, 1);
     EXPECT_FALSE(loss_found);
 }
@@ -636,21 +614,33 @@ TEST_F(LossDetectorTest, shouldHandleHwmGreaterThanCompletedBuffer)
 
     ASSERT_EQ(feedback_delay_state_init(true), 0);
     ASSERT_EQ(aeron_loss_detector_init(
-        &m_detector, &m_delay_generator_state, LossDetectorTest::on_gap_detected, this), 0);
+                  &m_detector, &m_delay_generator_state, LossDetectorTest::on_gap_detected, this),
+              0);
 
     m_on_gap_detected =
         [&](int32_t term_id, int32_t term_offset, size_t length)
+    {
+        called++;
+
+        if (called == 1)
         {
             EXPECT_EQ(term_id, TERM_ID);
             EXPECT_EQ(term_offset, offset_of_message(1));
             EXPECT_EQ(length, CAPACITY - (size_t)rebuild_position);
-            called++;
-        };
+        }
+
+        if (called == 2)
+        {
+            EXPECT_EQ(term_id, TERM_ID + 1);
+            EXPECT_EQ(term_offset, 0);
+            EXPECT_EQ(length, hwm_position - CAPACITY);
+        }
+    };
 
     ASSERT_EQ(aeron_loss_detector_scan(
-        &m_detector, &loss_found, m_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
-        offset_of_message(1));
-    EXPECT_EQ(called, 1);
+                  &m_detector, &loss_found, m_ptr, m_next_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
+              offset_of_message(1));
+    EXPECT_EQ(called, 2);
     EXPECT_TRUE(loss_found);
 }
 
@@ -666,20 +656,21 @@ TEST_F(LossDetectorTest, shouldHandleNonZeroInitialTermOffset)
 
     ASSERT_EQ(feedback_delay_state_init(true), 0);
     ASSERT_EQ(aeron_loss_detector_init(
-        &m_detector, &m_delay_generator_state, LossDetectorTest::on_gap_detected, this), 0);
+                  &m_detector, &m_delay_generator_state, LossDetectorTest::on_gap_detected, this),
+              0);
 
     m_on_gap_detected =
         [&](int32_t term_id, int32_t term_offset, size_t length)
-        {
-            EXPECT_EQ(term_id, TERM_ID);
-            EXPECT_EQ(term_offset, offset_of_message(3));
-            EXPECT_EQ(length, ALIGNED_FRAME_LENGTH);
-            called++;
-        };
+    {
+        EXPECT_EQ(term_id, TERM_ID);
+        EXPECT_EQ(term_offset, offset_of_message(3));
+        EXPECT_EQ(length, ALIGNED_FRAME_LENGTH);
+        called++;
+    };
 
     ASSERT_EQ(aeron_loss_detector_scan(
-        &m_detector, &loss_found, m_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
-        offset_of_message(3));
+                  &m_detector, &loss_found, m_ptr, m_next_ptr, rebuild_position, hwm_position, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
+              offset_of_message(3));
     EXPECT_EQ(called, 1);
     EXPECT_TRUE(loss_found);
 }
@@ -688,83 +679,101 @@ TEST_F(LossDetectorTest, shouldDetectChangesInTheGapLength)
 {
     const int64_t rebuild_position = ALIGNED_FRAME_LENGTH * 3;
     bool loss_found;
-    bool called = false;
+    int32_t called = 0;
 
     insert_frame(offset_of_message(2));
     insert_frame(offset_of_message(5));
 
     ASSERT_EQ(feedback_delay_state_init(true), 0);
     ASSERT_EQ(aeron_loss_detector_init(
-        &m_detector, &m_delay_generator_state, LossDetectorTest::on_gap_detected, this), 0);
+                  &m_detector, &m_delay_generator_state, LossDetectorTest::on_gap_detected, this),
+              0);
 
     m_on_gap_detected =
         [&](int32_t term_id, int32_t term_offset, size_t length)
-        {
-            EXPECT_EQ(term_id, TERM_ID);
-            EXPECT_EQ(term_offset, offset_of_message(3));
-            EXPECT_EQ(length, 32);
-            called = true;
-        };
+    {
+        EXPECT_EQ(term_id, TERM_ID);
+        EXPECT_EQ(term_offset, offset_of_message(3));
+        EXPECT_EQ(length, 32);
+        called++;
+    };
 
-    called = false;
+    called = 0;
     ASSERT_EQ(aeron_loss_detector_scan(
-        &m_detector, &loss_found, m_ptr, rebuild_position, rebuild_position + 32, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
-        offset_of_message(3));
-    EXPECT_TRUE(called);
+                  &m_detector, &loss_found, m_ptr, m_next_ptr, rebuild_position, rebuild_position + 32, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
+              offset_of_message(3));
+    EXPECT_EQ(called, 1);
     EXPECT_TRUE(loss_found);
 
     m_on_gap_detected =
         [&](int32_t term_id, int32_t term_offset, size_t length)
-        {
-            EXPECT_EQ(term_id, TERM_ID);
-            EXPECT_EQ(term_offset, offset_of_message(3));
-            EXPECT_EQ(length, 64);
-            called = true;
-        };
+    {
+        EXPECT_EQ(term_id, TERM_ID);
+        EXPECT_EQ(term_offset, offset_of_message(3));
+        EXPECT_EQ(length, 64);
+        called++;
+    };
 
-    called = false;
+    called = 0;
     ASSERT_EQ(aeron_loss_detector_scan(
-        &m_detector, &loss_found, m_ptr, rebuild_position, rebuild_position + 64, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
-        offset_of_message(3));
-    EXPECT_TRUE(called);
+                  &m_detector, &loss_found, m_ptr, m_next_ptr, rebuild_position, rebuild_position + 64, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
+              offset_of_message(3));
+    EXPECT_EQ(called, 1);
     EXPECT_TRUE(loss_found);
 
-    called = false;
     ASSERT_EQ(aeron_loss_detector_scan(
-        &m_detector, &loss_found, m_ptr, rebuild_position, rebuild_position + 64, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
-        offset_of_message(3));
-    EXPECT_FALSE(called);
+                  &m_detector, &loss_found, m_ptr, m_next_ptr, rebuild_position, rebuild_position + 64, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
+              offset_of_message(3));
+    EXPECT_EQ(called, 1);
     EXPECT_FALSE(loss_found);
 
     m_on_gap_detected =
         [&](int32_t term_id, int32_t term_offset, size_t length)
-        {
-            EXPECT_EQ(term_id, TERM_ID);
-            EXPECT_EQ(term_offset, offset_of_message(3));
-            EXPECT_EQ(length, 32);
-            called = true;
-        };
+    {
+        EXPECT_EQ(term_id, TERM_ID);
+        EXPECT_EQ(term_offset, offset_of_message(3));
+        EXPECT_EQ(length, 32);
+        called++;
+    };
 
-    called = false;
+    called = 0;
     ASSERT_EQ(aeron_loss_detector_scan(
-        &m_detector, &loss_found, m_ptr, rebuild_position, rebuild_position + 32, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
-        offset_of_message(3));
-    EXPECT_TRUE(called);
-    EXPECT_TRUE(loss_found);
+                  &m_detector, &loss_found, m_ptr, m_next_ptr, rebuild_position, rebuild_position + 32, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
+              offset_of_message(3));
+    EXPECT_EQ(called, 0);
+    EXPECT_FALSE(loss_found);
 
     m_on_gap_detected =
         [&](int32_t term_id, int32_t term_offset, size_t length)
+    {
+        called++;
+
+        if (called == 1)
         {
             EXPECT_EQ(term_id, TERM_ID);
             EXPECT_EQ(term_offset, offset_of_message(3));
             EXPECT_EQ(length, ALIGNED_FRAME_LENGTH * 2);
-            called = true;
-        };
+        }
 
-    called = false;
+        if (called == 2)
+        {
+            EXPECT_EQ(term_id, TERM_ID);
+            EXPECT_EQ(term_offset, offset_of_message(6));
+            EXPECT_EQ(length, CAPACITY - offset_of_message(6));
+        }
+
+        if (called == 3)
+        {
+            EXPECT_EQ(term_id, TERM_ID + 1);
+            EXPECT_EQ(term_offset, 0);
+            EXPECT_EQ(length, rebuild_position);
+        }
+    };
+
+    called = 0;
     ASSERT_EQ(aeron_loss_detector_scan(
-        &m_detector, &loss_found, m_ptr, rebuild_position, rebuild_position + CAPACITY, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
-        offset_of_message(3));
-    EXPECT_TRUE(called);
+                  &m_detector, &loss_found, m_ptr, m_next_ptr, rebuild_position, rebuild_position + CAPACITY, m_time, MASK, POSITION_BITS_TO_SHIFT, TERM_ID),
+              offset_of_message(3));
+    EXPECT_EQ(called, 3);
     EXPECT_TRUE(loss_found);
 }

--- a/aeron-driver/src/test/c/aeron_publication_image_test.cpp
+++ b/aeron-driver/src/test/c/aeron_publication_image_test.cpp
@@ -700,11 +700,7 @@ TEST_F(PublicationImageTest, shouldReportUniqueLoss)
 
     // initial loss report
     aeron_publication_image_on_gap_detected(image, term_id, offset, length);
-    EXPECT_EQ(1, image->begin_loss_change);
-    EXPECT_EQ(term_id, image->loss_term_id);
-    EXPECT_EQ(offset, image->loss_term_offset);
-    EXPECT_EQ(length, image->loss_length);
-    EXPECT_EQ(1, image->end_loss_change);
+    EXPECT_EQ(1, aeron_spsc_concurrent_array_queue_elem_size(&image->pending_losses));
     EXPECT_EQ(1, aeron_loss_reporter_read(
         m_loss_reporter_buffer.data(),
         m_loss_reporter_buffer.size(),
@@ -731,11 +727,7 @@ TEST_F(PublicationImageTest, shouldReportUniqueLoss)
 
     // same loss => no reporting
     aeron_publication_image_on_gap_detected(image, term_id, offset, length);
-    EXPECT_EQ(2, image->begin_loss_change);
-    EXPECT_EQ(term_id, image->loss_term_id);
-    EXPECT_EQ(offset, image->loss_term_offset);
-    EXPECT_EQ(length, image->loss_length);
-    EXPECT_EQ(2, image->end_loss_change);
+    EXPECT_EQ(2, aeron_spsc_concurrent_array_queue_elem_size(&image->pending_losses));
     EXPECT_EQ(1, aeron_loss_reporter_read(
         m_loss_reporter_buffer.data(),
         m_loss_reporter_buffer.size(),
@@ -761,12 +753,9 @@ TEST_F(PublicationImageTest, shouldReportUniqueLoss)
         nullptr));
 
     // less loss => no reporting
+
     aeron_publication_image_on_gap_detected(image, term_id, offset, 32);
-    EXPECT_EQ(3, image->begin_loss_change);
-    EXPECT_EQ(term_id, image->loss_term_id);
-    EXPECT_EQ(offset, image->loss_term_offset);
-    EXPECT_EQ(32, image->loss_length);
-    EXPECT_EQ(3, image->end_loss_change);
+    EXPECT_EQ(3, aeron_spsc_concurrent_array_queue_elem_size(&image->pending_losses));
     EXPECT_EQ(1, aeron_loss_reporter_read(
         m_loss_reporter_buffer.data(),
         m_loss_reporter_buffer.size(),
@@ -793,11 +782,7 @@ TEST_F(PublicationImageTest, shouldReportUniqueLoss)
 
     // larger loss => report
     aeron_publication_image_on_gap_detected(image, term_id, offset, 1500);
-    EXPECT_EQ(4, image->begin_loss_change);
-    EXPECT_EQ(term_id, image->loss_term_id);
-    EXPECT_EQ(offset, image->loss_term_offset);
-    EXPECT_EQ(1500, image->loss_length);
-    EXPECT_EQ(4, image->end_loss_change);
+    EXPECT_EQ(4, aeron_spsc_concurrent_array_queue_elem_size(&image->pending_losses));
     EXPECT_EQ(1, aeron_loss_reporter_read(
         m_loss_reporter_buffer.data(),
         m_loss_reporter_buffer.size(),
@@ -824,11 +809,7 @@ TEST_F(PublicationImageTest, shouldReportUniqueLoss)
 
     // overlapping loss => report
     aeron_publication_image_on_gap_detected(image, term_id, offset + 996, 700);
-    EXPECT_EQ(5, image->begin_loss_change);
-    EXPECT_EQ(term_id, image->loss_term_id);
-    EXPECT_EQ(offset + 996, image->loss_term_offset);
-    EXPECT_EQ(700, image->loss_length);
-    EXPECT_EQ(5, image->end_loss_change);
+    EXPECT_EQ(5, aeron_spsc_concurrent_array_queue_elem_size(&image->pending_losses));
     EXPECT_EQ(1, aeron_loss_reporter_read(
         m_loss_reporter_buffer.data(),
         m_loss_reporter_buffer.size(),
@@ -855,11 +836,7 @@ TEST_F(PublicationImageTest, shouldReportUniqueLoss)
 
     // non-overlapping loss => report
     aeron_publication_image_on_gap_detected(image, term_id, offset + 4096, 128);
-    EXPECT_EQ(6, image->begin_loss_change);
-    EXPECT_EQ(term_id, image->loss_term_id);
-    EXPECT_EQ(offset + 4096, image->loss_term_offset);
-    EXPECT_EQ(128, image->loss_length);
-    EXPECT_EQ(6, image->end_loss_change);
+    EXPECT_EQ(6, aeron_spsc_concurrent_array_queue_elem_size(&image->pending_losses));
     EXPECT_EQ(1, aeron_loss_reporter_read(
         m_loss_reporter_buffer.data(),
         m_loss_reporter_buffer.size(),
@@ -886,11 +863,7 @@ TEST_F(PublicationImageTest, shouldReportUniqueLoss)
 
     // loss in another term => report
     aeron_publication_image_on_gap_detected(image, term_id + 3, 0, 400);
-    EXPECT_EQ(7, image->begin_loss_change);
-    EXPECT_EQ(term_id + 3, image->loss_term_id);
-    EXPECT_EQ(0, image->loss_term_offset);
-    EXPECT_EQ(400, image->loss_length);
-    EXPECT_EQ(7, image->end_loss_change);
+    EXPECT_EQ(7, aeron_spsc_concurrent_array_queue_elem_size(&image->pending_losses));
     EXPECT_EQ(1, aeron_loss_reporter_read(
         m_loss_reporter_buffer.data(),
         m_loss_reporter_buffer.size(),
@@ -917,11 +890,7 @@ TEST_F(PublicationImageTest, shouldReportUniqueLoss)
 
     // same loss => no report
     aeron_publication_image_on_gap_detected(image, term_id + 3, 0, 400);
-    EXPECT_EQ(8, image->begin_loss_change);
-    EXPECT_EQ(term_id + 3, image->loss_term_id);
-    EXPECT_EQ(0, image->loss_term_offset);
-    EXPECT_EQ(400, image->loss_length);
-    EXPECT_EQ(8, image->end_loss_change);
+    EXPECT_EQ(8, aeron_spsc_concurrent_array_queue_elem_size(&image->pending_losses));
     EXPECT_EQ(1, aeron_loss_reporter_read(
         m_loss_reporter_buffer.data(),
         m_loss_reporter_buffer.size(),


### PR DESCRIPTION
Currently Aeron detects and recovers a single loss at a time. This works well enough for low-latency low-loss networks. However in case of long-range WAN connections and loss spikes it takes a lot of time to recover multiple losses. 
In our system we have a connection with RTT ~250ms, and lately we've been experiencing spikes to 5-10% packet loss. Such scenario completely freezes Aeron connections for several seconds.

This PR makes Aeron detects and request retransmission for all gaps instead of the closest one.