### PR TITLE
More fixes for flaky PS tests

### DIFF
--- a/aeron-archive/src/test/c/CMakeLists.txt
+++ b/aeron-archive/src/test/c/CMakeLists.txt
@@ -68,6 +68,8 @@ if (AERON_SYSTEM_TESTS)
     target_sources(aeron_archive_persistent_subscription_resilience_test PRIVATE
         ${AERON_TEST_SUPPORT_C_PATH}/aeron_stream_id_loss_generator.c
         ${AERON_TEST_SUPPORT_C_PATH}/aeron_stream_id_frame_data_loss_generator.c
-        ${AERON_TEST_SUPPORT_C_PATH}/aeron_frame_data_loss_generator.c)
+        ${AERON_TEST_SUPPORT_C_PATH}/aeron_frame_data_loss_generator.c
+        ${AERON_TEST_SUPPORT_C_PATH}/aeron_setup_at_position_loss_generator.c
+        ${AERON_TEST_SUPPORT_C_PATH}/aeron_data_in_range_loss_generator.c)
     aeron_c_archive_system_test(aeron_archive_test client/aeron_archive_test.cpp)
 endif ()

--- a/aeron-archive/src/test/c/client/aeron_archive_persistent_subscription_resilience_test.cpp
+++ b/aeron-archive/src/test/c/client/aeron_archive_persistent_subscription_resilience_test.cpp
@@ -42,6 +42,8 @@ extern "C"
 #include "aeron_stream_id_loss_generator.h"
 #include "aeron_stream_id_frame_data_loss_generator.h"
 #include "aeron_frame_data_loss_generator.h"
+#include "aeron_setup_at_position_loss_generator.h"
+#include "aeron_data_in_range_loss_generator.h"
 }
 
 static const std::string IPC_CHANNEL = "aeron:ipc";
@@ -229,36 +231,6 @@ private:
         listener->last_errcode = errcode;
         listener->last_error_message = message;
         listener->error_count++;
-    }
-};
-
-class PrintingListener
-{
-    aeron_archive_persistent_subscription_listener_t m_listener;
-
-    static void onLiveJoined(void *clientd)
-    {
-        std::cout << "live joined" << std::endl;
-    }
-
-    static void onLiveLeft(void *clientd)
-    {
-        std::cout << "live left" << std::endl;
-    }
-
-    static void onError(void *clientd, int errcode, const char *message)
-    {
-        std::cout << "error " << errcode << " " << message << std::endl;
-    }
-
-public:
-    PrintingListener() : m_listener({onLiveJoined, onLiveLeft, onError, nullptr})
-    {
-    }
-
-    aeron_archive_persistent_subscription_listener_t *listener()
-    {
-        return &m_listener;
     }
 };
 
@@ -1564,6 +1536,20 @@ public:
         m_ownedGenerators.push_back(gen);
     }
 
