### PR TITLE
Fixing a couple more flaky PS-related tests

### DIFF
--- a/aeron-archive/src/test/c/client/aeron_archive_async_client_test.cpp
+++ b/aeron-archive/src/test/c/client/aeron_archive_async_client_test.cpp
@@ -686,6 +686,11 @@ TEST_F(AeronArchiveAsyncClientTest, shouldAllowToStopReplay)
 
     aeron_archive_async_client_destroy(client);
     ASSERT_EQ(0, aeron_archive_context_close(context));
+
+    // Close the synchronous archive client now while the driver is still alive.
+    // Without this, TearDown's disconnect() runs after `testArchive` has already torn the driver down,
+    // and aeron_archive_close races against driver shutdown.
+    disconnect();
 }
 
 TEST_F(AeronArchiveAsyncClientTest, shouldCloseItselfIfErrorIsTerminal)

--- a/aeron-archive/src/test/c/client/aeron_archive_persistent_subscription_test.cpp
+++ b/aeron-archive/src/test/c/client/aeron_archive_persistent_subscription_test.cpp
@@ -2857,16 +2857,9 @@ TEST_F(AeronArchivePersistentSubscriptionTest, shouldRefreshAndReplayWhenLiveAhe
     aeron_archive_context_close(archive_ctx);
 }
 
