### PR TITLE
ConsensusModuleAgent idle strategy usage

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -1354,6 +1354,7 @@ final class ConsensusModuleAgent
             final CountersReader counters = ctx.aeron().countersReader();
             if (null != recPos)
             {
+                idleStrategy.reset();
                 while (CountersReader.RECORD_ALLOCATED == counters.getCounterState(recPos.counterId()) &&
                     recPos.registrationId() == counters.getCounterRegistrationId(recPos.counterId()))
                 {
@@ -1362,6 +1363,7 @@ final class ConsensusModuleAgent
             }
             else
             {
+                idleStrategy.reset();
                 final long archiveId = archive.archiveId();
                 while (CountersReader.NULL_COUNTER_ID !=
                     RecordingPos.findCounterIdByRecording(counters, logRecordingId, archiveId))
@@ -1648,6 +1650,8 @@ final class ConsensusModuleAgent
 
         leadershipTermId(leadershipTermId);
         startLogRecording(channel, ctx.logStreamId(), SourceLocation.LOCAL);
+
+        idleStrategy.reset();
         while (!tryCreateAppendPosition(logSessionId))
         {
             idle();
@@ -1671,6 +1675,8 @@ final class ConsensusModuleAgent
         if (null != consensusModuleExtension)
         {
             final Subscription subscription = aeron.addSubscription(localLogChannel, ctx.logStreamId());
+
+            idleStrategy.reset();
             while (0 == subscription.imageCount())
             {
                 idle();
@@ -1772,6 +1778,7 @@ final class ConsensusModuleAgent
 
             expectedAckPosition = logPosition;
 
+            idleStrategy.reset();
             while (!ServiceAck.hasReached(logPosition, serviceAckId, serviceAckQueues))
             {
                 idle(consensusModuleAdapter.poll());
@@ -2698,6 +2705,7 @@ final class ConsensusModuleAgent
             final Image image = awaitImage(sessionId, subscription);
             final ConsensusModuleSnapshotAdapter adapter = new ConsensusModuleSnapshotAdapter(image, this);
 
+            idleStrategy.reset();
             while (true)
             {
                 final int fragments = adapter.poll();
@@ -2889,6 +2897,7 @@ final class ConsensusModuleAgent
 
     void awaitLocalSocketsClosed(final long registrationId)
     {
+        idleStrategy.reset();
         final CountersReader countersReader = aeron.countersReader();
         while (LocalSocketAddressStatus.findNumberOfAddressesByRegistrationId(countersReader, registrationId) > 0)
         {
@@ -3415,6 +3424,7 @@ final class ConsensusModuleAgent
                 consensusModuleExtension.onStart(this, null);
             }
 
+            idleStrategy.reset();
             while (!ServiceAck.hasReached(expectedAckPosition, serviceAckId, serviceAckQueues))
             {
                 idle(consensusModuleAdapter.poll());
@@ -3489,6 +3499,7 @@ final class ConsensusModuleAgent
 
         serviceProxy.requestServiceAck(expectedAckPosition);
 
+        idleStrategy.reset();
         while (!ServiceAck.hasReached(expectedAckPosition, serviceAckId, serviceAckQueues))
         {
             idle(consensusModuleAdapter.poll());
@@ -3513,6 +3524,7 @@ final class ConsensusModuleAgent
             ctx.fileSyncLevel(),
             ctx.snapshotCounter()))
         {
+            idleStrategy.reset();
             while (!standbySnapshotReplicator.isComplete())
             {
                 try


### PR DESCRIPTION
This PR is to use ConsensusModuleAgent idle strategy not idle strategy supplier and to reset ConsensusModuleAgent idle strategy before using it to idle in a few cases.

Feel free to close if I'm wrong, misunderstanding something, or there's a better approach.