+    // Installs a custom supplier called for each new receive endpoint. The supplier
+    // is responsible for setting endpoint->data_loss_generator (and/or
+    // control_loss_generator) — typically by allocating a fresh per-endpoint
+    // generator that captures the endpoint pointer in its state. Use this when
+    // the loss decision needs endpoint-specific context (e.g. the URI) that isn't
+    // available at frame-check time through the simple shared-generator hook.
+    // Mutually exclusive with setReceiveChannelDataLossGenerator(); call before start().
+    void setReceiveChannelLossSupplier(
+        aeron_receive_channel_loss_supplier_func_t supplier, void *clientd)
+    {
+        m_receiveLossSupplier = supplier;
+        m_receiveLossSupplierClientd = clientd;
+    }
+
     void setImageLivenessTimeoutNs(std::uint64_t ns)
     {
         m_imageLivenessTimeoutNs = ns;
@@ -1621,7 +1607,12 @@ private:
         aeron_driver_context_set_enable_experimental_features(m_context, true);
         aeron_driver_context_set_spies_simulate_connection(m_context, true);
 
-        if (m_receiveDataLossGenerator != nullptr)
+        if (m_receiveLossSupplier != nullptr)
+        {
+            aeron_driver_context_set_receive_channel_loss_supplier(
+                m_context, m_receiveLossSupplier, m_receiveLossSupplierClientd);
+        }
+        else if (m_receiveDataLossGenerator != nullptr)
         {
             aeron_driver_context_set_receive_channel_loss_supplier(
                 m_context, installReceiveDataLossGenerator, m_receiveDataLossGenerator);
@@ -1658,6 +1649,8 @@ private:
     aeron_driver_context_t *m_context = nullptr;
     aeron_driver_t *m_driver = nullptr;
     aeron_loss_generator_t *m_receiveDataLossGenerator = nullptr;
+    aeron_receive_channel_loss_supplier_func_t m_receiveLossSupplier = nullptr;
+    void *m_receiveLossSupplierClientd = nullptr;
     std::vector<aeron_loss_generator_t *> m_ownedGenerators;
 };
 
@@ -1692,6 +1685,33 @@ public:
           m_archiveDir(archiveDir)
     {
         driver.setReceiveChannelDataLossGenerator(receiveDataLossGenerator);
+        driver.aeronDir(aeronDir);
+        if (imageLivenessTimeoutNs > 0)
+        {
+            driver.setImageLivenessTimeoutNs(imageLivenessTimeoutNs);
+        }
+        driver.start();
+
+        archive = std::make_unique<TestStandaloneArchive>(
+            m_aeronDir, m_archiveDir, std::cout,
+            LOCALHOST_CONTROL_REQUEST_CHANNEL, "aeron:udp?endpoint=localhost:0");
+    }
+
+    // Supplier-driven variant for tests that need per-endpoint loss generators.
+    // The supplier callback is invoked by the driver for each new receive endpoint
+    // and is expected to populate endpoint->data_loss_generator (and/or
+    // control_loss_generator) with a fresh per-endpoint generator that captures
+    // any endpoint-specific context it needs.
+    LossTestHarness(
+        const std::string &aeronDir,
+        const std::string &archiveDir,
+        aeron_receive_channel_loss_supplier_func_t receiveLossSupplier,
+        void *receiveLossSupplierClientd,
+        std::uint64_t imageLivenessTimeoutNs = 0)
+        : m_aeronDir(aeronDir),
+          m_archiveDir(archiveDir)
+    {
+        driver.setReceiveChannelLossSupplier(receiveLossSupplier, receiveLossSupplierClientd);
         driver.aeronDir(aeronDir);
         if (imageLivenessTimeoutNs > 0)
         {
@@ -1758,9 +1778,6 @@ void AeronArchivePersistentSubscriptionTest::shouldHandleReplayImageBecomingUnav
     PersistentSubscriptionContextGuard context_guard(context);
     aeron_archive_persistent_subscription_context_set_replay_channel(context,
         "aeron:udp?endpoint=127.0.0.1:10013|rcv-wnd=4k");
-
-    PrintingListener printingListener;
-    aeron_archive_persistent_subscription_context_set_listener(context, printingListener.listener());
 
     aeron_archive_persistent_subscription_t *persistent_subscription = nullptr;
     ASSERT_EQ(0, aeron_archive_persistent_subscription_create(&persistent_subscription, context)) << aeron_errmsg();
@@ -5148,3 +5165,395 @@ TEST_F(AeronArchivePersistentSubscriptionTest, shouldCancelPendingLiveSubscripti
 
 }
 
+// Per-endpoint supplier used by shouldRefreshAndReplayWhenLiveAheadOfStopPositionAfterResume.
+// `clientd` is the shared aeron_setup_at_position_loss_config_t. Each new receive endpoint
+// gets its own generator instance whose state captures the endpoint pointer; at frame-check
+// time the generator reads endpoint->conductor_fields.udp_channel->original_uri to decide
+// whether the endpoint is exempt from the drop (i.e. the recording subscription's endpoint).
+static void installSetupAtPositionLossGenerator(
+    void *clientd, aeron_receive_channel_endpoint_t *endpoint)
+{
+    auto *config = static_cast<aeron_setup_at_position_loss_config_t *>(clientd);
+    aeron_loss_generator_t *generator = nullptr;
+    if (aeron_setup_at_position_loss_generator_create(&generator, config, endpoint) == 0)
+    {
+        endpoint->data_loss_generator = generator;
+    }
+}
+
+// Deterministically exercises the AWAIT_LIVE -> live-ahead -> refresh_recording_descriptor
+// -> replay -> live path. PS shortcuts to AWAIT_LIVE while the recording is stopped at
+// stop_0. When publisher B is resumed, its first SETUP carries (initial_term_id,
+// term_id_at_stop_0, offset_at_stop_0) — which is also where PS's start_position sits.
+// Without intervention, PS's image is created at exactly stop_0, the AWAIT_LIVE check
+// `live_position > position` is false, and PS takes the direct LIVE path instead of
+// refreshing.
+//
+// To force the refresh path deterministically, a per-endpoint loss generator drops SETUPs
+// whose (initial_term_id, active_term_id, term_offset) tuple matches publisher B's initial
+// position — but only on PS's endpoint. The recording subscription's endpoint is exempt
+// (its URI carries `init-term-id=`), so the recording is created at stop_0 and stays
+// contiguous. PS's UDP receiver elicits another SETUP via SM. By the time publisher B's
+// next SETUP fires (gated by AERON_NETWORK_PUBLICATION_SETUP_TIMEOUT_NS = 100 ms),
+// `snd_pos` has advanced past the offers we issued, the SETUP no longer matches the drop
+// filter, and PS's image is created with `join_position > stop_0` — triggering the
+// refresh path.
+TEST_F(AeronArchivePersistentSubscriptionTest, shouldRefreshAndReplayWhenLiveAheadOfStopPositionAfterResume)
+{
+    aeron_setup_at_position_loss_config_t loss_config;
+    aeron_setup_at_position_loss_config_init(&loss_config);
+    // The archive's recording subscription URI carries `init-term-id=` (set by
+    // PersistentPublication::resume when it stamps the publisher's continuation params).
+    // PS's plain MDC subscription URI does not — that's how we tell the two endpoints
+    // apart at frame-check time.
+    aeron_setup_at_position_loss_config_set_endpoint_skip_substring(&loss_config, "init-term-id=");
+
+    const std::string archive_dir = std::string(ARCHIVE_DIR) + AERON_FILE_SEP + "refresh_replay_when_live_ahead";
+    LossTestHarness harness(
+        m_aeronDir, archive_dir, installSetupAtPositionLossGenerator, &loss_config);
+
+    PersistentPublication persistent_publication(m_aeronDir, MDC_PUBLICATION_CHANNEL, STREAM_ID);
+    persistent_publication.persist(generateFixedMessages(1, ONE_KB_MESSAGE_SIZE));
+    const int64_t stop_position = persistent_publication.stop();
+    ASSERT_GT(stop_position, 0);
+    const int64_t recording_id = persistent_publication.recordingId();
+
+    // Read the recording descriptor while persistent_publication still holds an archive
+    // client open; we need initial_term_id and term_buffer_length to compute publisher
+    // B's first-SETUP position so the loss filter can match it exactly.
+    struct RecordingInfo
+    {
+        int32_t initial_term_id;
+        int32_t term_buffer_length;
+    } info = {};
+    int32_t descriptor_count = 0;
+    ASSERT_LE(0, aeron_archive_list_recording(
+        &descriptor_count,
+        persistent_publication.archive(),
+        recording_id,
+        [](aeron_archive_recording_descriptor_t *descriptor, void *clientd)
+        {
+            RecordingInfo *i = static_cast<RecordingInfo *>(clientd);
+            i->initial_term_id = descriptor->initial_term_id;
+            i->term_buffer_length = descriptor->term_buffer_length;
+        },
+        &info));
+    ASSERT_EQ(1, descriptor_count);
+
+    const int32_t target_active_term_id = aeron_logbuffer_compute_term_id_from_position(
+        stop_position,
+        aeron_number_of_trailing_zeroes(info.term_buffer_length),
+        info.initial_term_id);
+    const int32_t target_term_offset = (int32_t)(stop_position & (info.term_buffer_length - 1));
+    aeron_setup_at_position_loss_config_set_target(
+        &loss_config, STREAM_ID, info.initial_term_id, target_active_term_id, target_term_offset);
+
+    aeron_publication_constants_t pub_constants;
+    aeron_exclusive_publication_constants(persistent_publication.publication(), &pub_constants);
+    aeron_counters_reader_t *counters = aeron_counters_reader(
+        aeron_archive_context_get_aeron(aeron_archive_get_archive_context(persistent_publication.archive())));
+    aeron_exclusive_publication_close(persistent_publication.publication(), nullptr, nullptr);
+    waitUntil("publication counters removed",
+        [&]
+        {
+            return AERON_NULL_COUNTER_ID == aeron_counters_reader_find_by_type_id_and_registration_id(
+                counters, AERON_COUNTER_PUBLISHER_POSITION_TYPE_ID, pub_constants.registration_id);
+        });
+
+    AeronResource aeron(m_aeronDir);
+
+    aeron_archive_context_t *archive_ctx = createArchiveContext();
+    ArchiveContextGuard archive_ctx_guard(archive_ctx);
+    aeron_archive_context_set_message_timeout_ns(archive_ctx, 500LL * 1000 * 1000);
+    aeron_archive_persistent_subscription_context_t *context = createPersistentSubscriptionContext(
+        aeron.aeron(),
+        archive_ctx,
+        recording_id,
+        MDC_SUBSCRIPTION_CHANNEL,
+        STREAM_ID,
+        "aeron:udp?endpoint=localhost:0",
+        REPLAY_STREAM_ID,
+        stop_position);
+
+    TestListener listener;
+    listener.attachTo(context);
+
+    PersistentSubscriptionContextGuard context_guard(context);
+    aeron_archive_persistent_subscription_t *persistent_subscription;
+    ASSERT_EQ(0, aeron_archive_persistent_subscription_create(&persistent_subscription, context)) << aeron_errmsg();
+    context_guard.release();
+    PersistentSubscriptionGuard ps_guard(persistent_subscription);
+
+    MessageCapturingFragmentHandler handler;
+    bool observed_replaying = false;
+    auto poller = [&]
+    {
+        const int fragments = aeron_archive_persistent_subscription_controlled_poll(
+            persistent_subscription,
+            MessageCapturingFragmentHandler::onFragment,
+            &handler,
+            10);
+        if (aeron_archive_persistent_subscription_is_replaying(persistent_subscription))
+        {
+            observed_replaying = true;
+        }
+        return fragments;
+    };
+
+    // PS shortcuts to ADD_LIVE_SUBSCRIPTION and parks in AWAIT_LIVE; with no publisher up,
+    // its live-image deadline breaches as a non-terminal error — fired exactly once.
+    executeUntil(
+        "live-image deadline breach fires",
+        poller,
+        [&] { return listener.error_count > 0; });
+    ASSERT_EQ(1, listener.error_count);
+    ASSERT_NE(std::string::npos,
+        listener.last_error_message.find("No image became available on the live subscription"));
+    ASSERT_FALSE(aeron_archive_persistent_subscription_is_live(persistent_subscription));
+    ASSERT_FALSE(observed_replaying);
+
+    // Arm the SETUP filter just before resuming. Publisher B's first SETUP carries the
+    // exact target tuple we configured above; it will be dropped at PS's endpoint and
+    // delivered normally to the archive's recording subscription's endpoint (which is
+    // exempt by URI substring).
+    aeron_setup_at_position_loss_config_enable(&loss_config);
+
+    PersistentPublication resumed_publication =
+        PersistentPublication::resume(m_aeronDir, MDC_PUBLICATION_CHANNEL, STREAM_ID, recording_id);
+
+    // Persist a few messages so publisher B's snd_pos advances past stop_0. The next SETUP
+    // (gated by AERON_NETWORK_PUBLICATION_SETUP_TIMEOUT_NS after the dropped one) carries
+    // the advanced term_offset, no longer matches the filter, and creates PS's image with
+    // join_position > stop_0.
+    const std::vector<std::vector<uint8_t>> post_resume_messages =
+        generateFixedMessages(4, ONE_KB_MESSAGE_SIZE);
+    resumed_publication.persist(post_resume_messages);
+
+    executeUntil(
+        "is live",
+        poller,
+        [&] { return aeron_archive_persistent_subscription_is_live(persistent_subscription); });
+
+    executeUntil(
+        "received all post-resume messages",
+        poller,
+        [&] { return handler.messages().size() == post_resume_messages.size(); });
+    ASSERT_EQ(post_resume_messages, handler.messages());
+
+    aeron_setup_at_position_loss_config_disable(&loss_config);
+
+    // Messages offered before PS's live image attached can only have arrived via the
+    // refresh -> replay path; mid-stream UDP subscribers don't backfill historical bytes
+    // on the live stream.
+    ASSERT_TRUE(observed_replaying)
+        << "PS did not transition through REPLAY/ATTEMPT_SWITCH; refresh path was not exercised";
+    ASSERT_EQ(1, listener.live_joined_count);
+    ASSERT_EQ(0, listener.live_left_count);
+    // Still exactly the one initial deadline-breach error — PS refreshed once, went to
+    // REPLAY then LIVE, and has stayed there. No additional AWAIT_LIVE entries means no
+    // additional breaches.
+    ASSERT_EQ(1, listener.error_count);
+    // The filter is a safety net for the race where publisher B's first SETUP carries
+    // its initial term_offset (causing PS's image to attach at stop_0 and skip refresh).
+    // It may or may not fire depending on how fast publisher B's snd_pos advances
+    // relative to the first SETUP send. observed_replaying being true is what proves
+    // the refresh path was taken — either naturally or because the filter forced it.
+
+    ps_guard.release();
+    ASSERT_EQ(0, aeron_archive_persistent_subscription_close(persistent_subscription)) << aeron_errmsg();
+    archive_ctx_guard.release();
+    aeron_archive_context_close(archive_ctx);
+}
+
+// Per-endpoint supplier used by shouldReplayAndCatchUpWhenExtendedRecordingIsAheadOfLivePosition.
+// Same pattern as installSetupAtPositionLossGenerator above, but allocates a DATA-in-range
+// loss generator instead of a SETUP-at-position one. Each new receive endpoint gets its own
+// generator instance whose state captures the endpoint pointer; at frame-check time the
+// generator inspects the endpoint's URI and decides whether to drop.
+static void installDataInRangeLossGenerator(
+    void *clientd, aeron_receive_channel_endpoint_t *endpoint)
+{
+    auto *config = static_cast<aeron_data_in_range_loss_config_t *>(clientd);
+    aeron_loss_generator_t *generator = nullptr;
+    if (aeron_data_in_range_loss_generator_create(&generator, config, endpoint) == 0)
+    {
+        endpoint->data_loss_generator = generator;
+    }
+}
+
+// Deterministically exercises the LIVE -> image-closed -> refresh -> replay path. PS
+// shortcuts to AWAIT_LIVE while the recording is stopped at stop_0, then publisher B is
+// resumed. PS receives publisher B's SETUP normally and either joins live directly at
+// stop_0 (and consumes first_batch via live) or refreshes via AWAIT_LIVE if publisher
+// B's first SETUP carries an advanced offset — both paths land in LIVE with first_batch
+// either delivered or about to be delivered.
+//
+// Once first_batch is delivered, a per-endpoint loss generator drops every catchup DATA
+// frame on PS's endpoint (the recording subscription's endpoint is exempt by URI: its
+// URI carries `init-term-id=`, PS's plain MDC URI does not). Heartbeats are always
+// preserved so PS still sees the EOS+REVOKE flag when publisher B is revoked. After
+// revoke, PS's image closes and the bytes the loss generator dropped can never be
+// recovered via NAK retransmits — PS must replay the full catchup from the recording.
+TEST_F(AeronArchivePersistentSubscriptionTest, shouldReplayAndCatchUpWhenExtendedRecordingIsAheadOfLivePosition)
+{
+    aeron_data_in_range_loss_config_t loss_config;
+    aeron_data_in_range_loss_config_init(&loss_config);
+    aeron_data_in_range_loss_config_set_endpoint_skip_substring(&loss_config, "init-term-id=");
+
+    const std::string archive_dir = std::string(ARCHIVE_DIR) + AERON_FILE_SEP + "replay_catchup_when_ahead";
+    LossTestHarness harness(
+        m_aeronDir, archive_dir, installDataInRangeLossGenerator, &loss_config);
+
+    PersistentPublication persistent_publication(m_aeronDir, MDC_PUBLICATION_CHANNEL, STREAM_ID);
+    persistent_publication.persist(generateFixedMessages(1, ONE_KB_MESSAGE_SIZE));
+    const int64_t stop_position = persistent_publication.stop();
+    ASSERT_GT(stop_position, 0);
+    const int64_t recording_id = persistent_publication.recordingId();
+
+    struct RecordingInfo
+    {
+        int32_t initial_term_id;
+        int32_t term_buffer_length;
+    } info = {};
+    int32_t descriptor_count = 0;
+    ASSERT_LE(0, aeron_archive_list_recording(
+        &descriptor_count,
+        persistent_publication.archive(),
+        recording_id,
+        [](aeron_archive_recording_descriptor_t *descriptor, void *clientd)
+        {
+            RecordingInfo *i = static_cast<RecordingInfo *>(clientd);
+            i->initial_term_id = descriptor->initial_term_id;
+            i->term_buffer_length = descriptor->term_buffer_length;
+        },
+        &info));
+    ASSERT_EQ(1, descriptor_count);
+
+    aeron_publication_constants_t pub_constants;
+    aeron_exclusive_publication_constants(persistent_publication.publication(), &pub_constants);
+    aeron_counters_reader_t *counters = aeron_counters_reader(
+        aeron_archive_context_get_aeron(aeron_archive_get_archive_context(persistent_publication.archive())));
+    aeron_exclusive_publication_close(persistent_publication.publication(), nullptr, nullptr);
+    waitUntil("publication counters removed",
+        [&]
+        {
+            return AERON_NULL_COUNTER_ID == aeron_counters_reader_find_by_type_id_and_registration_id(
+                counters, AERON_COUNTER_PUBLISHER_POSITION_TYPE_ID, pub_constants.registration_id);
+        });
+
+    AeronResource aeron(m_aeronDir);
+
+    aeron_archive_context_t *archive_ctx = createArchiveContext();
+    ArchiveContextGuard archive_ctx_guard(archive_ctx);
+    aeron_archive_context_set_message_timeout_ns(archive_ctx, 500LL * 1000 * 1000);
+    aeron_archive_persistent_subscription_context_t *context = createPersistentSubscriptionContext(
+        aeron.aeron(),
+        archive_ctx,
+        recording_id,
+        MDC_SUBSCRIPTION_CHANNEL,
+        STREAM_ID,
+        "aeron:udp?endpoint=localhost:0",
+        REPLAY_STREAM_ID,
+        stop_position);
+
+    TestListener listener;
+    listener.attachTo(context);
+
+    PersistentSubscriptionContextGuard context_guard(context);
+    aeron_archive_persistent_subscription_t *persistent_subscription;
+    ASSERT_EQ(0, aeron_archive_persistent_subscription_create(&persistent_subscription, context)) << aeron_errmsg();
+    context_guard.release();
+    PersistentSubscriptionGuard ps_guard(persistent_subscription);
+
+    MessageCapturingFragmentHandler handler;
+    bool observed_replaying = false;
+    auto poller = [&]
+    {
+        const int fragments = aeron_archive_persistent_subscription_controlled_poll(
+            persistent_subscription,
+            MessageCapturingFragmentHandler::onFragment,
+            &handler,
+            1);
+        if (aeron_archive_persistent_subscription_is_replaying(persistent_subscription))
+        {
+            observed_replaying = true;
+        }
+        return fragments;
+    };
+
+    // PS shortcuts to AWAIT_LIVE; no publisher up, deadline breaches exactly once.
+    executeUntil(
+        "deadline breach fires",
+        poller,
+        [&] { return listener.error_count > 0; });
+    ASSERT_EQ(1, listener.error_count);
+
+    // Resume publisher B at stop_0. Recording continues contiguously.
+    PersistentPublication resumed_publication =
+        PersistentPublication::resume(m_aeronDir, MDC_PUBLICATION_CHANNEL, STREAM_ID, recording_id);
+
+    // Persist first_batch and let PS receive it. Either path can deliver it: direct LIVE
+    // (publisher B's SETUP arrived at stop_0) or AWAIT_LIVE -> refresh -> replay
+    // (publisher B's SETUP arrived at an advanced offset). Either way, by the time the
+    // loop exits PS has consumed first_batch and is positioned just past it.
+    const std::vector<std::vector<uint8_t>> first_batch = generateFixedMessages(1, ONE_KB_MESSAGE_SIZE);
+    resumed_publication.persist(first_batch);
+    executeUntil(
+        "received first message",
+        poller,
+        [&] { return handler.messages().size() == first_batch.size(); });
+
+    // Reset observed_replaying after the first_batch phase. If publisher B's SETUP arrived
+    // at an advanced offset, PS already went through REFRESH/REPLAY once to deliver
+    // first_batch — we don't want that observation to satisfy the post-revoke assertion
+    // below. From here on, only the catchup-refresh path can flip this back to true.
+    observed_replaying = false;
+
+    // Arm the data-loss filter. Drop every catchup DATA frame on PS's endpoint, anywhere
+    // from "right past first_batch" through end-of-term. The recording subscription's
+    // endpoint is exempt (URI substring), so the recording stays contiguous.
+    const int64_t first_byte_after_first_batch = stop_position + (int64_t)(ONE_KB_MESSAGE_SIZE + AERON_DATA_HEADER_LENGTH);
+    const int32_t target_active_term_id = aeron_logbuffer_compute_term_id_from_position(
+        first_byte_after_first_batch,
+        aeron_number_of_trailing_zeroes(info.term_buffer_length),
+        info.initial_term_id);
+    const int32_t target_drop_min = (int32_t)(first_byte_after_first_batch & (info.term_buffer_length - 1));
+    aeron_data_in_range_loss_config_set_target(
+        &loss_config, STREAM_ID, target_active_term_id, target_drop_min, info.term_buffer_length);
+    aeron_data_in_range_loss_config_enable(&loss_config);
+
+    // Persist 40 catchup messages. The recording sees them all; PS sees none of them on
+    // its live image — they're dropped at PS's receive endpoint by the loss generator.
+    const std::vector<std::vector<uint8_t>> catchup_messages = generateFixedMessages(40, ONE_KB_MESSAGE_SIZE);
+    resumed_publication.persist(catchup_messages);
+
+    // Revoke ends the live image; after the EOS+REVOKE heartbeat reaches PS (loss gen
+    // explicitly preserves heartbeats) and the image closes, the dropped bytes are gone
+    // forever from the live channel — PS must replay them from the recording.
+    aeron_exclusive_publication_revoke(resumed_publication.publication(), nullptr, nullptr);
+
+    std::vector<std::vector<uint8_t>> expected;
+    expected.insert(expected.end(), first_batch.begin(), first_batch.end());
+    expected.insert(expected.end(), catchup_messages.begin(), catchup_messages.end());
+    executeUntil(
+        "received all messages",
+        poller,
+        [&] { return handler.messages().size() == expected.size(); });
+
+    aeron_data_in_range_loss_config_disable(&loss_config);
+
+    ASSERT_EQ(expected, handler.messages());
+    ASSERT_TRUE(observed_replaying)
+        << "PS did not transition through REPLAY/ATTEMPT_SWITCH after revoke; the "
+           "catchup-refresh path was not exercised (first_batch's refresh, if any, was "
+           "cleared before catchup was armed, so this isolates the post-revoke replay)";
+    // The filter must have actually fired — otherwise the test could pass for the wrong
+    // reason (the natural overrun race winning), and a future change that breaks the
+    // tuple computation would silently regress the test back to that race.
+    ASSERT_GT(aeron_data_in_range_loss_config_frames_dropped(&loss_config), 0);
+
+    ps_guard.release();
+    ASSERT_EQ(0, aeron_archive_persistent_subscription_close(persistent_subscription)) << aeron_errmsg();
+    archive_ctx_guard.release();
+    aeron_archive_context_close(archive_ctx);
+}

--- a/aeron-archive/src/test/c/client/aeron_archive_persistent_subscription_resilience_test.cpp
+++ b/aeron-archive/src/test/c/client/aeron_archive_persistent_subscription_resilience_test.cpp
@@ -5503,6 +5503,16 @@ TEST_F(AeronArchivePersistentSubscriptionTest, shouldReplayAndCatchUpWhenExtende
         poller,
         [&] { return handler.messages().size() == first_batch.size(); });
 
+    // Wait for PS to be on its live image. In the advanced-offset SETUP path, PS may have
+    // delivered first_batch via initial-refresh REPLAY and still be in REPLAY/ATTEMPT_SWITCH.
+    // Without polling the live image, PS's last_sm_position doesn't advance and publisher
+    // B's flow control stops sending live to PS — so the loss generator never sees catchup
+    // frames on PS's live endpoint and frames_dropped stays at 0.
+    executeUntil(
+        "is live",
+        poller,
+        [&] { return aeron_archive_persistent_subscription_is_live(persistent_subscription); });
+
     // Reset observed_replaying after the first_batch phase. If publisher B's SETUP arrived
     // at an advanced offset, PS already went through REFRESH/REPLAY once to deliver
     // first_batch — we don't want that observation to satisfy the post-revoke assertion

--- a/aeron-archive/src/test/c/client/aeron_archive_persistent_subscription_test.cpp
+++ b/aeron-archive/src/test/c/client/aeron_archive_persistent_subscription_test.cpp
@@ -218,35 +218,6 @@ private:
     }
 };
 
-class PrintingListener
-{
-    aeron_archive_persistent_subscription_listener_t m_listener;
-
-    static void onLiveJoined(void *clientd)
-    {
-        std::cout << "live joined" << std::endl;
-    }
-
-    static void onLiveLeft(void *clientd)
-    {
-        std::cout << "live left" << std::endl;
-    }
-
-    static void onError(void *clientd, int errcode, const char *message)
-    {
-        std::cout << "error " << errcode << " " << message << std::endl;
-    }
-
-public:
-    PrintingListener() : m_listener({onLiveJoined, onLiveLeft, onError, nullptr})
-    {
-    }
-
-    aeron_archive_persistent_subscription_listener_t *listener()
-    {
-        return &m_listener;
-    }
-};
 
 class PersistentPublication
 {
@@ -2726,137 +2697,6 @@ TEST_F(AeronArchivePersistentSubscriptionTest, shouldCatchUpWhenStartingAtStopPo
     aeron_archive_context_close(archive_ctx);
 }
 
-// Deterministically exercises the shortcut → live-ahead → refresh_recording_descriptor → replay → live
-// path. PS starts while the recording is stopped, so its first list_recording returns the stopped
-// descriptor and PS takes the shortcut to ADD_LIVE_SUBSCRIPTION. After PS has parked in AWAIT_LIVE
-// (confirmed by the deadline-breach error), the test resumes the recording and persists messages on
-// a fresh publisher. Because the new publisher has already advanced past stop_0 by the time its
-// live image reaches PS, `live_position > position` triggers the refresh. The second list_recording
-// sees the extended recording, validation passes, and PS replays the gap before joining live.
-TEST_F(AeronArchivePersistentSubscriptionTest, shouldRefreshAndReplayWhenLiveAheadOfStopPositionAfterResume)
-{
-    TestArchive archive = createArchive(m_aeronDir);
-
-    PersistentPublication persistent_publication(m_aeronDir, MDC_PUBLICATION_CHANNEL, STREAM_ID);
-    const std::vector<std::vector<uint8_t>> initial_messages = generateFixedMessages(1, ONE_KB_MESSAGE_SIZE);
-    persistent_publication.persist(initial_messages);
-
-    const int64_t stop_position = persistent_publication.stop();
-    ASSERT_GT(stop_position, 0);
-    const int64_t recording_id = persistent_publication.recordingId();
-
-    aeron_publication_constants_t pub_constants;
-    aeron_exclusive_publication_constants(persistent_publication.publication(), &pub_constants);
-    aeron_counters_reader_t *counters = aeron_counters_reader(
-        aeron_archive_context_get_aeron(aeron_archive_get_archive_context(persistent_publication.archive())));
-    aeron_exclusive_publication_close(persistent_publication.publication(), nullptr, nullptr);
-    waitUntil("publication counters removed",
-        [&]
-        {
-            return AERON_NULL_COUNTER_ID == aeron_counters_reader_find_by_type_id_and_registration_id(
-                counters, AERON_COUNTER_PUBLISHER_POSITION_TYPE_ID, pub_constants.registration_id);
-        });
-
-    AeronResource aeron(m_aeronDir);
-
-    aeron_archive_context_t *archive_ctx = createArchiveContext();
-    ArchiveContextGuard archive_ctx_guard(archive_ctx);
-    // Short timeout so the AWAIT_LIVE deadline breach fires quickly while the recording is stopped
-    // and no publisher is available yet.
-    aeron_archive_context_set_message_timeout_ns(archive_ctx, 500LL * 1000 * 1000);
-    aeron_archive_persistent_subscription_context_t *context = createPersistentSubscriptionContext(
-        aeron.aeron(),
-        archive_ctx,
-        recording_id,
-        MDC_SUBSCRIPTION_CHANNEL,
-        STREAM_ID,
-        "aeron:udp?endpoint=localhost:0",
-        -5,
-        stop_position);
-
-    TestListener listener;
-    listener.attachTo(context);
-
-    PersistentSubscriptionContextGuard context_guard(context);
-    aeron_archive_persistent_subscription_t *persistent_subscription;
-    ASSERT_EQ(0, aeron_archive_persistent_subscription_create(&persistent_subscription, context)) << aeron_errmsg();
-    context_guard.release();
-    PersistentSubscriptionGuard ps_guard(persistent_subscription);
-
-    MessageCapturingFragmentHandler handler;
-    bool observed_replaying = false;
-    auto poller = [&]
-    {
-        const int fragments = aeron_archive_persistent_subscription_controlled_poll(
-            persistent_subscription,
-            MessageCapturingFragmentHandler::onFragment,
-            &handler,
-            10);
-        if (aeron_archive_persistent_subscription_is_replaying(persistent_subscription))
-        {
-            observed_replaying = true;
-        }
-        return fragments;
-    };
-
-    // PS shortcuts to ADD_LIVE_SUBSCRIPTION and parks in AWAIT_LIVE; no publisher exists so the
-    // live-image deadline breaches as a non-terminal error — fired exactly once by this AWAIT_LIVE
-    // entry (guarded by `live_image_deadline_breached`).
-    executeUntil(
-        "live-image deadline breach fires",
-        poller,
-        [&] { return listener.error_count > 0; });
-    ASSERT_EQ(1, listener.error_count);
-    ASSERT_NE(std::string::npos,
-        listener.last_error_message.find("No image became available on the live subscription"));
-    ASSERT_FALSE(aeron_archive_persistent_subscription_is_live(persistent_subscription));
-    ASSERT_FALSE(observed_replaying);
-
-    PersistentPublication resumed_publication =
-        PersistentPublication::resume(m_aeronDir, MDC_PUBLICATION_CHANNEL, STREAM_ID, recording_id);
-
-    // Push the publisher tail past stop_position with a priming offer before the catchup
-    // messages. Without this, PS's live image often attaches at exactly stop_position, the
-    // await_live check `live_position > start_position` is false, and PS takes the direct
-    // AWAIT_LIVE → LIVE path instead of the refresh-replay path this test exercises.
-    const std::vector<std::vector<uint8_t>> priming_messages = generateFixedMessages(1, ONE_KB_MESSAGE_SIZE);
-    resumed_publication.persist(priming_messages);
-
-    const std::vector<std::vector<uint8_t>> catchup_messages = generateFixedMessages(3, ONE_KB_MESSAGE_SIZE);
-    resumed_publication.persist(catchup_messages);
-
-    executeUntil(
-        "is live",
-        poller,
-        [&] { return aeron_archive_persistent_subscription_is_live(persistent_subscription); });
-
-    std::vector<std::vector<uint8_t>> expected_messages;
-    expected_messages.insert(expected_messages.end(), priming_messages.begin(), priming_messages.end());
-    expected_messages.insert(expected_messages.end(), catchup_messages.begin(), catchup_messages.end());
-
-    executeUntil(
-        "received all post-resume messages",
-        poller,
-        [&] { return handler.messages().size() == expected_messages.size(); });
-    ASSERT_EQ(expected_messages, handler.messages());
-
-    // Messages offered before PS's live image attached can only have arrived via the refresh
-    // → replay path; mid-stream UDP subscribers don't backfill historical bytes on the live
-    // stream.
-    ASSERT_TRUE(observed_replaying)
-        << "PS did not transition through REPLAY/ATTEMPT_SWITCH; refresh path was not exercised";
-    ASSERT_EQ(1, listener.live_joined_count);
-    ASSERT_EQ(0, listener.live_left_count);
-    // Still exactly the one initial deadline-breach error — PS refreshed once, went to REPLAY then
-    // LIVE, and has stayed there. No additional AWAIT_LIVE entries, so no additional breaches.
-    ASSERT_EQ(1, listener.error_count);
-
-    ps_guard.release();
-    ASSERT_EQ(0, aeron_archive_persistent_subscription_close(persistent_subscription)) << aeron_errmsg();
-    archive_ctx_guard.release();
-    aeron_archive_context_close(archive_ctx);
-}
-
 // Exercises the refresh_recording_descriptor recovery path inside REPLAY: PS is mid-replay when
 // the publisher is stopped. The replay image closes; PS must refresh the descriptor (rather than
 // retry replay against stale recording info) before transitioning to await-live, so that when the
@@ -2932,132 +2772,6 @@ TEST_F(AeronArchivePersistentSubscriptionTest, shouldRecoverWhenThePersistentPub
     expected_messages.insert(expected_messages.end(), recorded_batch.begin(), recorded_batch.end());
     expected_messages.insert(expected_messages.end(), batch_after_resuming.begin(), batch_after_resuming.end());
     ASSERT_EQ(expected_messages, handler.messages());
-
-    ps_guard.release();
-    ASSERT_EQ(0, aeron_archive_persistent_subscription_close(persistent_subscription)) << aeron_errmsg();
-    archive_ctx_guard.release();
-    aeron_archive_context_close(archive_ctx);
-}
-
-// Recording is extended (no gap), PS lags the live stream, then the publisher is revoked.
-// The recording end is past PS's position when the live image dies, so PS must REPLAY to
-// catch up.
-TEST_F(AeronArchivePersistentSubscriptionTest, shouldReplayAndCatchUpWhenExtendedRecordingIsAheadOfLivePosition)
-{
-    TestArchive archive = createArchive(m_aeronDir);
-
-    // Set the publication's term-length to the Aeron minimum (64 KiB) so the receiver-side
-    // flow-control overrun threshold (`last_sm_position + term_length/2`) is just 32 KiB.
-    // With a 32 KiB threshold we can publish enough catchup data after PS's last SM
-    // to guarantee the trailing messages are dropped at PS and must come via REPLAY.
-    const std::string short_term_publication_channel = MDC_PUBLICATION_CHANNEL + "|term-length=65536";
-
-    PersistentPublication persistent_publication(m_aeronDir, short_term_publication_channel, STREAM_ID);
-    persistent_publication.persist(generateFixedMessages(1, ONE_KB_MESSAGE_SIZE));
-    const int64_t stop_position = persistent_publication.stop();
-    ASSERT_GT(stop_position, 0);
-    const int64_t recording_id = persistent_publication.recordingId();
-
-    aeron_publication_constants_t pub_constants;
-    aeron_exclusive_publication_constants(persistent_publication.publication(), &pub_constants);
-    aeron_counters_reader_t *counters = aeron_counters_reader(
-        aeron_archive_context_get_aeron(aeron_archive_get_archive_context(persistent_publication.archive())));
-    aeron_exclusive_publication_close(persistent_publication.publication(), nullptr, nullptr);
-    waitUntil("publication counters removed",
-        [&]
-        {
-            return AERON_NULL_COUNTER_ID == aeron_counters_reader_find_by_type_id_and_registration_id(
-                counters, AERON_COUNTER_PUBLISHER_POSITION_TYPE_ID, pub_constants.registration_id);
-        });
-
-    AeronResource aeron(m_aeronDir);
-
-    aeron_archive_context_t *archive_ctx = createArchiveContext();
-    ArchiveContextGuard archive_ctx_guard(archive_ctx);
-    aeron_archive_context_set_message_timeout_ns(archive_ctx, 500LL * 1000 * 1000);
-    aeron_archive_persistent_subscription_context_t *context = createPersistentSubscriptionContext(
-        aeron.aeron(),
-        archive_ctx,
-        recording_id,
-        MDC_SUBSCRIPTION_CHANNEL,
-        STREAM_ID,
-        "aeron:udp?endpoint=localhost:0",
-        -5,
-        stop_position);
-
-    TestListener listener;
-    listener.attachTo(context);
-
-    PersistentSubscriptionContextGuard context_guard(context);
-    aeron_archive_persistent_subscription_t *persistent_subscription;
-    ASSERT_EQ(0, aeron_archive_persistent_subscription_create(&persistent_subscription, context)) << aeron_errmsg();
-    context_guard.release();
-    PersistentSubscriptionGuard ps_guard(persistent_subscription);
-
-    MessageCapturingFragmentHandler handler;
-    bool observed_replaying = false;
-    auto poller = [&]
-    {
-        const int fragments = aeron_archive_persistent_subscription_controlled_poll(
-            persistent_subscription,
-            MessageCapturingFragmentHandler::onFragment,
-            &handler,
-            1);
-        if (aeron_archive_persistent_subscription_is_replaying(persistent_subscription))
-        {
-            observed_replaying = true;
-        }
-        return fragments;
-    };
-
-    // PS shortcuts to AWAIT_LIVE; no publisher, deadline breaches exactly once.
-    executeUntil(
-        "deadline breach fires",
-        poller,
-        [&] { return listener.error_count > 0; });
-    ASSERT_EQ(1, listener.error_count);
-
-    // Resume: creates publisher B at stop_0 and extends the recording. Because extend happens
-    // before any offers, the recording is contiguous from stop_0.
-    PersistentPublication resumed_publication =
-        PersistentPublication::resume(m_aeronDir, MDC_PUBLICATION_CHANNEL, STREAM_ID, recording_id);
-
-    // Publisher B offers and records the first message.
-    const std::vector<std::vector<uint8_t>> first_batch = generateFixedMessages(1, ONE_KB_MESSAGE_SIZE);
-    resumed_publication.persist(first_batch);
-
-    // Poll PS until it has received the first message (may arrive via live or replay).
-    executeUntil(
-        "received first message",
-        poller,
-        [&] { return handler.messages().size() == first_batch.size(); });
-
-    // Publisher B offers many more messages. Archive records all of them, but PS isn't being
-    // polled here so its `last_sm_position` is pinned ~2 KiB and the receiver-side overrun
-    // threshold is pinned ~34 KiB (2 KiB + term_length/2). Catchup data spans past that
-    // threshold, so the trailing messages are dropped at PS's image and only ever appear in
-    // the recording — PS must replay to receive them.
-    const std::vector<std::vector<uint8_t>> catchup_messages = generateFixedMessages(40, ONE_KB_MESSAGE_SIZE);
-    resumed_publication.persist(catchup_messages);
-
-    // Revoke ends the live image and discards any unsent term-buffer data, so the over-run
-    // bytes can't be recovered via NAK retransmits. After the term buffer is drained, PS sees
-    // the image closed, refreshes the recording descriptor, and replays the bytes the live
-    // channel never delivered.
-    aeron_exclusive_publication_revoke(resumed_publication.publication(), nullptr, nullptr);
-
-    std::vector<std::vector<uint8_t>> expected;
-    expected.insert(expected.end(), first_batch.begin(), first_batch.end());
-    expected.insert(expected.end(), catchup_messages.begin(), catchup_messages.end());
-
-    executeUntil(
-        "received all messages",
-        poller,
-        [&] { return handler.messages().size() == expected.size(); });
-
-    ASSERT_EQ(expected, handler.messages());
-    ASSERT_TRUE(observed_replaying)
-        << "PS did not transition through REPLAY/ATTEMPT_SWITCH; refresh-replay path was not exercised";
 
     ps_guard.release();
     ASSERT_EQ(0, aeron_archive_persistent_subscription_close(persistent_subscription)) << aeron_errmsg();
@@ -4632,7 +4346,6 @@ TEST_P(AeronArchivePersistentSubscriptionAllReplayChannelTypesTest, shouldCloseC
 
     const std::string& replay_channel = GetParam();
     std::vector<int64_t> states_up_to_live;
-    PrintingListener printingListener;
 
     {
         AeronResource aeron(m_aeronDir);
@@ -4649,7 +4362,6 @@ TEST_P(AeronArchivePersistentSubscriptionAllReplayChannelTypesTest, shouldCloseC
             STREAM_ID + 1,
             0);
 
-        aeron_archive_persistent_subscription_context_set_listener(context, printingListener.listener());
 
         PersistentSubscriptionContextGuard context_guard(context);
         aeron_archive_persistent_subscription_t *persistent_subscription;
@@ -4702,7 +4414,6 @@ TEST_P(AeronArchivePersistentSubscriptionAllReplayChannelTypesTest, shouldCloseC
             STREAM_ID + 1,
             0);
 
-        aeron_archive_persistent_subscription_context_set_listener(context, printingListener.listener());
 
         PersistentSubscriptionContextGuard context_guard(context);
         aeron_archive_persistent_subscription_t *persistent_subscription;

--- a/aeron-system-tests/src/test/java/io/aeron/archive/client/PersistentSubscriptionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/client/PersistentSubscriptionTest.java
@@ -52,7 +52,9 @@ import io.aeron.test.RandomWatcher;
 import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.TestContexts;
 import io.aeron.test.Tests;
+import io.aeron.test.driver.DataInRangeLossGenerator;
 import io.aeron.test.driver.FrameDataLossGenerator;
+import io.aeron.test.driver.SetupAtPositionLossGenerator;
 import io.aeron.test.driver.StreamIdFrameDataLossGenerator;
 import io.aeron.test.driver.StreamIdLossGenerator;
 import io.aeron.test.driver.TestMediaDriver;
@@ -224,7 +226,7 @@ abstract class PersistentSubscriptionTest
     @Test
     @InterruptAfter(15)
     @SuppressWarnings("MethodLength")
-    void shouldSwitchFromReplayToLiveAndFallBackToReplay()
+    void shouldDropFromLiveBackToReplayThenJoinLiveAgain()
     {
         final PersistentPublication persistentPublication =
             PersistentPublication.create(aeronArchive, MDC_PUBLICATION_CHANNEL, STREAM_ID);
@@ -454,7 +456,7 @@ abstract class PersistentSubscriptionTest
     @ParameterizedTest
     @ValueSource(longs = { 0, 1024 })
     @InterruptAfter(10)
-    void canReplayFromStartOfRecording(final long recordingStartPosition)
+    void shouldReplayFromRecordingStartPositionWhenStartingFromStart(final long recordingStartPosition)
     {
         final String channel = new ChannelUriStringBuilder()
             .media(IPC_MEDIA)
@@ -490,7 +492,7 @@ abstract class PersistentSubscriptionTest
 
     @Test
     @InterruptAfter(10)
-    void canReplayFromSpecifiedPosition()
+    void shouldReplayFromSpecificMidRecordingPosition()
     {
         final String channel = new ChannelUriStringBuilder()
             .media(IPC_MEDIA)
@@ -523,7 +525,7 @@ abstract class PersistentSubscriptionTest
 
     @Test
     @InterruptAfter(10)
-    void replayStartPositionMustNotBeBeforeRecordingStartPosition()
+    void shouldErrorIfStartPositionIsBeforeRecordingStartPosition()
     {
         final String channel = new ChannelUriStringBuilder()
             .media(IPC_MEDIA)
@@ -554,7 +556,7 @@ abstract class PersistentSubscriptionTest
 
     @Test
     @InterruptAfter(10)
-    void replayStartPositionMustNotBeAfterRecordingStopPosition()
+    void shouldErrorIfStartPositionIsAfterStopPosition()
     {
         final PersistentPublication persistentPublication =
             PersistentPublication.create(aeronArchive, IPC_CHANNEL, STREAM_ID);
@@ -584,7 +586,7 @@ abstract class PersistentSubscriptionTest
 
     @Test
     @InterruptAfter(10)
-    void replayStartPositionMustNotBeAfterRecordingLivePosition()
+    void shouldErrorIfStartPositionIsAfterRecordingLivePosition()
     {
         final PersistentPublication persistentPublication =
             PersistentPublication.create(aeronArchive, IPC_CHANNEL, STREAM_ID);
@@ -611,7 +613,7 @@ abstract class PersistentSubscriptionTest
 
     @Test
     @InterruptAfter(5)
-    void replayStartPositionMustBeAlignedOnFrameBoundary()
+    void shouldErrorWhenStartPositionDoesNotAlignWithFrame()
     {
         final PersistentPublication persistentPublication =
             PersistentPublication.create(aeronArchive, MDC_PUBLICATION_CHANNEL, STREAM_ID);
@@ -637,7 +639,7 @@ abstract class PersistentSubscriptionTest
 
     @Test
     @InterruptAfter(15)
-    void shouldJoinLiveWhenThereIsNoDataToReplay()
+    void shouldStartFromLiveWhenThereIsNoDataToReplay()
     {
         final PersistentPublication persistentPublication =
             PersistentPublication.create(aeronArchive, MDC_PUBLICATION_CHANNEL, STREAM_ID);
@@ -736,7 +738,7 @@ abstract class PersistentSubscriptionTest
 
     @Test
     @InterruptAfter(10)
-    void shouldJoinLiveWhenItBecomesAvailable()
+    void shouldRetryAndRecoverWhenLiveIsNotAvailableDuringStartUp()
     {
         // Ensure a recording exists for the stream.
         final PersistentPublication persistentPublication = PersistentPublication.create(
@@ -858,7 +860,8 @@ abstract class PersistentSubscriptionTest
     @ParameterizedTest
     @ValueSource(longs = { FROM_START, FROM_LIVE })
     @InterruptAfter(10)
-    void shouldConnectToArchiveWhenItBecomesAvailable(final long startPosition, final @TempDir Path tempDir)
+    void shouldRetryAndRecoverWhenArchiveIsNotAvailableDuringStartUp(
+        final long startPosition, final @TempDir Path tempDir)
     {
         archive.close();
         final File archiveDir = new File(tempDir.toString(), "testLocalArchive");
@@ -1274,58 +1277,56 @@ abstract class PersistentSubscriptionTest
         }
     }
 
-    // Exercises the shortcut → live-ahead → refresh → replay path. PS starts while the recording is
-    // stopped so the first list_recording returns stopPosition == startPosition and PS takes the
-    // shortcut to ADD_LIVE_SUBSCRIPTION. After PS has parked in AWAIT_LIVE (confirmed by the
-    // deadline-breach error), the recording is resumed and messages are persisted on a fresh
-    // publisher; that publisher is then revoked. PS must deliver every catchup message and must
-    // have transitioned through REPLAY/ATTEMPT_SWITCH at least once.
+    // Deterministically exercises the LIVE -> image-closed -> refresh -> replay path. PS
+    // shortcuts to AWAIT_LIVE while the recording is stopped at stop_0, then publisher B is
+    // resumed. PS receives publisher B's SETUP normally and either joins live directly at
+    // stop_0 (and consumes first_batch via live) or refreshes via AWAIT_LIVE if publisher B's
+    // first SETUP carries an advanced offset — both paths land in LIVE with first_batch
+    // either delivered or about to be delivered.
+    //
+    // Once first_batch is delivered AND PS is on its live image, a per-driver loss generator
+    // drops every catchup DATA frame on PS's live stream (the recording subscription on the
+    // main driver sees no loss). The isLive() wait is required: in path B without it PS
+    // stays in REPLAY/ATTEMPT_SWITCH, doesn't poll the live image, doesn't send SMs, and
+    // publisher B's flow control stops sending live to PS — catchup arrives only via the
+    // REPLAY stream and the loss generator never fires.
+    //
+    // Heartbeats are always preserved so PS still sees the EOS+REVOKED flag when publisher B
+    // is revoked. After revoke, PS's image closes and the bytes the loss generator dropped
+    // can never be recovered via NAK retransmits — PS must replay the full catchup from the
+    // recording.
     @Test
     @InterruptAfter(10)
-    void shouldRefreshAndReplayWhenLiveAheadOfStopPositionAfterResume()
+    void shouldReplayAndCatchUpWhenExtendedRecordingIsAheadOfLivePosition()
     {
+        TestMediaDriver.notSupportedOnCMediaDriver("loss generator");
+
+        final DataInRangeLossGenerator lossGenerator = new DataInRangeLossGenerator();
+        final Aeron aeron2 = startSecondAeronWithReceiveLoss(lossGenerator);
+
         final PersistentPublication persistentPublication =
             PersistentPublication.create(aeronArchive, MDC_PUBLICATION_CHANNEL, STREAM_ID);
 
-        persistentPublication.persist(generateRandomPayloads(1));
+        persistentPublication.persist(generateFixedPayloads(1, ONE_KB_MESSAGE_SIZE));
         final long stopPosition = persistentPublication.stop();
         assertTrue(stopPosition > 0);
         final long recordingId = persistentPublication.recordingId();
-        persistentPublication.closePublicationOnly();
-        // Wait for the closed publication's residual state to drain; otherwise PS's live subscription
-        // can briefly attach to the ghost image and join LIVE before the actual resumed publisher's
-        // image arrives.
-        Tests.await(() -> !persistentPublication.publicationCountersExist());
+
+        closePublicationAndAwaitDrain(persistentPublication);
 
         persistentSubscriptionCtx
+            .aeron(aeron2)
             .recordingId(recordingId)
             .startPosition(stopPosition)
-            .liveChannel(MDC_SUBSCRIPTION_CHANNEL + "|rcv-wnd=2K")
+            .liveChannel(MDC_SUBSCRIPTION_CHANNEL)
             .aeronArchiveContext().messageTimeoutNs(TimeUnit.MILLISECONDS.toNanos(500));
 
         try (PersistentSubscription persistentSubscription = PersistentSubscription.create(persistentSubscriptionCtx))
         {
             final boolean[] observedReplaying = { false };
-            final Runnable pollAndTrack = () ->
-            {
-                poll(persistentSubscription, fragmentHandler, 10);
-                if (persistentSubscription.isReplaying())
-                {
-                    observedReplaying[0] = true;
-                }
-            };
+            final Runnable pollAndTrack = newReplayObservingPoller(persistentSubscription, observedReplaying);
 
-            executeUntil(
-                () -> listener.errorCount > 0,
-                pollAndTrack);
-            // Exactly one deadline breach — fired once while PS was parked in AWAIT_LIVE.
-            assertEquals(1, listener.errorCount);
-            assertThat(
-                listener.lastException.getMessage(),
-                containsString("No image became available on the live subscription")
-            );
-            assertFalse(persistentSubscription.isLive());
-            assertFalse(observedReplaying[0]);
+            awaitFirstAwaitLiveDeadlineBreach(persistentSubscription, pollAndTrack, observedReplaying);
 
             final PersistentPublication resumedPublication =
                 PersistentPublication.resume(aeronArchive, MDC_PUBLICATION_CHANNEL, STREAM_ID, recordingId);
@@ -1340,15 +1341,31 @@ abstract class PersistentSubscriptionTest
                 () -> fragmentHandler.hasReceivedPayloads(firstBatch.size()),
                 pollAndTrack);
 
-            // Publish many more 1KB messages. PS isn't being polled here so its `last_sm_position`
-            // is pinned ~2 KiB and the receiver-side overrun threshold (`last_sm_position +
-            // term_length/2`) is pinned ~34 KiB. Catchup spans past that threshold, so the
-            // trailing messages are dropped at PS's image — they're only ever recorded — and PS
-            // must replay to receive them.
+            // Wait for PS to be on its live image. In path B (advanced-offset SETUP), PS may
+            // have delivered first_batch via initial-refresh REPLAY and still be in
+            // REPLAY/ATTEMPT_SWITCH. Without polling the live image, PS's last_sm_position
+            // doesn't advance and publisher B's flow control stops sending live to PS — so
+            // the loss generator never sees catchup frames on PS's live endpoint.
+            executeUntil(persistentSubscription::isLive, pollAndTrack);
+
+            // Reset observedReplaying after the first_batch phase. If publisher B's SETUP arrived
+            // at an advanced offset, PS already went through REFRESH/REPLAY once to deliver
+            // first_batch — we don't want that observation to satisfy the post-revoke assertion
+            // below. From here on, only the catchup-refresh path can flip this back to true.
+            observedReplaying[0] = false;
+
+            armDataDropFromPosition(lossGenerator, recordingId, stopPosition + 1024L);
+            lossGenerator.enable();
+
+            // Publish 40 catchup messages. The recording (on the main driver) sees them all;
+            // PS (on driver2) sees none of them on its live image — they're dropped by the
+            // loss generator on driver2's receive endpoint.
             final List<byte[]> catchupMessages = generateFixedPayloads(40, ONE_KB_MESSAGE_SIZE);
             resumedPublication.persist(catchupMessages);
 
-            // Revoke ends the live image. PS sees the close, refreshes, and replays missing bytes.
+            // Revoke ends the live image; after the EOS+REVOKED heartbeat reaches PS (the loss
+            // generator explicitly preserves heartbeats) and the image closes, the dropped
+            // bytes are gone forever from the live channel — PS must replay them.
             resumedPublication.publication.revoke();
 
             final List<byte[]> expected = new ArrayList<>(firstBatch);
@@ -1357,11 +1374,117 @@ abstract class PersistentSubscriptionTest
                 () -> fragmentHandler.hasReceivedPayloads(expected.size()),
                 pollAndTrack);
 
+            lossGenerator.disable();
+
             assertPayloads(fragmentHandler.receivedPayloads, expected);
             assertTrue(observedReplaying[0],
-                "PS did not transition through REPLAY/ATTEMPT_SWITCH; refresh path was not exercised");
+                "PS did not transition through REPLAY/ATTEMPT_SWITCH after revoke; the " +
+                    "catchup-refresh path was not exercised");
             // No additional AWAIT_LIVE entries after the initial one, so no additional breaches.
             assertEquals(1, listener.errorCount);
+            // The filter must have actually fired — otherwise the test could pass for the wrong
+            // reason (catchup somehow reaching PS without going through the drop range), and a
+            // future change that breaks the tuple computation would silently regress. The
+            // isLive() wait above is what makes this assertion deterministic: in path B without
+            // it, PS stays in REPLAY/ATTEMPT_SWITCH, doesn't poll the live image, doesn't send
+            // SMs, and publisher B's flow control stops sending live to PS — catchup arrives
+            // only via the REPLAY stream-id (which the filter doesn't target) and framesDropped
+            // would stay at 0.
+            assertTrue(lossGenerator.framesDropped() > 0,
+                "loss generator did not fire on any catchup DATA frame");
+            verify(persistentSubscription);
+        }
+    }
+
+    // Deterministically exercises the AWAIT_LIVE -> live-ahead -> refresh -> replay -> live path.
+    // PS shortcuts to AWAIT_LIVE while the recording is stopped at stop_0. When publisher B is
+    // resumed, its first SETUP carries the (initial_term_id, term_id_at_stop_0, offset_at_stop_0)
+    // tuple — which is also where PS's start_position sits. Without intervention, PS's image is
+    // created at stop_0, the AWAIT_LIVE check `live_position > position` is false, and PS takes
+    // the direct LIVE path instead of refreshing.
+    //
+    // To force the refresh path deterministically, PS runs on its own MediaDriver whose receive
+    // endpoints carry a SetupAtPositionLossGenerator. When publisher B is resumed, its first
+    // SETUP at stop_0 is dropped on PS's endpoint. PS's UDP receiver elicits another SETUP via
+    // SM. By the time publisher B's next SETUP fires, snd_pos has advanced past the offers we
+    // issued, the SETUP no longer matches the drop filter, and PS's image is created with
+    // join_position > stop_0 — triggering the refresh path. The recording subscription on the
+    // main driver is unaffected, so the recording stays contiguous.
+    @Test
+    @InterruptAfter(10)
+    void shouldRefreshAndReplayWhenLiveAheadOfStopPositionAfterResume()
+    {
+        TestMediaDriver.notSupportedOnCMediaDriver("loss generator");
+
+        final SetupAtPositionLossGenerator lossGenerator = new SetupAtPositionLossGenerator();
+        final Aeron aeron2 = startSecondAeronWithReceiveLoss(lossGenerator);
+
+        final PersistentPublication persistentPublication =
+            PersistentPublication.create(aeronArchive, MDC_PUBLICATION_CHANNEL, STREAM_ID);
+
+        persistentPublication.persist(generateFixedPayloads(1, ONE_KB_MESSAGE_SIZE));
+        final long stopPosition = persistentPublication.stop();
+        assertTrue(stopPosition > 0);
+        final long recordingId = persistentPublication.recordingId();
+
+        armSetupDropAtPosition(lossGenerator, recordingId, stopPosition);
+
+        closePublicationAndAwaitDrain(persistentPublication);
+
+        persistentSubscriptionCtx
+            .aeron(aeron2)
+            .recordingId(recordingId)
+            .startPosition(stopPosition)
+            .liveChannel(MDC_SUBSCRIPTION_CHANNEL)
+            .aeronArchiveContext().messageTimeoutNs(TimeUnit.MILLISECONDS.toNanos(500));
+
+        try (PersistentSubscription persistentSubscription = PersistentSubscription.create(persistentSubscriptionCtx))
+        {
+            final boolean[] observedReplaying = { false };
+            final Runnable pollAndTrack = newReplayObservingPoller(persistentSubscription, observedReplaying);
+
+            awaitFirstAwaitLiveDeadlineBreach(persistentSubscription, pollAndTrack, observedReplaying);
+
+            // Arm the SETUP filter just before resuming. Publisher B's first SETUP carries the
+            // exact target tuple we configured above; it will be dropped at PS's endpoint and
+            // delivered normally to the recording subscription on the main driver (driver1, which
+            // has no loss generator).
+            lossGenerator.enable();
+
+            final PersistentPublication resumedPublication =
+                PersistentPublication.resume(aeronArchive, MDC_PUBLICATION_CHANNEL, STREAM_ID, recordingId);
+
+            // Persist a few messages so publisher B's snd_pos advances past stop_0. The next SETUP
+            // (gated by the publication SETUP timeout) carries the advanced term_offset, no longer
+            // matches the filter, and creates PS's image with join_position > stop_0.
+            final List<byte[]> postResumeMessages = generateFixedPayloads(4, ONE_KB_MESSAGE_SIZE);
+            resumedPublication.persist(postResumeMessages);
+
+            executeUntil(persistentSubscription::isLive, pollAndTrack);
+
+            executeUntil(
+                () -> fragmentHandler.hasReceivedPayloads(postResumeMessages.size()),
+                pollAndTrack);
+            assertPayloads(fragmentHandler.receivedPayloads, postResumeMessages);
+
+            lossGenerator.disable();
+
+            // Messages offered before PS's live image attached can only have arrived via the
+            // refresh -> replay path; mid-stream UDP subscribers don't backfill historical bytes
+            // on the live stream.
+            assertTrue(observedReplaying[0],
+                "PS did not transition through REPLAY/ATTEMPT_SWITCH; refresh path was not exercised");
+            assertEquals(1, listener.liveJoinedCount);
+            assertEquals(0, listener.liveLeftCount);
+            // Still exactly the one initial deadline-breach error — PS refreshed once, went to
+            // REPLAY then LIVE, and has stayed there. No additional AWAIT_LIVE entries means no
+            // additional breaches.
+            assertEquals(1, listener.errorCount);
+            // The filter is a safety net for the race where publisher B's first SETUP carries
+            // its initial term_offset (causing PS's image to attach at stop_0 and skip refresh).
+            // It may or may not fire depending on how fast publisher B's snd_pos advances
+            // relative to the first SETUP send. observedReplaying being true is what proves
+            // the refresh path was taken — either naturally or because the filter forced it.
             verify(persistentSubscription);
         }
     }
@@ -1369,7 +1492,7 @@ abstract class PersistentSubscriptionTest
     @ParameterizedTest
     @ValueSource(ints = { 1, 10 })
     @InterruptAfter(5)
-    void canSwitchReplayToLiveWhenLivePositionMatchesReplayPosition(final int fragmentLimit)
+    void shouldReplayExistingRecordingThenJoinLive(final int fragmentLimit)
     {
         final PersistentPublication persistentPublication =
             PersistentPublication.create(aeronArchive, IPC_CHANNEL, STREAM_ID);
@@ -1517,7 +1640,7 @@ abstract class PersistentSubscriptionTest
 
     @Test
     @InterruptAfter(5)
-    void canSwitchFromReplayToLiveWhenLivePositionIsBehindReplayPosition()
+    void shouldHandleReplayBeingAheadOfLive()
     {
         final String pubChannel = "aeron:udp?control=localhost:2000|control-mode=dynamic|fc=min";
         final String subChannel = "aeron:udp?control=localhost:2000|rcv-wnd=4k";
@@ -1787,7 +1910,7 @@ abstract class PersistentSubscriptionTest
 
     @Test
     @InterruptAfter(5)
-    void canJoinLiveUponReachingEndOfRecordingIfLiveHasNotAdvanced()
+    void shouldStartFromStoppedRecordingAndJoinLiveWhenLiveHasNotAdvanced()
     {
         final PersistentPublication persistentPublication =
             PersistentPublication.create(aeronArchive, MDC_PUBLICATION_CHANNEL, STREAM_ID);
@@ -1887,7 +2010,7 @@ abstract class PersistentSubscriptionTest
 
     @Test
     @InterruptAfter(5)
-    void cannotJoinLiveUponReachingEndOfRecordingIfLiveHasAdvanced()
+    void shouldStartFromStoppedRecordingAndErrorWhenLiveHasAdvanced()
     {
         final PersistentPublication persistentPublication =
             PersistentPublication.create(aeronArchive, MDC_PUBLICATION_CHANNEL, STREAM_ID);
@@ -1938,7 +2061,7 @@ abstract class PersistentSubscriptionTest
 
     @Test
     @InterruptAfter(10)
-    void shouldStayOnAReplayWhenLiveCannotConnect()
+    void shouldStayOnReplayWhenLiveCannotConnect()
     {
         final PersistentPublication persistentPublication =
             PersistentPublication.create(aeronArchive, MDC_PUBLICATION_CHANNEL, STREAM_ID);
@@ -2154,7 +2277,7 @@ abstract class PersistentSubscriptionTest
 
     @Test
     @InterruptAfter(15)
-    void cannotFallbackToReplayWhenTheRecordingHasStoppedAtAnEarlierPosition()
+    void cannotFallbackToReplayWhenRecordingHasStoppedAtAnEarlierPosition()
     {
         final PersistentPublication persistentPublication =
             PersistentPublication.create(aeronArchive, MDC_PUBLICATION_CHANNEL, STREAM_ID);
@@ -2221,7 +2344,7 @@ abstract class PersistentSubscriptionTest
 
     @Test
     @InterruptAfter(10)
-    void cannotFallbackToReplayWhenTheRecordingHasBeenRemoved()
+    void cannotFallbackToReplayWhenRecordingHasBeenRemoved()
     {
         final PersistentPublication persistentPublication =
             PersistentPublication.create(aeronArchive, MDC_PUBLICATION_CHANNEL, STREAM_ID);
@@ -2573,10 +2696,167 @@ abstract class PersistentSubscriptionTest
         }
     }
 
+    // 30% replay loss while PS catches up from archive. NAK/retransmit must deliver all 100.
+    @Test
+    @InterruptAfter(60)
+    void shouldReceiveAllMessagesWithModerateReplayLoss()
+    {
+        runReplayLossTest(100, 0.3);
+    }
+
+    // 80% replay loss — severe stress on NAK/retransmit. Verifies no duplicates, no gaps.
+    @Test
+    @InterruptAfter(90)
+    void shouldReceiveAllMessagesWithHeavyReplayLoss()
+    {
+        runReplayLossTest(50, 0.8);
+    }
+
+    // Persist initial batch, start PS with lossy replay, then publish more WHILE PS is still
+    // replaying. PS must catch up through lossy replay, transition to LIVE, receive everything.
+    @Test
+    @InterruptAfter(60)
+    void shouldTransitionToLiveThroughLossyReplayWhilePublishing()
+    {
+        TestMediaDriver.notSupportedOnCMediaDriver("loss generator");
+
+        final StreamIdFrameDataLossGenerator lossGenerator = new StreamIdFrameDataLossGenerator();
+        final String aeronDir2 = CommonContext.generateRandomDirName();
+        final MediaDriver.Context driver2Ctx = driverCtxTpl.clone().aeronDirectoryName(aeronDir2)
+            .receiveChannelEndpointSupplier(receiveChannelEndpointSupplier(lossGenerator));
+        addCloseable(TestMediaDriver.launch(driver2Ctx, systemTestWatcher));
+        systemTestWatcher.dataCollector().add(driver2Ctx.aeronDirectory());
+        final Aeron aeron2 = addCloseable(Aeron.connect(aeronCtxTpl.clone().aeronDirectoryName(aeronDir2)));
+
+        final PersistentPublication persistentPublication =
+            PersistentPublication.create(aeronArchive, MDC_PUBLICATION_CHANNEL, STREAM_ID);
+        final List<byte[]> initialMessages = generateFixedPayloads(20, ONE_KB_MESSAGE_SIZE);
+        persistentPublication.persist(initialMessages);
+
+        persistentSubscriptionCtx
+            .aeron(aeron2)
+            .recordingId(persistentPublication.recordingId())
+            .liveChannel(MDC_SUBSCRIPTION_CHANNEL);
+
+        try (PersistentSubscription persistentSubscription = PersistentSubscription.create(persistentSubscriptionCtx))
+        {
+            final ThreadLocalRandom random = ThreadLocalRandom.current();
+            lossGenerator.enable(persistentSubscriptionCtx.replayStreamId(), bytes -> random.nextDouble() < 0.5);
+
+            // Start PS draining; while it's catching up from archive (with loss), publish more.
+            executeUntil(
+                () -> fragmentHandler.hasReceivedPayloads(initialMessages.size() / 2),
+                () -> poll(persistentSubscription, fragmentHandler, 10));
+
+            final List<byte[]> liveMessages = generateFixedPayloads(20, ONE_KB_MESSAGE_SIZE);
+            persistentPublication.publish(liveMessages);
+
+            executeUntil(
+                () -> fragmentHandler.hasReceivedPayloads(initialMessages.size() + liveMessages.size()) &&
+                    persistentSubscription.isLive(),
+                () -> poll(persistentSubscription, fragmentHandler, 10));
+
+            assertPayloads(fragmentHandler.receivedPayloads, initialMessages, liveMessages);
+            lossGenerator.disable();
+            verify(persistentSubscription);
+        }
+    }
+
+    private void runReplayLossTest(final int messageCount, final double dropRate)
+    {
+        TestMediaDriver.notSupportedOnCMediaDriver("loss generator");
+
+        final StreamIdFrameDataLossGenerator lossGenerator = new StreamIdFrameDataLossGenerator();
+        final String aeronDir2 = CommonContext.generateRandomDirName();
+        final MediaDriver.Context driver2Ctx = driverCtxTpl.clone().aeronDirectoryName(aeronDir2)
+            .receiveChannelEndpointSupplier(receiveChannelEndpointSupplier(lossGenerator));
+        addCloseable(TestMediaDriver.launch(driver2Ctx, systemTestWatcher));
+        systemTestWatcher.dataCollector().add(driver2Ctx.aeronDirectory());
+        final Aeron aeron2 = addCloseable(Aeron.connect(aeronCtxTpl.clone().aeronDirectoryName(aeronDir2)));
+
+        final PersistentPublication persistentPublication =
+            PersistentPublication.create(aeronArchive, MDC_PUBLICATION_CHANNEL, STREAM_ID);
+        final List<byte[]> messages = generateFixedPayloads(messageCount, ONE_KB_MESSAGE_SIZE);
+        persistentPublication.persist(messages);
+
+        persistentSubscriptionCtx
+            .aeron(aeron2)
+            .recordingId(persistentPublication.recordingId())
+            .liveChannel(MDC_SUBSCRIPTION_CHANNEL);
+
+        try (PersistentSubscription persistentSubscription = PersistentSubscription.create(persistentSubscriptionCtx))
+        {
+            // Drop the configured fraction of DATA frames on the replay stream-id. SETUPs and
+            // other control go through. NAK/retransmit must restore everything.
+            final ThreadLocalRandom random = ThreadLocalRandom.current();
+            lossGenerator.enable(persistentSubscriptionCtx.replayStreamId(), bytes -> random.nextDouble() < dropRate);
+
+            executeUntil(
+                () -> fragmentHandler.hasReceivedPayloads(messages.size()) && persistentSubscription.isLive(),
+                () -> poll(persistentSubscription, fragmentHandler, 10));
+
+            assertPayloads(fragmentHandler.receivedPayloads, messages);
+            lossGenerator.disable();
+            verify(persistentSubscription);
+        }
+    }
+
+    // 30% loss on PS's live MDC subscription channel. Initial 5 messages are persisted before
+    // PS starts so they replay cleanly; 30 more are offered live with loss. Verifies all 35
+    // messages are received in order — proves NAK-driven retransmission across loss.
+    @Test
+    @InterruptAfter(60)
+    void shouldReceiveAllMessagesWithLossOnLiveChannel()
+    {
+        TestMediaDriver.notSupportedOnCMediaDriver("loss generator");
+
+        final StreamIdFrameDataLossGenerator lossGenerator = new StreamIdFrameDataLossGenerator();
+        final String aeronDir2 = CommonContext.generateRandomDirName();
+        final MediaDriver.Context driver2Ctx = driverCtxTpl.clone().aeronDirectoryName(aeronDir2)
+            .receiveChannelEndpointSupplier(receiveChannelEndpointSupplier(lossGenerator));
+        addCloseable(TestMediaDriver.launch(driver2Ctx, systemTestWatcher));
+        systemTestWatcher.dataCollector().add(driver2Ctx.aeronDirectory());
+        final Aeron aeron2 = addCloseable(Aeron.connect(aeronCtxTpl.clone().aeronDirectoryName(aeronDir2)));
+
+        final PersistentPublication persistentPublication =
+            PersistentPublication.create(aeronArchive, MDC_PUBLICATION_CHANNEL, STREAM_ID);
+        final List<byte[]> initialMessages = generateFixedPayloads(5, ONE_KB_MESSAGE_SIZE);
+        persistentPublication.persist(initialMessages);
+
+        persistentSubscriptionCtx
+            .aeron(aeron2)
+            .recordingId(persistentPublication.recordingId())
+            .liveChannel(MDC_SUBSCRIPTION_CHANNEL);
+
+        try (PersistentSubscription persistentSubscription = PersistentSubscription.create(persistentSubscriptionCtx))
+        {
+            // Enable 30% drop on the live stream-id BEFORE PS is live, so SETUPs go through but
+            // post-attach DATA frames are sampled for drop.
+            final ThreadLocalRandom random = ThreadLocalRandom.current();
+            lossGenerator.enable(STREAM_ID, bytes -> random.nextDouble() < 0.3);
+
+            executeUntil(
+                persistentSubscription::isLive,
+                () -> poll(persistentSubscription, fragmentHandler, 10));
+
+            // Use offer (non-blocking) so persist's 30s timeout doesn't trip with backpressure.
+            final List<byte[]> liveMessages = generateFixedPayloads(30, ONE_KB_MESSAGE_SIZE);
+            persistentPublication.publish(liveMessages);
+
+            executeUntil(
+                () -> fragmentHandler.hasReceivedPayloads(initialMessages.size() + liveMessages.size()),
+                () -> poll(persistentSubscription, fragmentHandler, 10));
+
+            assertPayloads(fragmentHandler.receivedPayloads, initialMessages, liveMessages);
+            lossGenerator.disable();
+            verify(persistentSubscription);
+        }
+    }
+
     @ParameterizedTest
     @ValueSource(strings = { UNICAST_CHANNEL, IPC_CHANNEL })
     @InterruptAfter(15)
-    void anUntetheredPersistentSubscriptionCanFallBackToReplay(final String channel)
+    void anUntetheredPersistentSubscriptionCanFallBehindATetheredSubscription(final String channel)
     {
         final ChannelUriStringBuilder channelUriStringBuilder = new ChannelUriStringBuilder(channel);
 
@@ -2625,7 +2905,7 @@ abstract class PersistentSubscriptionTest
 
     @Test
     @InterruptAfter(10)
-    void recordingMustExist()
+    void shouldErrorIfRecordingDoesNotExist()
     {
         final int recordingId = 13; // <-- does not exist
         persistentSubscriptionCtx.recordingId(recordingId);
@@ -2645,7 +2925,7 @@ abstract class PersistentSubscriptionTest
 
     @Test
     @InterruptAfter(10)
-    void recordingStreamMustMatchLiveStream()
+    void shouldErrorIfRecordingStreamDoesNotMatchLiveStream()
     {
         final int liveStreamId = 1001; // <-- not the same as the recorded stream.
 
@@ -3244,6 +3524,105 @@ abstract class PersistentSubscriptionTest
             randomPayloads.add(bytes);
         }
         return randomPayloads;
+    }
+
+    private Aeron startSecondAeronWithReceiveLoss(final LossGenerator lossGenerator)
+    {
+        final String aeronDir2 = CommonContext.generateRandomDirName();
+        final MediaDriver.Context driver2Ctx = driverCtxTpl.clone().aeronDirectoryName(aeronDir2)
+            .receiveChannelEndpointSupplier(receiveChannelEndpointSupplier(lossGenerator));
+        addCloseable(TestMediaDriver.launch(driver2Ctx, systemTestWatcher));
+        systemTestWatcher.dataCollector().add(driver2Ctx.aeronDirectory());
+        return addCloseable(Aeron.connect(aeronCtxTpl.clone().aeronDirectoryName(aeronDir2)));
+    }
+
+    // Returns {initialTermId, termBufferLength} from the recording descriptor.
+    private int[] readRecordingTermLayout(final long recordingId)
+    {
+        final int[] result = { 0, 0 };
+        aeronArchive.listRecording(recordingId,
+            (controlSessionId, correlationId, recordingId1, startTimestamp, stopTimestamp,
+                startPosition, stopPos, initialTermId, segmentFileLength, termBufferLength,
+                mtuLength, sessionId, streamId1, strippedChannel, originalChannel, sourceIdentity) ->
+            {
+                result[0] = initialTermId;
+                result[1] = termBufferLength;
+            });
+        return result;
+    }
+
+    // Wait for the closed publication's residual state to drain; otherwise PS's live
+    // subscription can briefly attach to the ghost image and join LIVE before the actual
+    // resumed publisher's image arrives.
+    private static void closePublicationAndAwaitDrain(final PersistentPublication publication)
+    {
+        publication.closePublicationOnly();
+        Tests.await(() -> !publication.publicationCountersExist());
+    }
+
+    private Runnable newReplayObservingPoller(
+        final PersistentSubscription persistentSubscription,
+        final boolean[] observedReplaying)
+    {
+        return () ->
+        {
+            poll(persistentSubscription, fragmentHandler, 10);
+            if (persistentSubscription.isReplaying())
+            {
+                observedReplaying[0] = true;
+            }
+        };
+    }
+
+    private void awaitFirstAwaitLiveDeadlineBreach(
+        final PersistentSubscription persistentSubscription,
+        final Runnable pollAndTrack,
+        final boolean[] observedReplaying)
+    {
+        executeUntil(() -> listener.errorCount > 0, pollAndTrack);
+        // Exactly one deadline breach — fired once while PS was parked in AWAIT_LIVE.
+        assertEquals(1, listener.errorCount);
+        assertThat(
+            listener.lastException.getMessage(),
+            containsString("No image became available on the live subscription"));
+        assertFalse(persistentSubscription.isLive());
+        assertFalse(observedReplaying[0]);
+    }
+
+    // Drop every DATA frame on PS's live stream whose term offset lies past fromPosition,
+    // all the way to end-of-term. Stream-id discrimination (STREAM_ID vs the replay
+    // stream id) leaves the replay subscription unaffected.
+    private void armDataDropFromPosition(
+        final DataInRangeLossGenerator lossGenerator,
+        final long recordingId,
+        final long fromPosition)
+    {
+        final int[] info = readRecordingTermLayout(recordingId);
+        final int initialTermId = info[0];
+        final int termBufferLength = info[1];
+        final int positionBitsToShift = LogBufferDescriptor.positionBitsToShift(termBufferLength);
+        final int targetActiveTermId = LogBufferDescriptor.computeTermIdFromPosition(
+            fromPosition, positionBitsToShift, initialTermId);
+        final int targetTermOffsetMin = (int)(fromPosition & (termBufferLength - 1L));
+        lossGenerator.setTarget(STREAM_ID, targetActiveTermId, targetTermOffsetMin, termBufferLength);
+    }
+
+    // Drop SETUP frames whose (term_id, term_offset) tuple matches position. Once the
+    // publisher's snd_pos advances past it, subsequent SETUPs no longer match and PS
+    // attaches at the advanced position instead.
+    private void armSetupDropAtPosition(
+        final SetupAtPositionLossGenerator lossGenerator,
+        final long recordingId,
+        final long position)
+    {
+        final int[] info = readRecordingTermLayout(recordingId);
+        final int initialTermId = info[0];
+        final int termBufferLength = info[1];
+        final int positionBitsToShift = LogBufferDescriptor.positionBitsToShift(termBufferLength);
+        final int targetActiveTermId = LogBufferDescriptor.computeTermIdFromPosition(
+            position, positionBitsToShift, initialTermId);
+        final int targetTermOffset = (int)(position & (termBufferLength - 1L));
+        lossGenerator.setTarget(STREAM_ID, initialTermId, targetActiveTermId, targetTermOffset);
     }
 
     private static void executeUntil(final BooleanSupplier predicate, final Runnable runnable)

--- a/aeron-test-support/src/main/c/aeron_data_in_range_loss_generator.c
+++ b/aeron-test-support/src/main/c/aeron_data_in_range_loss_generator.c
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2026 Adaptive Financial Consulting Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "aeron_alloc.h"
+#include "concurrent/aeron_atomic.h"
+#include "media/aeron_receive_channel_endpoint.h"
+#include "media/aeron_udp_channel.h"
+#include "protocol/aeron_udp_protocol.h"
+#include "aeron_data_in_range_loss_generator.h"
+
+typedef struct aeron_data_in_range_loss_generator_state_stct
+{
+    aeron_data_in_range_loss_config_t *config;
+    struct aeron_receive_channel_endpoint_stct *endpoint;
+}
+aeron_data_in_range_loss_generator_state_t;
+
+void aeron_data_in_range_loss_config_init(aeron_data_in_range_loss_config_t *config)
+{
+    memset(config, 0, sizeof(*config));
+}
+
+void aeron_data_in_range_loss_config_set_target(
+    aeron_data_in_range_loss_config_t *config,
+    int32_t stream_id,
+    int32_t active_term_id,
+    int32_t term_offset_inclusive_min,
+    int32_t term_offset_exclusive_max)
+{
+    config->stream_id = stream_id;
+    config->active_term_id = active_term_id;
+    config->term_offset_inclusive_min = term_offset_inclusive_min;
+    config->term_offset_exclusive_max = term_offset_exclusive_max;
+}
+
+void aeron_data_in_range_loss_config_set_endpoint_skip_substring(
+    aeron_data_in_range_loss_config_t *config,
+    const char *substring)
+{
+    if (NULL == substring)
+    {
+        config->endpoint_skip_substring[0] = '\0';
+        return;
+    }
+    strncpy(config->endpoint_skip_substring, substring, sizeof(config->endpoint_skip_substring) - 1);
+    config->endpoint_skip_substring[sizeof(config->endpoint_skip_substring) - 1] = '\0';
+}
+
+void aeron_data_in_range_loss_config_enable(aeron_data_in_range_loss_config_t *config)
+{
+    AERON_SET_RELEASE(config->enabled, true);
+}
+
+void aeron_data_in_range_loss_config_disable(aeron_data_in_range_loss_config_t *config)
+{
+    AERON_SET_RELEASE(config->enabled, false);
+}
+
+int aeron_data_in_range_loss_config_frames_dropped(aeron_data_in_range_loss_config_t *config)
+{
+    int dropped;
+    AERON_GET_ACQUIRE(dropped, config->frames_dropped);
+    return dropped;
+}
+
+static bool aeron_data_in_range_loss_generator_should_drop_frame_detailed(
+    void *state_ptr,
+    const struct sockaddr_storage *address,
+    const uint8_t *buffer,
+    int32_t stream_id,
+    int32_t session_id,
+    int32_t term_id,
+    int32_t term_offset,
+    int32_t length)
+{
+    (void)address;
+    (void)session_id;
+
+    aeron_data_in_range_loss_generator_state_t *state =
+        (aeron_data_in_range_loss_generator_state_t *)state_ptr;
+    aeron_data_in_range_loss_config_t *config = state->config;
+
+    bool enabled;
+    AERON_GET_ACQUIRE(enabled, config->enabled);
+    if (!enabled)
+    {
+        return false;
+    }
+
+    // Heartbeats (length == header size, frame_length == 0) carry EOS / REVOKE flags.
+    // Dropping them would prevent the subscriber from detecting publisher revoke and
+    // closing its image, so always let them pass.
+    const aeron_frame_header_t *frame = (const aeron_frame_header_t *)buffer;
+    if ((size_t)length == AERON_DATA_HEADER_LENGTH && 0 == frame->frame_length)
+    {
+        return false;
+    }
+
+    if (stream_id != config->stream_id ||
+        term_id != config->active_term_id ||
+        term_offset < config->term_offset_inclusive_min ||
+        term_offset >= config->term_offset_exclusive_max)
+    {
+        return false;
+    }
+
+    if ('\0' != config->endpoint_skip_substring[0])
+    {
+        // udp_channel is set by the driver after the supplier callback returns and before
+        // any frame can arrive, so this dereference is safe at frame-check time.
+        aeron_udp_channel_t *channel = state->endpoint->conductor_fields.udp_channel;
+        if (NULL != channel && NULL != strstr(channel->original_uri, config->endpoint_skip_substring))
+        {
+            return false;
+        }
+    }
+
+    int prev;
+    AERON_GET_ACQUIRE(prev, config->frames_dropped);
+    AERON_SET_RELEASE(config->frames_dropped, prev + 1);
+
+    return true;
+}
+
+static void aeron_data_in_range_loss_generator_close(aeron_loss_generator_t *generator)
+{
+    // The state was allocated as a trailing block by aeron_loss_generator_alloc,
+    // so freeing the generator frees both. The shared config is owned by the caller.
+    aeron_free(generator);
+}
+
+int aeron_data_in_range_loss_generator_create(
+    aeron_loss_generator_t **generator,
+    aeron_data_in_range_loss_config_t *config,
+    struct aeron_receive_channel_endpoint_stct *endpoint)
+{
+    aeron_data_in_range_loss_generator_state_t *state = NULL;
+    if (aeron_loss_generator_alloc(generator, sizeof(*state), (void **)&state) < 0)
+    {
+        return -1;
+    }
+
+    state->config = config;
+    state->endpoint = endpoint;
+    (*generator)->should_drop_frame_simple = NULL;
+    (*generator)->should_drop_frame_detailed = aeron_data_in_range_loss_generator_should_drop_frame_detailed;
+    (*generator)->close = aeron_data_in_range_loss_generator_close;
+
+    return 0;
+}

--- a/aeron-test-support/src/main/c/aeron_data_in_range_loss_generator.h
+++ b/aeron-test-support/src/main/c/aeron_data_in_range_loss_generator.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 Adaptive Financial Consulting Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef AERON_DATA_IN_RANGE_LOSS_GENERATOR_H
+#define AERON_DATA_IN_RANGE_LOSS_GENERATOR_H
+
+#include "media/aeron_loss_generator.h"
+#include "uri/aeron_uri.h"
+
+// Drops incoming DATA frames whose `(stream_id, active_term_id)` matches and whose
+// term_offset falls in `[term_offset_inclusive_min, term_offset_exclusive_max)` — but
+// only on endpoints whose original_uri does NOT contain `endpoint_skip_substring`.
+// Used to deterministically punch a contiguous gap into one subscriber's reception
+// while letting another subscriber on the same publication receive the same range
+// normally (e.g. exempting the archive's recording subscription so the recording
+// stays contiguous while a client subscriber is forced to recover via replay).
+//
+// Generators are per-endpoint; the supplier callback creates one per receive endpoint
+// and the per-instance state holds a pointer to the endpoint plus the shared config.
+// At frame-check time the generator inspects endpoint->conductor_fields.udp_channel
+// (which the driver assigns AFTER the supplier returns, but BEFORE any frame arrives)
+// and decides whether to drop.
+typedef struct aeron_data_in_range_loss_config_stct
+{
+    int32_t stream_id;
+    int32_t active_term_id;
+    int32_t term_offset_inclusive_min;
+    int32_t term_offset_exclusive_max;
+
+    // If non-empty, endpoints whose original_uri contains this substring are SKIPPED
+    // (their DATA always passes, regardless of the position match). Used to exempt
+    // the archive's recording subscription, whose URI carries `init-term-id=` while
+    // a plain application subscription does not.
+    char endpoint_skip_substring[AERON_URI_MAX_LENGTH];
+
+    volatile bool enabled;
+    volatile int frames_dropped;
+}
+aeron_data_in_range_loss_config_t;
+
+void aeron_data_in_range_loss_config_init(aeron_data_in_range_loss_config_t *config);
+
+void aeron_data_in_range_loss_config_set_target(
+    aeron_data_in_range_loss_config_t *config,
+    int32_t stream_id,
+    int32_t active_term_id,
+    int32_t term_offset_inclusive_min,
+    int32_t term_offset_exclusive_max);
+
+void aeron_data_in_range_loss_config_set_endpoint_skip_substring(
+    aeron_data_in_range_loss_config_t *config,
+    const char *substring);
+
+void aeron_data_in_range_loss_config_enable(aeron_data_in_range_loss_config_t *config);
+
+void aeron_data_in_range_loss_config_disable(aeron_data_in_range_loss_config_t *config);
+
+int aeron_data_in_range_loss_config_frames_dropped(aeron_data_in_range_loss_config_t *config);
+
+// Forward decl — callers include the driver header for the full type.
+struct aeron_receive_channel_endpoint_stct;
+
+// Allocates a new generator bound to (config, endpoint). The config must outlive the
+// generator (and is not owned/freed by it). Caller transfers ownership of the returned
+// generator to the receive endpoint's data_loss_generator field; the driver invokes
+// gen->close on endpoint teardown, which frees the generator allocation.
+int aeron_data_in_range_loss_generator_create(
+    aeron_loss_generator_t **generator,
+    aeron_data_in_range_loss_config_t *config,
+    struct aeron_receive_channel_endpoint_stct *endpoint);
+
+#endif //AERON_DATA_IN_RANGE_LOSS_GENERATOR_H

--- a/aeron-test-support/src/main/c/aeron_setup_at_position_loss_generator.c
+++ b/aeron-test-support/src/main/c/aeron_setup_at_position_loss_generator.c
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2026 Adaptive Financial Consulting Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "aeron_alloc.h"
+#include "concurrent/aeron_atomic.h"
+#include "media/aeron_receive_channel_endpoint.h"
+#include "media/aeron_udp_channel.h"
+#include "protocol/aeron_udp_protocol.h"
+#include "aeron_setup_at_position_loss_generator.h"
+
+typedef struct aeron_setup_at_position_loss_generator_state_stct
+{
+    aeron_setup_at_position_loss_config_t *config;
+    struct aeron_receive_channel_endpoint_stct *endpoint;
+}
+aeron_setup_at_position_loss_generator_state_t;
+
+void aeron_setup_at_position_loss_config_init(aeron_setup_at_position_loss_config_t *config)
+{
+    memset(config, 0, sizeof(*config));
+}
+
+void aeron_setup_at_position_loss_config_set_target(
+    aeron_setup_at_position_loss_config_t *config,
+    int32_t stream_id,
+    int32_t initial_term_id,
+    int32_t active_term_id,
+    int32_t term_offset)
+{
+    config->stream_id = stream_id;
+    config->initial_term_id = initial_term_id;
+    config->active_term_id = active_term_id;
+    config->term_offset = term_offset;
+}
+
+void aeron_setup_at_position_loss_config_set_endpoint_skip_substring(
+    aeron_setup_at_position_loss_config_t *config,
+    const char *substring)
+{
+    if (NULL == substring)
+    {
+        config->endpoint_skip_substring[0] = '\0';
+        return;
+    }
+    strncpy(config->endpoint_skip_substring, substring, sizeof(config->endpoint_skip_substring) - 1);
+    config->endpoint_skip_substring[sizeof(config->endpoint_skip_substring) - 1] = '\0';
+}
+
+void aeron_setup_at_position_loss_config_enable(aeron_setup_at_position_loss_config_t *config)
+{
+    AERON_SET_RELEASE(config->enabled, true);
+}
+
+void aeron_setup_at_position_loss_config_disable(aeron_setup_at_position_loss_config_t *config)
+{
+    AERON_SET_RELEASE(config->enabled, false);
+}
+
+int aeron_setup_at_position_loss_config_setups_dropped(aeron_setup_at_position_loss_config_t *config)
+{
+    int dropped;
+    AERON_GET_ACQUIRE(dropped, config->setups_dropped);
+    return dropped;
+}
+
+static bool aeron_setup_at_position_loss_generator_should_drop_frame_simple(
+    void *state_ptr,
+    const struct sockaddr_storage *address,
+    const uint8_t *buffer,
+    int32_t length)
+{
+    (void)address;
+
+    aeron_setup_at_position_loss_generator_state_t *state =
+        (aeron_setup_at_position_loss_generator_state_t *)state_ptr;
+    aeron_setup_at_position_loss_config_t *config = state->config;
+
+    bool enabled;
+    AERON_GET_ACQUIRE(enabled, config->enabled);
+    if (!enabled)
+    {
+        return false;
+    }
+
+    if (length < (int32_t)sizeof(aeron_setup_header_t))
+    {
+        return false;
+    }
+
+    const aeron_frame_header_t *frame = (const aeron_frame_header_t *)buffer;
+    if (AERON_HDR_TYPE_SETUP != frame->type)
+    {
+        return false;
+    }
+
+    const aeron_setup_header_t *setup = (const aeron_setup_header_t *)buffer;
+    if (setup->stream_id != config->stream_id ||
+        setup->initial_term_id != config->initial_term_id ||
+        setup->active_term_id != config->active_term_id ||
+        setup->term_offset != config->term_offset)
+    {
+        return false;
+    }
+
+    if ('\0' != config->endpoint_skip_substring[0])
+    {
+        // udp_channel is set by the driver after the supplier callback returns and before
+        // any frame can arrive, so this dereference is safe at frame-check time.
+        aeron_udp_channel_t *channel = state->endpoint->conductor_fields.udp_channel;
+        if (NULL != channel && NULL != strstr(channel->original_uri, config->endpoint_skip_substring))
+        {
+            return false;
+        }
+    }
+
+    int prev;
+    AERON_GET_ACQUIRE(prev, config->setups_dropped);
+    AERON_SET_RELEASE(config->setups_dropped, prev + 1);
+
+    return true;
+}
+
+static void aeron_setup_at_position_loss_generator_close(aeron_loss_generator_t *generator)
+{
+    // The state was allocated as a trailing block by aeron_loss_generator_alloc,
+    // so freeing the generator frees both. The shared config is owned by the caller.
+    aeron_free(generator);
+}
+
+int aeron_setup_at_position_loss_generator_create(
+    aeron_loss_generator_t **generator,
+    aeron_setup_at_position_loss_config_t *config,
+    struct aeron_receive_channel_endpoint_stct *endpoint)
+{
+    aeron_setup_at_position_loss_generator_state_t *state = NULL;
+    if (aeron_loss_generator_alloc(generator, sizeof(*state), (void **)&state) < 0)
+    {
+        return -1;
+    }
+
+    state->config = config;
+    state->endpoint = endpoint;
+    (*generator)->should_drop_frame_simple = aeron_setup_at_position_loss_generator_should_drop_frame_simple;
+    (*generator)->should_drop_frame_detailed = NULL;
+    (*generator)->close = aeron_setup_at_position_loss_generator_close;
+
+    return 0;
+}

--- a/aeron-test-support/src/main/c/aeron_setup_at_position_loss_generator.h
+++ b/aeron-test-support/src/main/c/aeron_setup_at_position_loss_generator.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 Adaptive Financial Consulting Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef AERON_SETUP_AT_POSITION_LOSS_GENERATOR_H
+#define AERON_SETUP_AT_POSITION_LOSS_GENERATOR_H
+
+#include "media/aeron_loss_generator.h"
+#include "uri/aeron_uri.h"
+
+// Drops incoming SETUP frames whose (initial_term_id, active_term_id, term_offset)
+// tuple matches a target — but only on endpoints whose original_uri does NOT contain
+// `endpoint_skip_substring`. This lets a test deterministically force a publication-image
+// match-time race: SETUPs at the publisher's join position are dropped on one
+// subscriber's endpoint (forcing it to attach via a later SETUP at an advanced
+// position), while another subscriber's endpoint sees the first SETUP normally.
+//
+// Generators are per-endpoint; the supplier callback creates one per receive endpoint
+// and the per-instance state holds a pointer to the endpoint plus the shared config.
+// At frame-check time the generator inspects endpoint->conductor_fields.udp_channel
+// (which the driver assigns AFTER the supplier returns, but BEFORE any frame arrives)
+// and decides whether to drop.
+typedef struct aeron_setup_at_position_loss_config_stct
+{
+    // Target SETUP fields. SETUPs whose stream_id matches AND whose
+    // initial_term_id/active_term_id/term_offset all match are candidates for dropping.
+    // Other SETUPs always pass.
+    int32_t stream_id;
+    int32_t initial_term_id;
+    int32_t active_term_id;
+    int32_t term_offset;
+
+    // If non-empty, endpoints whose original_uri contains this substring are SKIPPED
+    // (their SETUPs always pass, regardless of position match). Used to exempt the
+    // archive's recording subscription, whose URI carries `init-term-id=` while a plain
+    // application subscription does not.
+    char endpoint_skip_substring[AERON_URI_MAX_LENGTH];
+
+    volatile bool enabled;
+    volatile int setups_dropped;
+}
+aeron_setup_at_position_loss_config_t;
+
+void aeron_setup_at_position_loss_config_init(aeron_setup_at_position_loss_config_t *config);
+
+void aeron_setup_at_position_loss_config_set_target(
+    aeron_setup_at_position_loss_config_t *config,
+    int32_t stream_id,
+    int32_t initial_term_id,
+    int32_t active_term_id,
+    int32_t term_offset);
+
+void aeron_setup_at_position_loss_config_set_endpoint_skip_substring(
+    aeron_setup_at_position_loss_config_t *config,
+    const char *substring);
+
+void aeron_setup_at_position_loss_config_enable(aeron_setup_at_position_loss_config_t *config);
+
+void aeron_setup_at_position_loss_config_disable(aeron_setup_at_position_loss_config_t *config);
+
+int aeron_setup_at_position_loss_config_setups_dropped(aeron_setup_at_position_loss_config_t *config);
+
+// Forward decl — callers include the driver header for the full type.
+struct aeron_receive_channel_endpoint_stct;
+
+// Allocates a new generator bound to (config, endpoint). The config must outlive the
+// generator (and is not owned/freed by it). Caller transfers ownership of the returned
+// generator to the receive endpoint's data_loss_generator field; the driver invokes
+// gen->close on endpoint teardown, which frees the generator allocation.
+int aeron_setup_at_position_loss_generator_create(
+    aeron_loss_generator_t **generator,
+    aeron_setup_at_position_loss_config_t *config,
+    struct aeron_receive_channel_endpoint_stct *endpoint);
+
+#endif //AERON_SETUP_AT_POSITION_LOSS_GENERATOR_H

--- a/aeron-test-support/src/main/java/io/aeron/test/driver/DataInRangeLossGenerator.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/driver/DataInRangeLossGenerator.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026 Adaptive Financial Consulting Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.test.driver;
+
+import io.aeron.driver.ext.LossGenerator;
+import io.aeron.protocol.DataHeaderFlyweight;
+import io.aeron.protocol.HeaderFlyweight;
+import org.agrona.concurrent.UnsafeBuffer;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.net.InetSocketAddress;
+import java.nio.ByteOrder;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Drops incoming DATA frames whose {@code (streamId, termId)} matches and whose
+ * {@code termOffset} falls in {@code [termOffsetInclusiveMin, termOffsetExclusiveMax)}.
+ * Used to deterministically punch a contiguous gap into one subscriber's reception
+ * (e.g. a persistent subscription on a dedicated test driver) while another
+ * subscriber on the publisher's own driver receives the same range normally.
+ *
+ * <p>SETUP frames (handled by the simple {@code shouldDropFrame} variant) always pass.
+ * Heartbeat DATA frames (frame-length == 0) also always pass — they carry the EOS and
+ * REVOKED flags, which the subscriber needs to see to detect a revoked publication
+ * and close its image. Without that the subscriber would never refresh-replay.
+ */
+public final class DataInRangeLossGenerator implements LossGenerator
+{
+    private static final VarHandle ENABLED_VH;
+
+    static
+    {
+        try
+        {
+            ENABLED_VH = MethodHandles.lookup()
+                .findVarHandle(DataInRangeLossGenerator.class, "enabled", boolean.class);
+        }
+        catch (final NoSuchFieldException | IllegalAccessException e)
+        {
+            throw new Error(e);
+        }
+    }
+
+    private int streamId;
+    private int activeTermId;
+    private int termOffsetInclusiveMin;
+    private int termOffsetExclusiveMax;
+    private volatile boolean enabled;
+    private final AtomicInteger framesDropped = new AtomicInteger();
+
+    public void setTarget(
+        final int streamId,
+        final int activeTermId,
+        final int termOffsetInclusiveMin,
+        final int termOffsetExclusiveMax)
+    {
+        this.streamId = streamId;
+        this.activeTermId = activeTermId;
+        this.termOffsetInclusiveMin = termOffsetInclusiveMin;
+        this.termOffsetExclusiveMax = termOffsetExclusiveMax;
+    }
+
+    public void enable()
+    {
+        ENABLED_VH.setRelease(this, true);
+    }
+
+    public void disable()
+    {
+        ENABLED_VH.setRelease(this, false);
+    }
+
+    public int framesDropped()
+    {
+        return framesDropped.get();
+    }
+
+    public boolean shouldDropFrame(
+        final InetSocketAddress address,
+        final UnsafeBuffer buffer,
+        final int streamId,
+        final int sessionId,
+        final int termId,
+        final int termOffset,
+        final int length)
+    {
+        if (!(boolean)ENABLED_VH.getAcquire(this))
+        {
+            return false;
+        }
+
+        // Heartbeats (frame_length == 0, length == DATA header size) carry EOS / REVOKED flags.
+        // Dropping them would prevent the subscriber from seeing publisher revoke and closing
+        // its image, which would block the refresh-replay path this generator is meant to drive.
+        if (length == DataHeaderFlyweight.HEADER_LENGTH &&
+            0 == buffer.getInt(HeaderFlyweight.FRAME_LENGTH_FIELD_OFFSET, ByteOrder.LITTLE_ENDIAN))
+        {
+            return false;
+        }
+
+        if (streamId != this.streamId ||
+            termId != this.activeTermId ||
+            termOffset < this.termOffsetInclusiveMin ||
+            termOffset >= this.termOffsetExclusiveMax)
+        {
+            return false;
+        }
+
+        framesDropped.incrementAndGet();
+        return true;
+    }
+
+    public boolean shouldDropFrame(final InetSocketAddress address, final UnsafeBuffer buffer, final int length)
+    {
+        return false;
+    }
+}

--- a/aeron-test-support/src/main/java/io/aeron/test/driver/SetupAtPositionLossGenerator.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/driver/SetupAtPositionLossGenerator.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 Adaptive Financial Consulting Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.test.driver;
+
+import io.aeron.driver.ext.LossGenerator;
+import io.aeron.protocol.HeaderFlyweight;
+import io.aeron.protocol.SetupFlyweight;
+import org.agrona.concurrent.UnsafeBuffer;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.net.InetSocketAddress;
+import java.nio.ByteOrder;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Drops incoming SETUP frames whose {@code (streamId, initialTermId, activeTermId, termOffset)}
+ * tuple matches a target. DATA frames always pass.
+ *
+ * <p>Used to deterministically force a publication-image match-time race: SETUPs at a publisher's
+ * join position can be dropped on a subscriber's endpoint, forcing it to attach via a later
+ * SETUP at an advanced position. Pair with another driver hosting the recording subscription
+ * (or any subscriber that should see SETUPs normally) so its endpoint isn't filtered.
+ */
+public final class SetupAtPositionLossGenerator implements LossGenerator
+{
+    private static final VarHandle ENABLED_VH;
+
+    static
+    {
+        try
+        {
+            ENABLED_VH = MethodHandles.lookup()
+                .findVarHandle(SetupAtPositionLossGenerator.class, "enabled", boolean.class);
+        }
+        catch (final NoSuchFieldException | IllegalAccessException e)
+        {
+            throw new Error(e);
+        }
+    }
+
+    private final SetupFlyweight setupFlyweight = new SetupFlyweight();
+    private int streamId;
+    private int initialTermId;
+    private int activeTermId;
+    private int termOffset;
+    private volatile boolean enabled;
+    private final AtomicInteger setupsDropped = new AtomicInteger();
+
+    public void setTarget(
+        final int streamId,
+        final int initialTermId,
+        final int activeTermId,
+        final int termOffset)
+    {
+        this.streamId = streamId;
+        this.initialTermId = initialTermId;
+        this.activeTermId = activeTermId;
+        this.termOffset = termOffset;
+    }
+
+    public void enable()
+    {
+        ENABLED_VH.setRelease(this, true);
+    }
+
+    public void disable()
+    {
+        ENABLED_VH.setRelease(this, false);
+    }
+
+    public int setupsDropped()
+    {
+        return setupsDropped.get();
+    }
+
+    public boolean shouldDropFrame(final InetSocketAddress address, final UnsafeBuffer buffer, final int length)
+    {
+        if (!(boolean)ENABLED_VH.getAcquire(this))
+        {
+            return false;
+        }
+
+        if (length < SetupFlyweight.HEADER_LENGTH)
+        {
+            return false;
+        }
+
+        final int type = buffer.getShort(HeaderFlyweight.TYPE_FIELD_OFFSET, ByteOrder.LITTLE_ENDIAN) & 0xFFFF;
+        if (HeaderFlyweight.HDR_TYPE_SETUP != type)
+        {
+            return false;
+        }
+
+        setupFlyweight.wrap(buffer, 0, length);
+        if (setupFlyweight.streamId() != this.streamId ||
+            setupFlyweight.initialTermId() != this.initialTermId ||
+            setupFlyweight.activeTermId() != this.activeTermId ||
+            setupFlyweight.termOffset() != this.termOffset)
+        {
+            return false;
+        }
+
+        setupsDropped.incrementAndGet();
+        return true;
+    }
+
+    public boolean shouldDropFrame(
+        final InetSocketAddress address,
+        final UnsafeBuffer buffer,
+        final int streamId,
+        final int sessionId,
+        final int termId,
+        final int termOffset,
+        final int length)
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
Made shouldRefreshAndReplayWhenLiveAheadOfStopPositionAfterResume and shouldReplayAndCatchUpWhenExtendedRecordingIsAheadOfLivePosition tests more deterministic, ported a few resilience tests from C to Java, normalized test names between C and Java