### PR TITLE
Added support for C/C++ builds using MSVC on Windows ARM

### DIFF
--- a/aeron-client/src/main/c/concurrent/aeron_atomic.h
+++ b/aeron-client/src/main/c/concurrent/aeron_atomic.h
@@ -58,14 +58,20 @@ while (false)
 
 #endif
 
-#if defined(AERON_COMPILER_GCC) && defined(AERON_CPU_X64)
-    #include "concurrent/aeron_atomic64_gcc_x86_64.h"
-#elif defined(AERON_COMPILER_GCC) && defined(AERON_CPU_ARM)
-    #include "concurrent/aeron_atomic64_c11.h"
-#elif defined(AERON_COMPILER_MSVC) && defined(AERON_CPU_X64)
+#if !defined(AERON_CPU_X64) && !defined(AERON_CPU_ARM)
+    #error Unsupported CPU type!
+#endif
+
+#if defined(AERON_COMPILER_GCC)
+    #if defined(AERON_CPU_X64)
+        #include "concurrent/aeron_atomic64_gcc_x86_64.h"
+    #elif defined(AERON_CPU_ARM)
+        #include "concurrent/aeron_atomic64_c11.h"
+    #endif
+#elif defined(AERON_COMPILER_MSVC)
     #include "concurrent/aeron_atomic64_msvc.h"
 #else
-    #error Unsupported platform!
+    #error Unsupported compiler!
 #endif
 
 #endif //AERON_ATOMIC_H

--- a/aeron-client/src/main/c/concurrent/aeron_atomic64_msvc.h
+++ b/aeron-client/src/main/c/concurrent/aeron_atomic64_msvc.h
@@ -23,22 +23,44 @@
 #include <windows.h>
 #include <intrin.h>
 
+#if defined(AERON_CPU_ARM)
+#define AERON_MEMORY_BARRIER() MemoryBarrier()
+#else
+#define AERON_MEMORY_BARRIER() _ReadWriteBarrier()
+#endif
+
 #define AERON_GET_ACQUIRE(dst, src) \
 do \
 { \
     dst = src; \
-    _ReadWriteBarrier(); \
+    AERON_MEMORY_BARRIER(); \
 } \
 while (false) \
 
 #define AERON_SET_RELEASE(dst, src) \
 do \
 { \
-    _ReadWriteBarrier(); \
+    AERON_MEMORY_BARRIER(); \
     dst = src; \
 } \
 while (false) \
 
+#if defined(AERON_CPU_ARM)
+#define AERON_GET_AND_ADD_INT64(original, current, value) \
+do \
+{ \
+    original = _InterlockedAdd64((long long volatile *)&current, (long long)value) - value; \
+} \
+while (false) \
+
+#define AERON_GET_AND_ADD_INT32(original, current, value) \
+do \
+{ \
+    original = _InterlockedAdd((long volatile *)&current, (long)value) - value; \
+} \
+while (false) \
+
+#else
 #define AERON_GET_AND_ADD_INT64(original, current, value) \
 do \
 { \
@@ -52,6 +74,8 @@ do \
     original = _InlineInterlockedAdd((long volatile *)&current, (long)value) - value; \
 } \
 while (false) \
+
+#endif
 
 inline bool aeron_cas_int64(volatile int64_t *dst, int64_t expected, int64_t desired)
 {
@@ -78,12 +102,12 @@ inline bool aeron_cas_int32(volatile int32_t *dst, int32_t expected, int32_t des
 
 inline void aeron_acquire(void)
 {
-    _ReadWriteBarrier();
+    AERON_MEMORY_BARRIER();
 }
 
 inline void aeron_release(void)
 {
-    _ReadWriteBarrier();
+    AERON_MEMORY_BARRIER();
 }
 
 #define AERON_DECL_ALIGNED(declaration, amt) __declspec(align(amt))  declaration

--- a/aeron-client/src/main/c/concurrent/aeron_thread.h
+++ b/aeron-client/src/main/c/concurrent/aeron_thread.h
@@ -123,7 +123,11 @@ void proc_yield(void);
 #elif defined(AERON_COMPILER_MSVC)
 
 int sched_yield(void);
+#if defined(AERON_CPU_ARM)
+#define proc_yield __yield
+#else
 #define proc_yield _mm_pause
+#endif
 
 #else
 #error Unsupported platform!

--- a/aeron-client/src/main/c/util/aeron_dlopen.c
+++ b/aeron-client/src/main/c/util/aeron_dlopen.c
@@ -263,7 +263,7 @@ int aeron_dl_load_libs_delete(aeron_dl_loaded_libs_state_t *state)
 
 #if defined(AERON_COMPILER_GCC)
             dlclose(lib->handle);
-#elif defined(AERON_COMPILER_MSVC) && defined(AERON_CPU_X64)
+#elif defined(AERON_COMPILER_MSVC)
             FreeLibrary(lib->handle);
 #else
 #error Unsupported platform!

--- a/aeron-client/src/main/c/util/aeron_platform.h
+++ b/aeron-client/src/main/c/util/aeron_platform.h
@@ -26,6 +26,8 @@
 
 #if defined(_M_X64)
 #define AERON_CPU_X64 1
+#elif defined(_M_ARM64)
+#define AERON_CPU_ARM 1
 #else
 #error Unsupported CPU!
 #endif

--- a/aeron-client/src/main/cpp_wrapper/concurrent/Atomic64.h
+++ b/aeron-client/src/main/cpp_wrapper/concurrent/Atomic64.h
@@ -24,6 +24,8 @@
     #include "concurrent/atomic/Atomic64_gcc_cpp11.h"
 #elif defined(AERON_COMPILER_MSVC) && defined(AERON_CPU_X64)
     #include "concurrent/atomic/Atomic64_msvc.h"
+#elif defined(AERON_COMPILER_MSVC) && defined(AERON_CPU_ARM)
+    #include "concurrent/atomic/Atomic64_msvc.h"
 #else
     #error Unsupported platform!
 #endif

--- a/aeron-client/src/main/cpp_wrapper/concurrent/atomic/Atomic64_msvc.h
+++ b/aeron-client/src/main/cpp_wrapper/concurrent/atomic/Atomic64_msvc.h
@@ -44,7 +44,11 @@ inline void release()
 
 inline void cpu_pause()
 {
+#if defined(AERON_CPU_ARM)
+    __yield();
+#else
     _mm_pause();
+#endif
 }
 
 inline std::int32_t getInt32Volatile(volatile std::int32_t *source)

--- a/aeron-client/src/main/cpp_wrapper/util/Platform.h
+++ b/aeron-client/src/main/cpp_wrapper/util/Platform.h
@@ -26,6 +26,8 @@
 
     #if defined(_M_X64)
         #define AERON_CPU_X64 1
+    #elif defined(_M_ARM64)
+        #define AERON_CPU_ARM 1
     #else
         #error Unsupported CPU!
     #endif


### PR DESCRIPTION
A couple small fixes to support builds on Windows ARM; mostly useful at the moment for developers working on an ARM Mac with a Windows VM (all... at least one of them, including me).