### PR TITLE
Point to the usage instructions from the persistent subscription sample

### DIFF
--- a/aeron-samples/scripts/archive/README.md
+++ b/aeron-samples/scripts/archive/README.md
@@ -124,7 +124,5 @@ channel.
 4. Let some messages be sentm then start a Persistent Subscription subscriber, setting `aeron.sample.channel` to the same channel as the publication.
 
 ```shell
-export JVM_OPTS="-Daeron.sample.channel=aeron:udp?control=localhost:20550"
-
 ./persistent-subscriber
 ```

--- a/aeron-samples/src/main/java/io/aeron/samples/archive/PersistentSubscriber.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/archive/PersistentSubscriber.java
@@ -38,6 +38,8 @@ import static io.aeron.samples.SamplesUtil.findLatestRecording;
  * The default values for channel and stream ID are defined in {@link SampleConfiguration} and can be
  * overridden by setting their corresponding properties via the command-line; e.g.:
  * {@code -Daeron.sample.channel=aeron:udp?endpoint=localhost:5555 -Daeron.sample.streamId=20}
+ *
+ * For details on how to use this sample, see the Persistent Subscription section in the Archive samples README.
  */
 public class PersistentSubscriber
 {


### PR DESCRIPTION
Point to README from Persistent Subscription sample and remove `export` command from usage instructions. 