### PR TITLE
Fixed potential integer overflow of blockLengthLimit in Image.blockPoll and Image.rawPoll

### DIFF
--- a/aeron-client/src/main/java/io/aeron/Image.java
+++ b/aeron-client/src/main/java/io/aeron/Image.java
@@ -774,7 +774,9 @@ public final class Image
 
         final long position = subscriberPosition.get();
         final int offset = (int)position & termLengthMask;
-        final int limitOffset = Math.min(offset + blockLengthLimit, termLengthMask + 1);
+        final int capacity = termLengthMask + 1;
+        final long highLimitOffset = (long)offset + blockLengthLimit;
+        final int limitOffset = capacity < highLimitOffset ? capacity : (int)highLimitOffset;
         final UnsafeBuffer termBuffer = activeTermBuffer(position);
         final int resultingOffset = TermBlockScanner.scan(termBuffer, offset, limitOffset);
         final int length = resultingOffset - offset;
@@ -831,7 +833,8 @@ public final class Image
         final int activeIndex = LogBufferDescriptor.indexByPosition(position, positionBitsToShift);
         final UnsafeBuffer termBuffer = termBuffers[activeIndex];
         final int capacity = termBuffer.capacity();
-        final int limitOffset = Math.min(offset + blockLengthLimit, capacity);
+        final long highLimitOffset = (long)offset + blockLengthLimit;
+        final int limitOffset = capacity < highLimitOffset ? capacity : (int)highLimitOffset;
         final int resultingOffset = TermBlockScanner.scan(termBuffer, offset, limitOffset);
         final int length = resultingOffset - offset;
 

--- a/aeron-client/src/test/java/io/aeron/ImageTest.java
+++ b/aeron-client/src/test/java/io/aeron/ImageTest.java
@@ -753,6 +753,60 @@ class ImageTest
         verify(position, never()).setRelease(AdditionalMatchers.not(eq(initialPosition)));
     }
 
+    @Test
+    void blockPollClampsBlockLengthLimitWithoutIntegerOverflow()
+    {
+        final int frameOffset = ALIGNED_FRAME_LENGTH;
+        final long initialPosition = computePosition(
+            INITIAL_TERM_ID, frameOffset, POSITION_BITS_TO_SHIFT, INITIAL_TERM_ID);
+        position.setRelease(initialPosition);
+        final Image image = createImage();
+
+        insertDataFrame(INITIAL_TERM_ID, frameOffset);
+
+        final int[] handlerCallCount = { 0 };
+        final int[] receivedLength = { -1 };
+        final int bytes = image.blockPoll(
+            (buf, off, len, sid, tid) ->
+            {
+                handlerCallCount[0]++;
+                receivedLength[0] = len;
+            },
+            Integer.MAX_VALUE);
+
+        assertEquals(ALIGNED_FRAME_LENGTH, bytes);
+        assertEquals(1, handlerCallCount[0]);
+        assertEquals(ALIGNED_FRAME_LENGTH, receivedLength[0]);
+        assertEquals(initialPosition + ALIGNED_FRAME_LENGTH, image.position());
+    }
+
+    @Test
+    void rawPollClampsBlockLengthLimitWithoutIntegerOverflow()
+    {
+        final int frameOffset = ALIGNED_FRAME_LENGTH;
+        final long initialPosition = computePosition(
+            INITIAL_TERM_ID, frameOffset, POSITION_BITS_TO_SHIFT, INITIAL_TERM_ID);
+        position.setRelease(initialPosition);
+        final Image image = createImage();
+
+        insertDataFrame(INITIAL_TERM_ID, frameOffset);
+
+        final int[] handlerCallCount = { 0 };
+        final int[] receivedLength = { -1 };
+        final int bytes = image.rawPoll(
+            (fc, fo, buf, to, len, sid, tid) ->
+            {
+                handlerCallCount[0]++;
+                receivedLength[0] = len;
+            },
+            Integer.MAX_VALUE);
+
+        assertEquals(ALIGNED_FRAME_LENGTH, bytes);
+        assertEquals(1, handlerCallCount[0]);
+        assertEquals(ALIGNED_FRAME_LENGTH, receivedLength[0]);
+        assertEquals(initialPosition + ALIGNED_FRAME_LENGTH, image.position());
+    }
+
     private Image createImage()
     {
         return new Image(subscription, SESSION_ID, position, logBuffers, errorHandler, SOURCE_IDENTITY, CORRELATION_ID);


### PR DESCRIPTION
C already handled this correctly - just updated Java code to match C.