### PR TITLE
[Cluster] Guard onStandbySnapshot() against NPE when acceptStandbypshots is false.

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -1245,6 +1245,11 @@ final class ConsensusModuleAgent
     {
         if (null == election)
         {
+            if (!ctx.acceptStandbySnapshots())
+            {
+                return;
+            }
+
             if (state == ConsensusModule.State.ACTIVE ||
                 state == ConsensusModule.State.SUSPENDED ||
                 state == ConsensusModule.State.SNAPSHOT)


### PR DESCRIPTION
**Description**

  When a Cluster Standby node sends a standby snapshot notification to the cluster (with standbySnapshotNotificationsEnabled=true), all cluster nodes that receive the message will crash into an infinite NullPointerException loop in ConsensusModuleAgent.processPendingSessions() if they have not configured acceptStandbySnapshots=true.

  The NPE is caused by ctx.standbySnapshotCounter() returning null — the counter is only allocated when acceptStandbySnapshots is true in ConsensusModule.Context.conclude(), but the message reception path in onStandbySnapshot() has no corresponding guard.

  **Root Cause**

  ConsensusModuleAgent.onStandbySnapshot() does not check ctx.acceptStandbySnapshots() before accepting the standby snapshot notification. It unconditionally creates a ClusterSession with action=STANDBY_SNAPSHOT and adds it to pendingBackupSessions.

  Later, when processPendingSessions() handles the STANDBY_SNAPSHOT case, it calls:

  ctx.standbySnapshotCounter().increment();  // ConsensusModuleAgent.java:2688

  Since standbySnapshotCounter is null (only allocated when acceptStandbySnapshots=true), this throws a NullPointerException.

  **Impact**

  The NPE is thrown on every duty cycle iteration because:
  1. The exception occurs before the session is removed from pendingSessions (the ArrayListUtil.fastUnorderedRemove call is on the next line)
  2. The AgentRunner catches the exception and re-enters the work loop
  3. The same pending session triggers the same NPE again
  
   This creates a tight error loop (~48,000 NPEs in 10 seconds per node in our testing), which:
  - Prevents consensusWork() from completing (heartbeats, session checks, etc. are skipped)
  - Causes leader heartbeat timeout on followers and inactive follower quorum on the leader
  - Triggers a cluster-wide election, temporarily disrupting service availability
  - Affects all cluster nodes (leader + followers), since the standby sends the notification to every consensus endpoint