### PR TITLE
Improved Windows implementation of aeron_dlopen / aeron_dlsym

### DIFF
--- a/aeron-client/src/main/c/CMakeLists.txt
+++ b/aeron-client/src/main/c/CMakeLists.txt
@@ -22,7 +22,7 @@ endif ()
 if (MSVC AND "${CMAKE_SYSTEM_NAME}" MATCHES "Windows")
     set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
     set(BUILD_SHARED_LIBS ON)
-    set(AERON_LIB_WINSOCK_LIBS wsock32 ws2_32 Iphlpapi)
+    set(AERON_LIB_WINSOCK_LIBS wsock32 ws2_32 Iphlpapi Psapi)
     set(WSAPOLL_PROTOTYPE_EXISTS True)
 endif ()
 

--- a/aeron-client/src/main/c/util/aeron_dlopen.c
+++ b/aeron-client/src/main/c/util/aeron_dlopen.c
@@ -63,92 +63,151 @@ const char *aeron_dlinfo_func(void (*func)(void), char *buffer, size_t max_buffe
 #include "concurrent/aeron_counters_manager.h"
 #include "aeronc.h"
 #include <Windows.h>
+#include <Psapi.h>
+#include <intrin.h>
 
-void *aeron_dlsym_fallback(LPCSTR name)
-{
-    return NULL;
-}
-
+static SRWLOCK modules_lock = SRWLOCK_INIT;
 static HMODULE *modules = NULL;
 static size_t modules_size = 0;
 static size_t modules_capacity = 10;
 
-HMODULE GetCurrentModule()
-{
-    HMODULE hModule = NULL;
-    if (GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCTSTR)GetCurrentModule, &hModule))
-    {
-        return hModule;
-    }
-
-    return NULL;
-}
-
-void aeron_init_dlopen_support()
+// Caller must hold modules_lock exclusively.
+static void aeron_init_dlopen_support()
 {
     if (NULL == modules)
     {
-        modules = (HMODULE*)malloc(sizeof(HMODULE) * modules_capacity);
-        memset(modules, 0, sizeof(HMODULE) * modules_capacity);
-        modules[0] = GetCurrentModule();
-        modules_size = modules[0] != NULL;
+        HANDLE process = GetCurrentProcess();
+        DWORD cb_needed = 0;
+
+        EnumProcessModules(process, NULL, 0, &cb_needed);
+
+        do
+        {
+            size_t num_modules = cb_needed / sizeof(HMODULE);
+            modules_capacity = num_modules + 10;  // extra space for future aeron_dlopen() calls
+            modules = (HMODULE *)realloc(modules, sizeof(HMODULE) * modules_capacity);
+            memset(modules, 0, sizeof(HMODULE) * modules_capacity);
+
+            EnumProcessModules(process, modules, (DWORD)(modules_capacity * sizeof(HMODULE)), &cb_needed);
+        }
+        while (cb_needed / sizeof(HMODULE) > modules_capacity);
+
+        modules_size = cb_needed / sizeof(HMODULE);
     }
 }
 
