### PR TITLE
Added check to skip re-resolution for response control mode endpoints

### DIFF
--- a/aeron-driver/src/main/c/aeron_driver_conductor.c
+++ b/aeron-driver/src/main/c/aeron_driver_conductor.c
@@ -6405,7 +6405,7 @@ void aeron_driver_conductor_on_re_resolve_endpoint_complete(
     {
         aeron_driver_conductor_log_explicit_error(conductor, errcode, errmsg);
     }
-    else if (AF_UNSPEC != async_cmd->existing_addr.ss_family && 0 != memcmp(
+    else if (0 != memcmp(
         &async_cmd->async_resolve.sockaddr,
         &async_cmd->existing_addr,
         sizeof(struct sockaddr_storage)))

--- a/aeron-driver/src/main/c/aeron_driver_conductor.c
+++ b/aeron-driver/src/main/c/aeron_driver_conductor.c
@@ -6405,7 +6405,7 @@ void aeron_driver_conductor_on_re_resolve_endpoint_complete(
     {
         aeron_driver_conductor_log_explicit_error(conductor, errcode, errmsg);
     }
-    else if (0 != memcmp(
+    else if (AF_UNSPEC != async_cmd->existing_addr.ss_family && 0 != memcmp(
         &async_cmd->async_resolve.sockaddr,
         &async_cmd->existing_addr,
         sizeof(struct sockaddr_storage)))

--- a/aeron-driver/src/main/c/media/aeron_send_channel_endpoint.c
+++ b/aeron-driver/src/main/c/media/aeron_send_channel_endpoint.c
@@ -665,6 +665,7 @@ int aeron_send_channel_endpoint_check_for_re_resolution(
     }
     else if (!endpoint->conductor_fields.udp_channel->is_multicast &&
         endpoint->conductor_fields.udp_channel->has_explicit_endpoint &&
+        AERON_UDP_CHANNEL_CONTROL_MODE_RESPONSE != endpoint->conductor_fields.udp_channel->control_mode &&
         now_ns > (endpoint->time_of_last_sm_ns + AERON_SEND_CHANNEL_ENDPOINT_DESTINATION_TIMEOUT_NS))
     {
         const char *endpoint_name = endpoint->conductor_fields.udp_channel->uri.params.udp.endpoint;

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -530,7 +530,7 @@ public final class DriverConductor implements Agent
                     {
                         recordError(new AeronEvent("could not re-resolve: endpoint=" + endpoint));
                     }
-                    else if (!address.equals(newAddress))
+                    else if (address != null && !address.equals(newAddress))
                     {
                         senderProxy.onResolutionChange(channelEndpoint, endpoint, newAddress);
                     }

--- a/aeron-driver/src/main/java/io/aeron/driver/media/SendChannelEndpoint.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/SendChannelEndpoint.java
@@ -339,7 +339,7 @@ public class SendChannelEndpoint extends UdpChannelTransport
         {
             multiSndDestination.checkForReResolution(this, nowNs, conductorProxy);
         }
-        else if (udpChannel.hasExplicitEndpoint() && !udpChannel.isMulticast())
+        else if (udpChannel.hasExplicitEndpoint() && !udpChannel.isMulticast() && !udpChannel.isResponseControlMode())
         {
             if (statusMessageTimeout(nowNs) && ((timeOfLastResolutionNs + DESTINATION_TIMEOUT) - nowNs) < 0)
             {

--- a/aeron-driver/src/test/c/aeron_network_publication_test.cpp
+++ b/aeron-driver/src/test/c/aeron_network_publication_test.cpp
@@ -24,6 +24,7 @@ extern "C"
 #include "aeron_test_udp_bindings.h"
 #include "aeron_driver_sender.h"
 #include "aeron_position.h"
+#include "concurrent/aeron_mpsc_rb.h"
 
 int aeron_driver_ensure_dir_is_recreated(aeron_driver_context_t *context);
 }
@@ -516,4 +517,79 @@ TEST_F(NetworkPublicationTest, publicationLimitShouldNotCrossIntoTheDirtyTerm)
     aeron_network_publication_update_pub_pos_and_lmt(publication);
     EXPECT_EQ(initial_position + 2 * term_length + 192 + 2 * publication_window_length, aeron_counter_get_plain(publication->pub_lmt_position.value_addr));
     EXPECT_EQ(initial_position + term_length + 192 + publication_window_length, publication->conductor_fields.clean_position);
+}
+
+typedef std::array<std::uint8_t, 4096 + AERON_RB_TRAILER_LENGTH> cmd_queue_buffer_t;
+
+class CheckForReResolutionTest : public NetworkPublicationTest
+{
+protected:
+    void SetUp() override
+    {
+        NetworkPublicationTest::SetUp();
+        ASSERT_EQ(0, aeron_mpsc_rb_init(&m_cmd_queue, m_cmd_queue_buffer.data(), m_cmd_queue_buffer.size()));
+        m_conductor_proxy.threading_mode = AERON_THREADING_MODE_DEDICATED;
+        m_conductor_proxy.command_queue = &m_cmd_queue;
+        m_conductor_proxy.fail_counter = &m_fail_counter;
+    }
+
+    void TearDown() override
+    {
+        EXPECT_EQ(0, m_fail_counter) << "command queue should never have been full";
+        NetworkPublicationTest::TearDown();
+    }
+
+    aeron_send_channel_endpoint_t *createEndpointForUri(const char *uri)
+    {
+        aeron_driver_uri_publication_params_t params = {};
+        params.mtu_length = 1408;
+        params.has_mtu_length = true;
+        params.term_length = 65536;
+        params.has_term_length = true;
+        params.publication_window_length = (int32_t)(params.term_length >> 1);
+        params.has_publication_window_length = true;
+        return createEndpoint(uri, &params, false);
+    }
+
+    static void countMessage(int32_t /*type_id*/, const void * /*buffer*/, size_t /*length*/, void *clientd)
+    {
+        (*static_cast<int *>(clientd))++;
+    }
+
+    int drainAndCount()
+    {
+        int count = 0;
+        aeron_mpsc_rb_read(&m_cmd_queue, countMessage, &count, 100);
+        return count;
+    }
+
+    AERON_DECL_ALIGNED(cmd_queue_buffer_t m_cmd_queue_buffer, 16) = {};
+    aeron_mpsc_rb_t m_cmd_queue = {};
+    aeron_driver_conductor_proxy_t m_conductor_proxy = {};
+    int64_t m_fail_counter = 0;
+};
+
+TEST_F(CheckForReResolutionTest, shouldSkipReResolveForResponseControlMode)
+{
+    auto *endpoint = createEndpointForUri(
+        "aeron:udp?control-mode=response|control=127.0.0.1:10001|endpoint=127.0.0.1:10002");
+    ASSERT_NE(nullptr, endpoint) << aeron_errmsg();
+
+    const int64_t now_ns = AERON_SEND_CHANNEL_ENDPOINT_DESTINATION_TIMEOUT_NS * 2;
+
+    ASSERT_EQ(0, aeron_send_channel_endpoint_check_for_re_resolution(endpoint, now_ns, &m_conductor_proxy));
+
+    EXPECT_EQ(0, drainAndCount()) << "no re-resolve command should be posted for response control mode";
+}
+
+TEST_F(CheckForReResolutionTest, shouldReResolveExplicitEndpointAfterTimeout)
+{
+    auto *endpoint = createEndpointForUri("aeron:udp?endpoint=127.0.0.1:10002");
+    ASSERT_NE(nullptr, endpoint) << aeron_errmsg();
+
+    const int64_t now_ns = AERON_SEND_CHANNEL_ENDPOINT_DESTINATION_TIMEOUT_NS * 2;
+
+    ASSERT_EQ(0, aeron_send_channel_endpoint_check_for_re_resolution(endpoint, now_ns, &m_conductor_proxy));
+
+    EXPECT_EQ(1, drainAndCount());
 }

--- a/aeron-driver/src/test/java/io/aeron/driver/media/SendChannelEndpointTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/media/SendChannelEndpointTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2014-2025 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.driver.media;
+
+import io.aeron.driver.DriverConductorProxy;
+import io.aeron.driver.MediaDriver;
+import io.aeron.driver.status.SystemCounters;
+import org.agrona.CloseHelper;
+import org.agrona.concurrent.CachedNanoClock;
+import org.agrona.concurrent.status.AtomicCounter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+
+import static io.aeron.driver.media.SendChannelEndpoint.DESTINATION_TIMEOUT;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class SendChannelEndpointTest
+{
+    private final SystemCounters mockSystemCounters = mock(SystemCounters.class);
+    private final AtomicCounter mockCounter = mock(AtomicCounter.class);
+    private final AtomicCounter mockStatusIndicator = mock(AtomicCounter.class);
+    private final DriverConductorProxy mockConductorProxy = mock(DriverConductorProxy.class);
+    private final CachedNanoClock nanoClock = new CachedNanoClock();
+
+    private final MediaDriver.Context context = new MediaDriver.Context()
+        .systemCounters(mockSystemCounters)
+        .cachedNanoClock(nanoClock)
+        .senderCachedNanoClock(nanoClock)
+        .receiverCachedNanoClock(nanoClock)
+        .receiveChannelEndpointThreadLocals(new ReceiveChannelEndpointThreadLocals())
+        .senderPortManager(new WildcardPortManager(WildcardPortManager.EMPTY_PORT_RANGE, true))
+        .receiverPortManager(new WildcardPortManager(WildcardPortManager.EMPTY_PORT_RANGE, false));
+
+    private SendChannelEndpoint endpoint;
+
+    SendChannelEndpointTest()
+    {
+        when(mockSystemCounters.get(any())).thenReturn(mockCounter);
+    }
+
+    @AfterEach
+    void tearDown()
+    {
+        CloseHelper.close(endpoint);
+    }
+
+    @Test
+    void shouldSkipReResolveForResponseControlMode()
+    {
+        final UdpChannel responseChannel = UdpChannel.parse(
+            "aeron:udp?control-mode=response|control=127.0.0.1:10001|endpoint=127.0.0.1:10002");
+
+        endpoint = new SendChannelEndpoint(responseChannel, mockStatusIndicator, context);
+
+        endpoint.checkForReResolution(DESTINATION_TIMEOUT * 2, mockConductorProxy);
+
+        verify(mockConductorProxy, never()).reResolveEndpoint(
+            anyString(), any(SendChannelEndpoint.class), nullable(InetSocketAddress.class));
+    }
+
+    @Test
+    void shouldReResolveExplicitEndpointAfterTimeout()
+    {
+        final UdpChannel channel = UdpChannel.parse("aeron:udp?endpoint=127.0.0.1:10002");
+
+        endpoint = new SendChannelEndpoint(channel, mockStatusIndicator, context);
+
+        endpoint.checkForReResolution(DESTINATION_TIMEOUT * 2, mockConductorProxy);
+
+        verify(mockConductorProxy, times(1)).reResolveEndpoint(
+            anyString(), any(SendChannelEndpoint.class), nullable(InetSocketAddress.class));
+    }
+}


### PR DESCRIPTION
No need to re-resolve things for an endpoint that should just be null anyway. Already enforced here:

https://github.com/aeron-io/aeron/commit/411f7b6a64e99ea834fcda41af4f95b0a7741034#diff-a29f3df5050a13706ce29b053e4f5b062097b2e5b01f67a8b365ae6875a62ac1L105

when first constructing the endpoint, but the same check was missing in `checkForReResolution`.