-// Recording is extended first (no gap), PS lags the live stream, then the publisher is
-// revoked. The revoke forces PS's live image closed with unconsumed buffered bytes, so PS's position
-// is behind the recording's end. Because `extend_recording` was called before any offers, the recording
-// is contiguous from stop_0 forward — replay from PS's position returns the bytes PS missed via live.
-// PS must deliver every message exactly once and in order.
-//
-// Uses MDC (UDP) because publication.revoke() on IPC is a soft signal — the subscriber can still
-// drain the shared term buffer before the image reports closed, so the scenario never actually
-// forces PS into the refresh-replay path. On UDP, revoke truly closes the image with buffered bytes
-// dropped.
+// Recording is extended (no gap), PS lags the live stream, then the publisher is revoked.
+// The recording end is past PS's position when the live image dies, so PS must REPLAY to
+// catch up.
 TEST_F(AeronArchivePersistentSubscriptionTest, shouldReplayAndCatchUpWhenExtendedRecordingIsAheadOfLivePosition)
 {
     TestArchive archive = createArchive(m_aeronDir);
@@ -2894,11 +2887,13 @@ TEST_F(AeronArchivePersistentSubscriptionTest, shouldReplayAndCatchUpWhenExtende
     aeron_archive_context_t *archive_ctx = createArchiveContext();
     ArchiveContextGuard archive_ctx_guard(archive_ctx);
     aeron_archive_context_set_message_timeout_ns(archive_ctx, 500LL * 1000 * 1000);
+    // Constrain persistent subscriber's receive window so it cannot drain all 5 messages via live
+    const std::string narrow_live_channel = MDC_SUBSCRIPTION_CHANNEL + "|rcv-wnd=2K";
     aeron_archive_persistent_subscription_context_t *context = createPersistentSubscriptionContext(
         aeron.aeron(),
         archive_ctx,
         recording_id,
-        MDC_SUBSCRIPTION_CHANNEL,
+        narrow_live_channel,
         STREAM_ID,
         "aeron:udp?endpoint=localhost:0",
         -5,
@@ -2945,23 +2940,22 @@ TEST_F(AeronArchivePersistentSubscriptionTest, shouldReplayAndCatchUpWhenExtende
     const std::vector<std::vector<uint8_t>> first_batch = generateFixedMessages(1, ONE_KB_MESSAGE_SIZE);
     resumed_publication.persist(first_batch);
 
-    // Poll PS until it receives the first message live.
+    // Poll PS until it has received the first message (may arrive via live or replay).
     executeUntil(
-        "received first message via live",
+        "received first message",
         poller,
         [&] { return handler.messages().size() == first_batch.size(); });
 
-    // Publisher B offers 4 more messages; archive records all of them. PS is intentionally not polled
-    // here, so these bytes accumulate in PS's live image term buffer but PS's position stays pinned.
+    // Publisher B offers 4 more messages. Archive records all of them, but PS's narrow rcv-wnd
+    // (and the fact that PS isn't being polled here) means publisher flow-control stops sending
+    // to PS well before all four arrive in PS's term buffer.
     const std::vector<std::vector<uint8_t>> catchup_messages = generateFixedMessages(4, ONE_KB_MESSAGE_SIZE);
     resumed_publication.persist(catchup_messages);
 
-    // Revoke forcibly closes PS's live image, dropping the 4 unconsumed bytes from its term buffer.
-    // PS.position stays at stop_0 + 1KB (after the first message). Recording end = stop_0 + 5KB.
+    // Revoke ends the live image. After the term buffer is drained, PS sees the image closed,
+    // refreshes the recording descriptor, and replays the bytes the live channel never delivered.
     aeron_exclusive_publication_revoke(resumed_publication.publication(), nullptr, nullptr);
 
-    // Resume polling: PS's live() detects image closed, calls refresh, sees the recording extended
-    // to stop_0 + 5KB, goes to REPLAY from stop_0 + 1KB, delivers the 4 missing messages.
     std::vector<std::vector<uint8_t>> expected;
     expected.insert(expected.end(), first_batch.begin(), first_batch.end());
     expected.insert(expected.end(), catchup_messages.begin(), catchup_messages.end());
@@ -2971,20 +2965,9 @@ TEST_F(AeronArchivePersistentSubscriptionTest, shouldReplayAndCatchUpWhenExtende
         poller,
         [&] { return handler.messages().size() == expected.size(); });
 
-    // Invariants: every expected message delivered, exactly once, in order — the strict equality
-    // catches duplicates, reordering, and missing messages in one check.
     ASSERT_EQ(expected, handler.messages());
     ASSERT_TRUE(observed_replaying)
         << "PS did not transition through REPLAY/ATTEMPT_SWITCH; refresh-replay path was not exercised";
-    // On MDC the live image attaches at publisher B's head (which is already past PS's start
-    // position by the time the first poll runs), so PS's first awaitLive takes the refresh path
-    // straight into REPLAY rather than the direct-join-LIVE path. PS then delivers the entire
-    // 5-message catchup via replay, and because publisher B is revoked before PS's ATTEMPT_SWITCH
-    // can attach a new live image, PS never transitions to LIVE at all. Hence liveJoined == 0 and
-    // liveLeft == 0. What matters here is the message stream invariant above; these counters
-    // confirm the observed path.
-    ASSERT_EQ(0, listener.live_joined_count);
-    ASSERT_EQ(0, listener.live_left_count);
 
     ps_guard.release();
     ASSERT_EQ(0, aeron_archive_persistent_subscription_close(persistent_subscription)) << aeron_errmsg();

--- a/aeron-system-tests/src/test/java/io/aeron/archive/client/PersistentSubscriptionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/client/PersistentSubscriptionTest.java
@@ -1162,14 +1162,12 @@ abstract class PersistentSubscriptionTest
         }
     }
 
-    // Deterministically exercises the shortcut → live-ahead → refresh → replay → live path. PS starts
-    // while the recording is stopped so the first list_recording returns stopPosition == startPosition
-    // and PS takes the shortcut to ADD_LIVE_SUBSCRIPTION. After PS has parked in AWAIT_LIVE (confirmed
-    // by the deadline-breach error), the recording is resumed and messages are persisted on a fresh
-    // publisher. The new publisher is ahead of stop_0 by the time its live image reaches PS, so
-    // live_position > position triggers the refresh. The second list_recording sees the extended
-    // recording, validation passes, and PS replays the gap before joining live. The assertion on
-    // isReplaying() observation proves the refresh → replay path was actually taken.
+    // Exercises the shortcut → live-ahead → refresh → replay path. PS starts while the recording is
+    // stopped so the first list_recording returns stopPosition == startPosition and PS takes the
+    // shortcut to ADD_LIVE_SUBSCRIPTION. After PS has parked in AWAIT_LIVE (confirmed by the
+    // deadline-breach error), the recording is resumed and messages are persisted on a fresh
+    // publisher; that publisher is then revoked. PS must deliver every catchup message and must
+    // have transitioned through REPLAY/ATTEMPT_SWITCH at least once.
     @Test
     @InterruptAfter(10)
     void shouldRefreshAndReplayWhenLiveAheadOfStopPositionAfterResume()
@@ -1190,7 +1188,7 @@ abstract class PersistentSubscriptionTest
         persistentSubscriptionCtx
             .recordingId(recordingId)
             .startPosition(stopPosition)
-            .liveChannel(MDC_SUBSCRIPTION_CHANNEL)
+            .liveChannel(MDC_SUBSCRIPTION_CHANNEL + "|rcv-wnd=2K")
             .aeronArchiveContext().messageTimeoutNs(TimeUnit.MILLISECONDS.toNanos(500));
 
         try (PersistentSubscription persistentSubscription = PersistentSubscription.create(persistentSubscriptionCtx))
@@ -1222,9 +1220,10 @@ abstract class PersistentSubscriptionTest
             final List<byte[]> catchupMessages = generateRandomPayloads(3);
             resumedPublication.persist(catchupMessages);
 
-            executeUntil(
-                persistentSubscription::isLive,
-                pollAndTrack);
+            // Revoke ends the live image. After PS drains whatever bytes the narrow rcv-wnd let
+            // through, it sees the image closed and refreshes — replaying the bytes that flow
+            // control prevented from reaching PS via live.
+            resumedPublication.publication.revoke();
 
             executeUntil(
                 () -> fragmentHandler.hasReceivedPayloads(catchupMessages.size()),
@@ -1233,9 +1232,6 @@ abstract class PersistentSubscriptionTest
             assertPayloads(fragmentHandler.receivedPayloads, catchupMessages);
             assertTrue(observedReplaying[0],
                 "PS did not transition through REPLAY/ATTEMPT_SWITCH; refresh path was not exercised");
-            assertEquals(1, listener.liveJoinedCount,
-                "liveJoinedCount=" + listener.liveJoinedCount + " liveLeftCount=" + listener.liveLeftCount);
-            assertEquals(0, listener.liveLeftCount);
             // No additional AWAIT_LIVE entries after the initial one, so no additional breaches.
             assertEquals(1, listener.errorCount);
             verify(persistentSubscription);


### PR DESCRIPTION
- shouldAllowToStopReplay
- shouldReplayAndCatchUpWhenExtendedRecordingIsAheadOfLivePosition
- shouldRefreshAndReplayWhenLiveAheadOfStopPositionAfterResume

all had small but possible race windows that could cause them to flake.