### PR TITLE
[C] Added AERON_RB_IS_CAPACITY_VALID upper bound check.

### DIFF
--- a/aeron-client/src/main/c/concurrent/aeron_rb.h
+++ b/aeron-client/src/main/c/concurrent/aeron_rb.h
@@ -76,6 +76,9 @@ typedef enum aeron_rb_read_action_stct aeron_rb_read_action_t;
 
 typedef aeron_rb_read_action_t (*aeron_rb_controlled_handler_t)(int32_t, const void *, size_t, void *);
 
-#define AERON_RB_IS_CAPACITY_VALID(capacity, min_capacity) AERON_IS_POWER_OF_TWO(capacity) && (capacity) >= (min_capacity)
+#define AERON_RB_IS_CAPACITY_VALID(capacity, min_capacity) \
+    (AERON_IS_POWER_OF_TWO(capacity) && \
+    (capacity) >= (min_capacity) && \
+    (capacity) <= INT32_MAX)
 
 #endif //AERON_RB_H


### PR DESCRIPTION
The maximum capacity for a ringbuffer is limited to INT32_MAX because of available_capacity calculations which are limited to int32_t.

Without this upper bound check, one could create a rb with a capacity larger than INT32_MAX and then run into overflow bugs which can lead to UB.

```
 const int32_t available_capacity = (int32_t)ring_buffer->capacity - (int32_t)(tail - head);
```

