### PR TITLE
Fixed flaky cannotFallbackToReplayWhenTheRecordingHasStoppedAtAnEarlierPosition test

### DIFF
--- a/aeron-archive/src/test/c/client/aeron_archive_persistent_subscription_test.cpp
+++ b/aeron-archive/src/test/c/client/aeron_archive_persistent_subscription_test.cpp
@@ -3366,26 +3366,10 @@ TEST_F(AeronArchivePersistentSubscriptionTest, cannotFallbackToReplayWhenRecordi
     executeUntil("receives both batches", poller,
         [&] { return handler.messageCount() == first_batch.size() + second_batch.size(); });
 
-    // Flood messages to make the persistent subscription fall behind and drop from live.
-    // Interleave offering with polling the fast consumer so the publication can advance.
-    for (int i = 0; i < 3; i++)
-    {
-        const std::vector<std::vector<uint8_t>> flood = generateFixedMessages(32, ONE_KB_MESSAGE_SIZE);
-        for (const std::vector<uint8_t> &msg : flood)
-        {
-            while (aeron_exclusive_publication_offer(
-                persistent_publication.publication(), msg.data(), msg.size(), nullptr, nullptr) < 0)
-            {
-                aeron_subscription_poll(fast_subscription,
-                    [](void*, const uint8_t*, size_t, aeron_header_t*){}, nullptr, 10);
-            }
-        }
-        // Drain any remaining in the fast consumer
-        while (aeron_subscription_poll(fast_subscription,
-            [](void*, const uint8_t*, size_t, aeron_header_t*){}, nullptr, 10) > 0)
-        {
-        }
-    }
+    // Close the publication so the live image ends via EOS rather than relying on a flow-control timeout.
+    // The persistent subscription then refreshes the recording descriptor and the validate step rejects
+    // the replay because its position is past the recording's stop position.
+    aeron_exclusive_publication_close(persistent_publication.publication(), nullptr, nullptr);
 
     // PS should fail because it can't replay past the recording's stop position
     executeUntil("has failed", poller,

--- a/aeron-system-tests/src/test/java/io/aeron/archive/client/PersistentSubscriptionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/client/PersistentSubscriptionTest.java
@@ -2029,7 +2029,7 @@ abstract class PersistentSubscriptionTest
     }
 
     @Test
-    @InterruptAfter(30)
+    @InterruptAfter(15)
     void cannotFallbackToReplayWhenTheRecordingHasStoppedAtAnEarlierPosition()
     {
         final PersistentPublication persistentPublication =
@@ -2065,7 +2065,8 @@ abstract class PersistentSubscriptionTest
             // Stop the recording
             aeronArchive.stopRecording(persistentPublication.publication);
 
-            // Consume more messages on live, which will not be recorded
+            // Publish more messages that will not be recorded so the persistent subscription advances past
+            // the recording's stop position.
             final List<byte[]> secondMessageBatch = generateFixedPayloads(5, ONE_KB_MESSAGE_SIZE);
             persistentPublication.publish(secondMessageBatch);
 
@@ -2074,21 +2075,11 @@ abstract class PersistentSubscriptionTest
                 () -> poll(persistentSubscription, fragmentHandler, 10)
             );
 
-            // Allow a faster consumer to advance ahead, causing the persistent subscription to drop from live.
-            final List<byte[]> thirdMessageBatch = new ArrayList<>();
-            for (int i = 0; i < 3; i++)
-            {
-                final List<byte[]> batch = generateFixedPayloads(32, ONE_KB_MESSAGE_SIZE);
-                persistentPublication.publish(batch);
-                thirdMessageBatch.addAll(batch);
-                executeUntil(
-                    () -> countingFragmentHandler.hasReceivedPayloads(thirdMessageBatch.size()),
-                    () -> fastSubscription.poll(countingFragmentHandler, 10)
-                );
-            }
+            // Close the publication so the live image ends via EOS rather than relying on a flow-control timeout.
+            // The persistent subscription then refreshes the recording descriptor and the validate step rejects
+            // the replay because its position is past the recording's stop position.
+            persistentPublication.closePublicationOnly();
 
-            // Verify we cannot fall back to replay, as we have already advanced beyond the stop position of
-            // the recording.
             executeUntil(
                 persistentSubscription::hasFailed,
                 () -> poll(persistentSubscription, fragmentHandler, 10)


### PR DESCRIPTION
`cannotFallbackToReplayWhenTheRecordingHasStoppedAtAnEarlierPosition` was written to rely on an image timing out and closing.  Almost always it did time out:

1. After the flood, PS is far behind the publisher's snd_pos.
2. PS's last sent SM has a low sm_position, so last_overrun_threshold = sm_position + term_length/2 stays low.
3. The publisher emits a heartbeat every 100 ms. Each heartbeat's position equals snd_pos, which is now above the threshold.
4. aeron_publication_image_insert_packet rejects the heartbeat as is_flow_control_over_run, so time_of_last_packet_ns is not refreshed.
6. After 2 s of no refresh, the C driver's image_liveness_timeout fires; the image transitions ACTIVE → DRAINING → LINGER → unavailable_image.

However... if PS happens to consume just enough during the flood that its last_sm_position advances close to snd_pos, the last_overrun_threshold rises with it. Heartbeats now stay below threshold and update time_of_last_packet_ns, and the 2-second liveness timer never fires, the image never closes, and PS sits in LIVE forever.

So instead of relying on a complicated and brittle timeout to close the image... this change just closes the publication explicitly.  I believe the test is still more or less testing what it was mostly meant to test, and we have other existing tests that already cover a real image timeout, so I don't think we lose anything.