### PR TITLE
[C] Fix bug aeron_spsc_rb_try_claim when insufficient space begin/end

### DIFF
--- a/aeron-client/src/main/c/concurrent/aeron_spsc_rb.c
+++ b/aeron-client/src/main/c/concurrent/aeron_spsc_rb.c
@@ -71,7 +71,7 @@ inline static int32_t aeron_spsc_rb_claim_capacity(aeron_spsc_rb_t *ring_buffer,
 
         if (required_capacity > (ring_buffer->capacity - (size_t)(tail - head)))
         {
-            return -1;
+            return AERON_RB_FULL;
         }
 
         ring_buffer->descriptor->head_cache_position = head;
@@ -101,7 +101,7 @@ inline static int32_t aeron_spsc_rb_claim_capacity(aeron_spsc_rb_t *ring_buffer,
 
             if (required_capacity > head_index)
             {
-                write_index = -1;
+                write_index = AERON_RB_FULL;
                 next_tail = tail;
             }
 
@@ -127,7 +127,7 @@ inline static int32_t aeron_spsc_rb_claim_capacity(aeron_spsc_rb_t *ring_buffer,
         record_index = 0;
     }
 
-    if (-1 != write_index)
+    if (AERON_RB_FULL != write_index)
     {
         next_header = (aeron_rb_record_descriptor_t *)(ring_buffer->buffer + write_index + aligned_record_length);
 
@@ -135,7 +135,7 @@ inline static int32_t aeron_spsc_rb_claim_capacity(aeron_spsc_rb_t *ring_buffer,
         next_header->msg_type_id = 0;
     }
 
-    return (int32_t)record_index;
+    return (int32_t)write_index;
 }
 
 aeron_rb_write_result_t aeron_spsc_rb_writev(

--- a/aeron-client/src/test/c/concurrent/aeron_spsc_rb_test.cpp
+++ b/aeron-client/src/test/c/concurrent/aeron_spsc_rb_test.cpp
@@ -1032,3 +1032,66 @@ TEST(SpscRbConcurrentTest, shouldExchangeMessagesViaTryClaim)
         }
     }
 }
+
+TEST_F(SpscRbTest, tryClaimShouldReturnFullWhenNoSpaceAtEndOrStartOfBuffer)
+{
+    aeron_spsc_rb_t rb;
+    ASSERT_EQ(aeron_spsc_rb_init(&rb, m_buffer.data(), m_buffer.size()), 0);
+
+    const size_t length = 100;
+    const size_t required_capacity =
+        AERON_ALIGN(length + AERON_RB_RECORD_HEADER_LENGTH, AERON_RB_ALIGNMENT) + AERON_RB_RECORD_HEADER_LENGTH;
+
+    const size_t tail = CAPACITY - (AERON_RB_ALIGNMENT * 2);          // 1008
+    const size_t head = required_capacity - (AERON_RB_ALIGNMENT * 2); // 104
+
+    // We prepare the queue so that there is insufficient space at the end
+    // and beginning of the queue to for claim to succeed.
+    rb.descriptor->head_position       = (int64_t)head;
+    rb.descriptor->head_cache_position = (int64_t)head;
+    rb.descriptor->tail_position       = (int64_t)tail;
+
+    EXPECT_EQ(AERON_RB_FULL, aeron_spsc_rb_try_claim(&rb, MSG_TYPE_ID, length));
+
+    EXPECT_EQ((int64_t)CAPACITY, rb.descriptor->tail_position);
+    EXPECT_EQ((int64_t)head,     rb.descriptor->head_position);
+    EXPECT_EQ((int64_t)head,     rb.descriptor->head_cache_position);
+
+    // Ensure that the padding was added at the end
+    auto *padding = (aeron_rb_record_descriptor_t *)(rb.buffer + tail);
+    EXPECT_EQ((int32_t)(CAPACITY - tail),            padding->length);
+    EXPECT_EQ((int32_t)AERON_RB_PADDING_MSG_TYPE_ID, padding->msg_type_id);
+}
+
+TEST_F(SpscRbTest, writeMustNotOverwriteUnreadMessageWhenNoSpaceAtEndOrStartOfBuffer)
+{
+    // this test fills up the buffer with small messages and then consume a single small
+    // message at beginning  so we end up with a queue that has little space in front
+    // and little space at the back. And then we try to place a large message that will
+    // not fit into the available space at either side.
+
+    aeron_spsc_rb_t rb;
+    ASSERT_EQ(aeron_spsc_rb_init(&rb, m_buffer.data(), m_buffer.size()), 0);
+
+    // fill up the ringbuffer with small messages; there will be a bit of space left at
+    // the back
+    for (int32_t i = 0; i < 15; i++)
+    {
+        ASSERT_EQ(AERON_RB_SUCCESS, aeron_spsc_rb_write(&rb, MSG_TYPE_ID + i, m_srcBuffer.data(), 56));
+    }
+
+    // read the first messager so we have some space in the front
+    size_t count = 0;
+    ASSERT_EQ(1u, aeron_spsc_rb_read(&rb, countTimesAsSizeT, &count, 1));
+
+    auto *unread = (aeron_rb_record_descriptor_t *)(rb.buffer + 64);
+    const int32_t unread_length      = unread->length;
+    const int32_t unread_msg_type_id = unread->msg_type_id;
+
+    // try write a single large message
+    EXPECT_EQ(AERON_RB_FULL, aeron_spsc_rb_write(&rb, MSG_TYPE_ID + 99, m_srcBuffer.data(), 128));
+
+    // The 2nd message must be intact and not overwritten by the large message
+    EXPECT_EQ(unread_length,      unread->length)      << "unread message length was overwritten";
+    EXPECT_EQ(unread_msg_type_id, unread->msg_type_id) << "unread message type was overwritten";
+}


### PR DESCRIPTION
When there is insufficient space at the end and at the beginning, the claim_capacity doesn't return -1 (AERON_RB_FULL) unlike the Java version.

So the caller doesn't know there was no space and starts to overwrite content in the ringbuffer. 

It can lead to:
1) corruption of the ringbuffer content 
2) the content corruption can lead to a data race between the producer and consumer, which can lead to UB.