-void *aeron_dlsym(void *module, const char *name)
+// Returns the index of the module containing addr, or modules_size if not found.
+static size_t aeron_dlsym_find_module_index(void *addr)
 {
-    aeron_init_dlopen_support();
+    HMODULE caller_module = NULL;
+    GetModuleHandleEx(
+        GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+        (LPCTSTR)addr,
+        &caller_module);
+
+    if (NULL != caller_module)
+    {
+        for (size_t i = 0; i < modules_size; i++)
+        {
+            if (modules[i] == caller_module)
+            {
+                return i;
+            }
+        }
+    }
+
+    return modules_size;
+}
+
+static void *aeron_dlsym_from(void *module, const char *name, void *return_address)
+{
+    void *result = NULL;
+
+    AcquireSRWLockShared(&modules_lock);
+
+    if (NULL == modules)
+    {
+        ReleaseSRWLockShared(&modules_lock);
+        AcquireSRWLockExclusive(&modules_lock);
+        aeron_init_dlopen_support();
+        ReleaseSRWLockExclusive(&modules_lock);
+        AcquireSRWLockShared(&modules_lock);
+    }
 
     if (RTLD_DEFAULT == module)
     {
-        for (size_t i = 1; i <= modules_size; i++)
+        for (size_t i = 0; i < modules_size; i++)
         {
-            void *res = aeron_dlsym(modules[modules_size - i], name);
+            void *res = GetProcAddress(modules[i], name);
             if (NULL != res)
             {
-                return res;
+                result = res;
+                break;
             }
         }
-
-        return aeron_dlsym_fallback(name);
     }
-
-    if (RTLD_NEXT == module)
+    else if (RTLD_NEXT == module)
     {
-        BOOL firstFound = FALSE;
-        for (size_t i = 1; i <= modules_size; i++)
-        {
-            void *res = aeron_dlsym(modules[modules_size - i], name);
-            if (NULL != res && firstFound)
-            {
-                return res;
-            }
+        size_t caller_index = aeron_dlsym_find_module_index(return_address);
 
-            if (NULL != res && !firstFound)
+        for (size_t i = caller_index + 1; i < modules_size; i++)
+        {
+            void *res = GetProcAddress(modules[i], name);
+            if (NULL != res)
             {
-                firstFound = TRUE;
+                result = res;
+                break;
             }
         }
-
-        return aeron_dlsym_fallback(name);
+    }
+    else
+    {
+        result = GetProcAddress((HMODULE)module, name);
     }
 
-    return GetProcAddress((HMODULE)module, name);
+    ReleaseSRWLockShared(&modules_lock);
+
+    return result;
+}
+
+__declspec(noinline) void *aeron_dlsym(void *module, const char *name)
+{
+    return aeron_dlsym_from(module, name, _ReturnAddress());
 }
 
 void *aeron_dlopen(const char *filename)
 {
+    AcquireSRWLockExclusive(&modules_lock);
     aeron_init_dlopen_support();
 
     HMODULE module = LoadLibraryA(filename);
 
-    if (modules_size == modules_capacity)
+    if (NULL != module)
     {
-        modules_capacity = modules_capacity * 2;
-        modules = (HMODULE*)realloc(modules, sizeof(HMODULE) * modules_capacity);
+        // Check if module is already in the list (may have been captured by EnumProcessModules)
+        BOOL found = FALSE;
+        for (size_t i = 0; i < modules_size; i++)
+        {
+            if (modules[i] == module)
+            {
+                found = TRUE;
+                break;
+            }
+        }
+
+        if (!found)
+        {
+            if (modules_size == modules_capacity)
+            {
+                modules_capacity = modules_capacity * 2;
+                modules = (HMODULE *)realloc(modules, sizeof(HMODULE) * modules_capacity);
+            }
+
+            modules[modules_size++] = module;
+        }
     }
 
-    modules[modules_size++] = module;
+    ReleaseSRWLockExclusive(&modules_lock);
 
     return module;
 }

--- a/aeron-client/src/test/c/CMakeLists.txt
+++ b/aeron-client/src/test/c/CMakeLists.txt
@@ -32,6 +32,18 @@ function(aeron_c_client_test name file)
 endfunction()
 
 if (AERON_UNIT_TESTS)
+    add_library(aeron_dlopen_test_lib_a SHARED util/aeron_dlopen_test_lib_a.c)
+    set_target_properties(aeron_dlopen_test_lib_a PROPERTIES C_VISIBILITY_PRESET default)
+
+    add_library(aeron_dlopen_test_lib_b SHARED util/aeron_dlopen_test_lib_b.c)
+    set_target_properties(aeron_dlopen_test_lib_b PROPERTIES C_VISIBILITY_PRESET default)
+
+    aeron_c_client_test(dlopen_test util/aeron_dlopen_test.cpp)
+    add_dependencies(dlopen_test aeron_dlopen_test_lib_a aeron_dlopen_test_lib_b)
+    target_compile_definitions(dlopen_test PRIVATE
+        AERON_DLOPEN_TEST_LIB_A_PATH="$<TARGET_FILE:aeron_dlopen_test_lib_a>"
+        AERON_DLOPEN_TEST_LIB_B_PATH="$<TARGET_FILE:aeron_dlopen_test_lib_b>")
+
     aeron_c_client_test(alloc_test aeron_alloc_test.cpp)
     aeron_c_client_test(array_to_ptr_hash_map_test collections/aeron_array_to_ptr_hash_map_test.cpp)
     aeron_c_client_test(int64_to_ptr_hash_map_test collections/aeron_int64_to_ptr_hash_map_test.cpp)

--- a/aeron-client/src/test/c/util/aeron_dlopen_test.cpp
+++ b/aeron-client/src/test/c/util/aeron_dlopen_test.cpp
@@ -27,12 +27,9 @@ class DlopenTest : public testing::Test
 
 TEST_F(DlopenTest, shouldFindExistingSymbolWithRtldDefault)
 {
-    void *sym = aeron_dlsym(RTLD_DEFAULT, "aeron_version_major");
-    ASSERT_NE(nullptr, sym);
-
-    typedef int (*version_func_t)(void);
-    version_func_t version_func = (version_func_t)sym;
-    EXPECT_GT(version_func(), 0);
+    // printf is universally available in the C runtime on all platforms
+    void *sym = aeron_dlsym(RTLD_DEFAULT, "printf");
+    EXPECT_NE(nullptr, sym);
 }
 
 TEST_F(DlopenTest, shouldReturnNullForNonexistentSymbolWithRtldDefault)

--- a/aeron-client/src/test/c/util/aeron_dlopen_test.cpp
+++ b/aeron-client/src/test/c/util/aeron_dlopen_test.cpp
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2026 Adaptive Financial Consulting Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+extern "C"
+{
+#include "util/aeron_dlopen.h"
+}
+
+class DlopenTest : public testing::Test
+{
+};
+
+TEST_F(DlopenTest, shouldFindExistingSymbolWithRtldDefault)
+{
+    void *sym = aeron_dlsym(RTLD_DEFAULT, "aeron_version_major");
+    ASSERT_NE(nullptr, sym);
+
+    typedef int (*version_func_t)(void);
+    version_func_t version_func = (version_func_t)sym;
+    EXPECT_GT(version_func(), 0);
+}
+
+TEST_F(DlopenTest, shouldReturnNullForNonexistentSymbolWithRtldDefault)
+{
+    void *sym = aeron_dlsym(RTLD_DEFAULT, "aeron_nonexistent_symbol_that_does_not_exist_xyz");
+    EXPECT_EQ(nullptr, sym);
+}
+
+TEST_F(DlopenTest, shouldLoadLibraryAndFindSymbolByHandle)
+{
+    void *lib = aeron_dlopen(AERON_DLOPEN_TEST_LIB_A_PATH);
+    ASSERT_NE(nullptr, lib) << "Failed to load test lib A: " << aeron_dlerror();
+
+    typedef int (*func_t)(void);
+    void *sym = aeron_dlsym(lib, "aeron_test_lib_a_func");
+    ASSERT_NE(nullptr, sym);
+
+    func_t func = (func_t)sym;
+    EXPECT_EQ(42, func());
+}
+
+TEST_F(DlopenTest, shouldReturnNullForNonexistentSymbolByHandle)
+{
+    void *lib = aeron_dlopen(AERON_DLOPEN_TEST_LIB_A_PATH);
+    ASSERT_NE(nullptr, lib) << "Failed to load test lib A: " << aeron_dlerror();
+
+    void *sym = aeron_dlsym(lib, "aeron_nonexistent_symbol_xyz");
+    EXPECT_EQ(nullptr, sym);
+}
+
+TEST_F(DlopenTest, shouldReturnNullForNonexistentLibrary)
+{
+    void *lib = aeron_dlopen("nonexistent_library_that_does_not_exist.so");
+    EXPECT_EQ(nullptr, lib);
+}
+
+TEST_F(DlopenTest, shouldFindSymbolFromLoadedLibraryWithRtldDefault)
+{
+    void *lib = aeron_dlopen(AERON_DLOPEN_TEST_LIB_A_PATH);
+    ASSERT_NE(nullptr, lib) << "Failed to load test lib A: " << aeron_dlerror();
+
+    typedef int (*func_t)(void);
+    void *sym = aeron_dlsym(RTLD_DEFAULT, "aeron_test_lib_a_func");
+    ASSERT_NE(nullptr, sym);
+
+    func_t func = (func_t)sym;
+    EXPECT_EQ(42, func());
+}
+
+TEST_F(DlopenTest, shouldFindSymbolNotInFirstModuleWithRtldDefault)
+{
+    void *lib_b = aeron_dlopen(AERON_DLOPEN_TEST_LIB_B_PATH);
+    ASSERT_NE(nullptr, lib_b) << "Failed to load test lib B: " << aeron_dlerror();
+
+    typedef int (*func_t)(void);
+    void *sym = aeron_dlsym(RTLD_DEFAULT, "aeron_test_lib_b_func");
+    ASSERT_NE(nullptr, sym);
+
+    func_t func = (func_t)sym;
+    EXPECT_EQ(99, func());
+}
+
+TEST_F(DlopenTest, shouldFindFirstLoadedSymbolWithRtldDefault)
+{
+    void *lib_a = aeron_dlopen(AERON_DLOPEN_TEST_LIB_A_PATH);
+    ASSERT_NE(nullptr, lib_a) << "Failed to load test lib A: " << aeron_dlerror();
+
+    void *lib_b = aeron_dlopen(AERON_DLOPEN_TEST_LIB_B_PATH);
+    ASSERT_NE(nullptr, lib_b) << "Failed to load test lib B: " << aeron_dlerror();
+
+    typedef int (*func_t)(void);
+
+    // Both libs export aeron_test_shared_func; RTLD_DEFAULT searches in load order,
+    // so lib_a (loaded first) should be found first
+    void *sym = aeron_dlsym(RTLD_DEFAULT, "aeron_test_shared_func");
+    ASSERT_NE(nullptr, sym);
+
+    func_t func = (func_t)sym;
+    EXPECT_EQ(1, func());
+}
+
+// RTLD_NEXT tests are skipped on macOS because its native dlsym(RTLD_NEXT, ...) does not search
+// through dlopen'd libraries, only the static dependency chain. On Linux and Windows (our
+// implementation), RTLD_NEXT correctly searches all loaded modules after the caller's module.
+#if !defined(__APPLE__)
+TEST_F(DlopenTest, shouldFindNextSymbolAfterCallerWithRtldNext)
+{
+    void *lib_a = aeron_dlopen(AERON_DLOPEN_TEST_LIB_A_PATH);
+    ASSERT_NE(nullptr, lib_a) << "Failed to load test lib A: " << aeron_dlerror();
+
+    void *lib_b = aeron_dlopen(AERON_DLOPEN_TEST_LIB_B_PATH);
+    ASSERT_NE(nullptr, lib_b) << "Failed to load test lib B: " << aeron_dlerror();
+
+    typedef int (*func_t)(void);
+
+    // RTLD_NEXT searches modules after the caller's module.
+    // The test executable is the caller, so it should find lib_a first (loaded before lib_b).
+    void *sym = aeron_dlsym(RTLD_NEXT, "aeron_test_shared_func");
+    ASSERT_NE(nullptr, sym);
+
+    func_t func = (func_t)sym;
+    EXPECT_EQ(1, func());
+}
+
+TEST_F(DlopenTest, shouldReturnNullForRtldNextWithNoMatchAfterCaller)
+{
+    void *sym = aeron_dlsym(RTLD_NEXT, "aeron_nonexistent_symbol_that_does_not_exist_xyz");
+    EXPECT_EQ(nullptr, sym);
+}
+#endif
+
+TEST_F(DlopenTest, shouldNotFindSymbolFromOtherLibByHandle)
+{
+    void *lib_a = aeron_dlopen(AERON_DLOPEN_TEST_LIB_A_PATH);
+    ASSERT_NE(nullptr, lib_a) << "Failed to load test lib A: " << aeron_dlerror();
+
+    void *lib_b = aeron_dlopen(AERON_DLOPEN_TEST_LIB_B_PATH);
+    ASSERT_NE(nullptr, lib_b) << "Failed to load test lib B: " << aeron_dlerror();
+
+    // lib_a should not contain lib_b's unique symbol
+    void *sym = aeron_dlsym(lib_a, "aeron_test_lib_b_func");
+    EXPECT_EQ(nullptr, sym);
+
+    // lib_b should not contain lib_a's unique symbol
+    sym = aeron_dlsym(lib_b, "aeron_test_lib_a_func");
+    EXPECT_EQ(nullptr, sym);
+}

--- a/aeron-client/src/test/c/util/aeron_dlopen_test_lib_a.c
+++ b/aeron-client/src/test/c/util/aeron_dlopen_test_lib_a.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Adaptive Financial Consulting Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined(_MSC_VER)
+#define TEST_EXPORT __declspec(dllexport)
+#else
+#define TEST_EXPORT __attribute__((visibility("default")))
+#endif
+
+TEST_EXPORT int aeron_test_lib_a_func(void)
+{
+    return 42;
+}
+
+TEST_EXPORT int aeron_test_shared_func(void)
+{
+    return 1;
+}

--- a/aeron-client/src/test/c/util/aeron_dlopen_test_lib_b.c
+++ b/aeron-client/src/test/c/util/aeron_dlopen_test_lib_b.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Adaptive Financial Consulting Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined(_MSC_VER)
+#define TEST_EXPORT __declspec(dllexport)
+#else
+#define TEST_EXPORT __attribute__((visibility("default")))
+#endif
+
+TEST_EXPORT int aeron_test_lib_b_func(void)
+{
+    return 99;
+}
+
+TEST_EXPORT int aeron_test_shared_func(void)
+{
+    return 2;
+}


### PR DESCRIPTION
aeron_dlopen / aeron_dlsym behavior on Windows should now be much closer to its behavior on Unix. Specifically, aeron_dlsym on Windows previously only looked in the current module to find a symbol, rather than searching through all loaded modules.

Added some appropriate locking to make the dlopen/dlsym utils thread-safe on Windows as well.