### PR TITLE
[Driver/C] Fix aeron_diver_uri_publication_params term_offset.

### DIFF
--- a/aeron-driver/src/main/c/uri/aeron_driver_uri.c
+++ b/aeron-driver/src/main/c/uri/aeron_driver_uri.c
@@ -384,7 +384,7 @@ int aeron_diver_uri_publication_params(
                 EINVAL,
                 "Param %s=%" PRIu64 " must be multiple of FRAME_ALIGNMENT",
                 AERON_URI_TERM_OFFSET_KEY,
-                params->term_offset);
+                term_offset);
             return -1;
         }
 


### PR DESCRIPTION
The check if done if the term_offset is properly aligned. If isn't properly aligned, then an error message is shown which uses the params.term_offset instead of the term_offset as variable.

But the params.term_offset is still 0. So the error message will always show term_offset 0 instead of the offending term offset.