### PR TITLE
Support using Cpusets to handle thread affinity.

### DIFF
--- a/aeron-client/src/main/c/util/aeron_fileutil.c
+++ b/aeron-client/src/main/c/util/aeron_fileutil.c
@@ -318,6 +318,35 @@ int aeron_delete_file(const char *dir)
     return aeron_delete_path(dir, FOF_NORECURSION | FOF_FILESONLY | FOF_NOCONFIRMATION | FOF_NOERRORUI | FOF_SILENT);
 }
 
+const char *aeron_realpath(const char *path, char *resolved_path, const size_t resolved_path_len)
+{
+    return _fullpath(resolved_path, path, resolved_path_len);
+}
+
+const char *aeron_tmpdir(char path, size_t path_len)
+{
+    const int result = GetTempPath2(path, path_len);
+    if (0 < result && result < path_len)
+    {
+        path[result] = '\0';
+        return path;
+    }
+
+    return NULL;
+}
+
+bool aeron_file_exists(const char* path)
+{
+    const int result = _access_s(path, F_OK);
+    if (0 == result)
+    {
+        return true;
+    }
+
+    errno = 0;
+    return false;
+}
+
 #else
 #include <unistd.h>
 #include <sys/mman.h>
@@ -376,6 +405,29 @@ int aeron_delete_file(const char *path)
 {
     return remove(path);
 }
+
+const char *aeron_realpath(const char *path, char *resolved_path, const size_t resolved_path_len)
+{
+    return realpath(path, resolved_path);
+}
+
+const char *aeron_tmpdir(char *path, size_t path_len)
+{
+    return P_tmpdir;
+}
+
+bool aeron_file_exists(const char* path)
+{
+    const int result = access(path, F_OK);
+    if (0 == result)
+    {
+        return true;
+    }
+
+    errno = 0;
+    return false;
+}
+
 
 static int unlink_func(const char *path, const struct stat *sb, int type_flag, struct FTW *ftw)
 {

--- a/aeron-client/src/main/c/util/aeron_fileutil.c
+++ b/aeron-client/src/main/c/util/aeron_fileutil.c
@@ -325,7 +325,7 @@ const char *aeron_realpath(const char *path, char *resolved_path, const size_t r
 
 const char *aeron_tmpdir(char path, size_t path_len)
 {
-    const int result = GetTempPath2(path, path_len);
+    const int result = GetTempPath2(path_len, path);
     if (0 < result && result < path_len)
     {
         path[result] = '\0';

--- a/aeron-client/src/main/c/util/aeron_fileutil.c
+++ b/aeron-client/src/main/c/util/aeron_fileutil.c
@@ -323,9 +323,9 @@ const char *aeron_realpath(const char *path, char *resolved_path, const size_t r
     return _fullpath(resolved_path, path, resolved_path_len);
 }
 
-const char *aeron_tmpdir(char path, size_t path_len)
+const char *aeron_tmpdir(char *path, size_t path_len)
 {
-    const int result = GetTempPath2(path_len, path);
+    const int result = GetTempPath(path_len, path);
     if (0 < result && result < path_len)
     {
         path[result] = '\0';
@@ -337,7 +337,7 @@ const char *aeron_tmpdir(char path, size_t path_len)
 
 bool aeron_file_exists(const char* path)
 {
-    const int result = _access_s(path, F_OK);
+    const int result = _access_s(path, 0);
     if (0 == result)
     {
         return true;

--- a/aeron-client/src/main/c/util/aeron_fileutil.h
+++ b/aeron-client/src/main/c/util/aeron_fileutil.h
@@ -23,6 +23,8 @@
 #include "util/aeron_platform.h"
 #include "concurrent/aeron_logbuffer_descriptor.h"
 
+#define AERON_MAX_FILE_PATH_LENGTH (4096)
+
 typedef struct aeron_mapped_file_stct
 {
     void *addr;
@@ -47,6 +49,9 @@ int aeron_unmap(aeron_mapped_file_t *mapped_file);
 
 int aeron_msync(void *addr, size_t length);
 int aeron_delete_file(const char *path);
+const char *aeron_realpath(const char *path, char *resolved_path, size_t resolved_path_len);
+const char *aeron_tmpdir(char *path, size_t path_len);
+bool aeron_file_exists(const char* path);
 
 #if defined(AERON_COMPILER_GCC)
 #include <unistd.h>

--- a/aeron-driver/src/main/c/CMakeLists.txt
+++ b/aeron-driver/src/main/c/CMakeLists.txt
@@ -317,7 +317,8 @@ SET(DRIVER_ONLY_SOURCE
     aeron_publication_image.c
     aeron_retransmit_handler.c
     aeron_system_counters.c
-    aeron_termination_validator.c)
+    aeron_termination_validator.c
+    aeron_topology.c)
 
 SET(SOURCE
     ${C_CLIENT_SOURCE}
@@ -373,6 +374,7 @@ SET(HEADERS
     aeron_retransmit_handler.h
     aeron_system_counters.h
     aeron_termination_validator.h
+    aeron_topology.h
     aeron_driver_version.h
     aeronmd.h)
 

--- a/aeron-driver/src/main/c/CMakeLists.txt
+++ b/aeron-driver/src/main/c/CMakeLists.txt
@@ -292,6 +292,7 @@ SET(DRIVER_ONLY_SOURCE
     uri/aeron_driver_uri.c
     aeron_async_executor.c
     aeron_congestion_control.c
+    aeron_cpuset.c
     aeron_csv_table_name_resolver.c
     aeron_data_packet_dispatcher.c
     aeron_driver_version.c
@@ -346,6 +347,7 @@ SET(HEADERS
     uri/aeron_driver_uri.h
     aeron_async_executor.h
     aeron_congestion_control.h
+    aeron_cpuset.h
     aeron_csv_table_name_resolver.h
     aeron_data_packet_dispatcher.h
     aeron_driver.h

--- a/aeron-driver/src/main/c/aeron_cpuset.c
+++ b/aeron-driver/src/main/c/aeron_cpuset.c
@@ -19,7 +19,6 @@
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
 
 #include "aeron_alloc.h"
 #include "util/aeron_error.h"

--- a/aeron-driver/src/main/c/aeron_cpuset.c
+++ b/aeron-driver/src/main/c/aeron_cpuset.c
@@ -25,51 +25,22 @@
 #include "aeron_alloc.h"
 #include "util/aeron_error.h"
 
-char *aeron_cpuset_read_file(const char *filename)
+#define AERON_CGROUP_SYS_FILE_LENGTH_MAX (4096)
+
+int aeron_cpuset_read_sysfs_file(const char *filename, char *buf, size_t buf_size)
 {
-    char *file_data = NULL;
-    FILE *io_file = fopen(filename, "r");
-    if (!io_file)
+    FILE *f = fopen(filename, "r");
+    if (NULL == f)
     {
-        AERON_SET_ERR(EINVAL, "unable to open file: %s", filename);
-        return NULL;
+        AERON_SET_ERR(errno, "unable to open: %s", filename);
+        return -1;
     }
 
-    if (fseek(io_file, 0, SEEK_END) < 0)
-    {
-        AERON_SET_ERR(errno, "unable to seek to end of file: %s", filename);
-        goto error;
-    }
+    size_t read = fread(buf, 1, buf_size - 1, f);
+    fclose(f);
+    buf[read] = '\0';
 
-    const int size = ftell(io_file);
-    if (size < 0)
-    {
-        AERON_SET_ERR(errno, "unable to get file length: %s", filename);
-        goto error;
-    }
-
-    if (aeron_alloc((void **)&file_data, size + 1) < 0)
-    {
-        AERON_APPEND_ERR("unable to allocate buffer for: %s", filename);
-        goto error;
-    }
-
-    fseek(io_file, 0, SEEK_SET);
-    const size_t read = fread(file_data, 1, size, io_file);
-    if (read != (size_t)size)
-    {
-        AERON_SET_ERR(EINVAL, "unable to read from file: %s", filename);
-        goto error;
-    }
-
-    fclose(io_file);
-    file_data[size] = '\0';
-    return file_data;
-
-error:
-    fclose(io_file);
-    aeron_free(file_data);
-    return NULL;
+    return (int)read;
 }
 
 typedef enum aeron_cpuset_cgroup_parse_state_en
@@ -83,14 +54,15 @@ aeron_cpuset_cgroup_parse_state_t;
 
 static const char *aeron_cpuset_find_cgroup_path(const char *proc_cgroup_file)
 {
-    char *proc_cgroup_data = aeron_cpuset_read_file(proc_cgroup_file);
-    if (NULL == proc_cgroup_data)
+    char proc_cgroup_data[AERON_CGROUP_SYS_FILE_LENGTH_MAX];
+    const int proc_cgroup_len = aeron_cpuset_read_sysfs_file(
+        proc_cgroup_file, proc_cgroup_data, sizeof(proc_cgroup_data));
+
+    if (-1 == proc_cgroup_len)
     {
         AERON_APPEND_ERR("%s", "");
         return NULL;
     }
-
-    const int proc_cgroup_len = (int)strlen(proc_cgroup_data);
 
     aeron_cpuset_cgroup_parse_state_t state = AERON_CPUSET_CGROUP_PARSE_STATE_ID;
     const char *id = NULL;
@@ -164,7 +136,6 @@ static const char *aeron_cpuset_find_cgroup_path(const char *proc_cgroup_file)
         }
     }
 
-    aeron_free(proc_cgroup_data);
     return return_path;
 }
 
@@ -336,30 +307,26 @@ error:
 
 int aeron_cpuset_parse_cpulist_from_file(const char *cgroup_path, int **cpus, int *cpu_count)
 {
-    char *cpulist_data = aeron_cpuset_read_file(cgroup_path);
-    if (NULL == cpulist_data)
+    char cpulist_data[AERON_CGROUP_SYS_FILE_LENGTH_MAX];
+
+    if (-1 == aeron_cpuset_read_sysfs_file(cgroup_path, cpulist_data, sizeof(cpulist_data)))
     {
         AERON_APPEND_ERR("%s", "");
-        goto error;
+        return -1;
     }
 
     if (aeron_cpuset_parse_cpulist(cpulist_data, cpus, cpu_count) < 0)
     {
         AERON_APPEND_ERR("%s", "");
-        goto error;
+        return -1;
     }
 
-    aeron_free(cpulist_data);
     return 0;
-
-error:
-    aeron_free(cpulist_data);
-    return -1;
 }
 
 int aeron_cpuset_cgroup_read_v2(const char *proc_cgroup_file, const char *mount_root, int **cpus, int *cpu_count)
 {
-    const char *cgroup_path = aeron_cpuset_find_cgroup_path(proc_cgroup_file);
+    char *cgroup_path = (char *)aeron_cpuset_find_cgroup_path(proc_cgroup_file);
     if (NULL == cgroup_path)
     {
         AERON_APPEND_ERR("%s", "");
@@ -367,22 +334,45 @@ int aeron_cpuset_cgroup_read_v2(const char *proc_cgroup_file, const char *mount_
     }
 
     char absolute_cgroup_path[4096];
-    const int written = snprintf(
-        absolute_cgroup_path, sizeof(absolute_cgroup_path), "%s%s/cpuset.cpus.effective", mount_root, cgroup_path);
-
-    printf("%s\n", absolute_cgroup_path);
-
-    if (written < 0 || sizeof(absolute_cgroup_path) <= (size_t)written)
+    do
     {
-        AERON_SET_ERR(EINVAL, "%s", "cgroup path name too long");
-        goto error;
-    }
+        const int written = snprintf(
+            absolute_cgroup_path, sizeof(absolute_cgroup_path), "%s%s/cpuset.cpus.effective", mount_root, cgroup_path);
 
-    if (aeron_cpuset_parse_cpulist_from_file(absolute_cgroup_path, cpus, cpu_count) < 0)
-    {
-        AERON_APPEND_ERR("%s", "");
-        goto error;
+        if (written < 0 || sizeof(absolute_cgroup_path) <= (size_t)written)
+        {
+            AERON_SET_ERR(EINVAL, "%s", "cgroup path name too long");
+            goto error;
+        }
+
+        if (0 <= aeron_cpuset_parse_cpulist_from_file(absolute_cgroup_path, cpus, cpu_count))
+        {
+            break;
+        }
+
+        if ('\0' == *cgroup_path)
+        {
+            AERON_APPEND_ERR("unable to find '%s' in path '%s'", "cpuset.cpus.effective", mount_root);
+            return -1;
+        }
+
+        if (ENOMEM == aeron_errcode())
+        {
+            AERON_APPEND_ERR("%s", "");
+            return -1;
+        }
+
+        char *last_slash = strrchr(cgroup_path, '/');
+        if (NULL == last_slash)
+        {
+            *cgroup_path = '\0';
+        }
+        else
+        {
+            *last_slash = '\0';
+        }
     }
+    while (true);
 
     aeron_free((void *)cgroup_path);
     return 0;

--- a/aeron-driver/src/main/c/aeron_cpuset.c
+++ b/aeron-driver/src/main/c/aeron_cpuset.c
@@ -138,8 +138,6 @@ static const char *aeron_cpuset_find_cgroup_path(const char *proc_cgroup_file)
     return return_path;
 }
 
-
-
 typedef enum aeron_cpuset_cpulist_parse_state_en
 {
     AERON_CPUSET_CPULIST_PARSE_STATE_ID,
@@ -177,6 +175,26 @@ static int aeron_cpuset_validate_path_root(const char *path, char *validated_pat
     }
 
     return 0;
+}
+
+static int aeron_cpuset_uniq(int *array, const int array_count)
+{
+    if (array_count <= 1)
+    {
+        return array_count;
+    }
+
+    int write = 1;
+    for (int read = 1; read < array_count; read++)
+    {
+        if (array[read] != array[write - 1])
+        {
+            array[write] = array[read];
+            write++;
+        }
+    }
+
+    return write;
 }
 
 int aeron_cpuset_parse_cpulist(const char *cpulist_data, int **cpus, int *cpu_count)
@@ -294,22 +312,7 @@ int aeron_cpuset_parse_cpulist(const char *cpulist_data, int **cpus, int *cpu_co
     }
 
     qsort(_cpus, _cpu_count, sizeof(int), aeron_cpuset_cmp_int);
-
-    for (int i = 0; i < _cpu_count; i++)
-    {
-        for (int j = i + 1; j < _cpu_count; j++)
-        {
-            if (_cpus[i] == _cpus[j])
-            {
-                for (int k = j; k < _cpu_count - 1; k++)
-                {
-                    _cpus[k] = _cpus[k + 1];
-                }
-                _cpu_count--;
-                j--;
-            }
-        }
-    }
+    _cpu_count = aeron_cpuset_uniq(_cpus, _cpu_count);
 
     if (aeron_reallocf((void **)&_cpus, sizeof(int) * _cpu_count) < 0)
     {

--- a/aeron-driver/src/main/c/aeron_cpuset.c
+++ b/aeron-driver/src/main/c/aeron_cpuset.c
@@ -1,0 +1,393 @@
+/*
+* Copyright 2026 Adaptive Financial Consulting Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "aeron_cpuset.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <asm-generic/errno-base.h>
+
+#include "aeron_alloc.h"
+#include "util/aeron_error.h"
+
+char *aeron_cpuset_read_file(const char *filename)
+{
+    char *file_data = NULL;
+    FILE *io_file = fopen(filename, "r");
+    if (!io_file)
+    {
+        AERON_SET_ERR(EINVAL, "unable to open file: %s", filename);
+        return NULL;
+    }
+
+    if (fseek(io_file, 0, SEEK_END) < 0)
+    {
+        AERON_SET_ERR(errno, "unable to seek to end of file: %s", filename);
+        goto error;
+    }
+
+    const int size = ftell(io_file);
+    if (size < 0)
+    {
+        AERON_SET_ERR(errno, "unable to get file length: %s", filename);
+        goto error;
+    }
+
+    if (aeron_alloc((void **)&file_data, size + 1) < 0)
+    {
+        AERON_APPEND_ERR("unable to allocate buffer for: %s", filename);
+        goto error;
+    }
+
+    fseek(io_file, 0, SEEK_SET);
+    const size_t read = fread(file_data, 1, size, io_file);
+    if (read != (size_t)size)
+    {
+        AERON_SET_ERR(EINVAL, "unable to read from file: %s", filename);
+        goto error;
+    }
+
+    fclose(io_file);
+    file_data[size] = '\0';
+    return file_data;
+
+error:
+    fclose(io_file);
+    aeron_free(file_data);
+    return NULL;
+}
+
+typedef enum aeron_cpuset_cgroup_parse_state_en
+{
+    AERON_CPUSET_CGROUP_PARSE_STATE_ID,
+    AERON_CPUSET_CGROUP_PARSE_STATE_CONTROLLERS,
+    AERON_CPUSET_CGROUP_PARSE_STATE_PATH,
+    AERON_CPUSET_CGROUP_PARSE_STATE_DONE,
+}
+aeron_cpuset_cgroup_parse_state_t;
+
+static const char *aeron_cpuset_find_cgroup_path(const char *proc_cgroup_file)
+{
+    char *proc_cgroup_data = aeron_cpuset_read_file(proc_cgroup_file);
+    if (NULL == proc_cgroup_data)
+    {
+        AERON_APPEND_ERR("%s", "");
+        return NULL;
+    }
+
+    const int proc_cgroup_len = (int)strlen(proc_cgroup_data);
+
+    aeron_cpuset_cgroup_parse_state_t state = AERON_CPUSET_CGROUP_PARSE_STATE_ID;
+    const char *id = NULL;
+    const char *controllers = NULL;
+    const char *path = NULL;
+    const char *return_path = NULL;
+
+    for (int i = 0; i < proc_cgroup_len; i++)
+    {
+        const char c = proc_cgroup_data[i];
+        switch (state)
+        {
+            case AERON_CPUSET_CGROUP_PARSE_STATE_ID:
+            {
+                if (NULL == id)
+                {
+                    id = &proc_cgroup_data[i];
+                }
+
+                if (':' == c)
+                {
+                    proc_cgroup_data[i] = '\0';
+                    state = AERON_CPUSET_CGROUP_PARSE_STATE_CONTROLLERS;
+                }
+                break;
+            }
+
+            case AERON_CPUSET_CGROUP_PARSE_STATE_CONTROLLERS:
+            {
+                if (NULL == controllers)
+                {
+                    controllers = &proc_cgroup_data[i];
+                }
+
+                if (':' == c)
+                {
+                    proc_cgroup_data[i] = '\0';
+                    state = AERON_CPUSET_CGROUP_PARSE_STATE_PATH;
+                }
+
+                break;
+            }
+
+            case AERON_CPUSET_CGROUP_PARSE_STATE_PATH:
+            {
+                if (NULL == path)
+                {
+                    path = &proc_cgroup_data[i];
+                }
+
+                if ('\n' == c)
+                {
+                    proc_cgroup_data[i] = '\0';
+
+                    if (0 == strcmp("0", id) && 0 == strlen(controllers))
+                    {
+                        return_path = strdup(path);
+                    }
+
+                    state = AERON_CPUSET_CGROUP_PARSE_STATE_DONE;
+                }
+
+                break;
+            }
+
+            case AERON_CPUSET_CGROUP_PARSE_STATE_DONE:
+            default:
+            {
+                break;
+            }
+        }
+    }
+
+    aeron_free(proc_cgroup_data);
+    return return_path;
+}
+
+
+
+typedef enum aeron_cpuset_cpulist_parse_state_en
+{
+    AERON_CPUSET_CPULIST_PARSE_STATE_ID,
+    AERON_CPUSET_CPULIST_PARSE_STATE_CONTROLLERS,
+    AERON_CPUSET_CPULIST_PARSE_STATE_PATH,
+    AERON_CPUSET_CPULIST_PARSE_STATE_DONE,
+}
+aeron_cpuset_cpulist_parse_state_t;
+
+static int aeron_cpuset_cmp_int(const void *a, const void *b)
+{
+    const int _a = *(int *)a;
+    const int _b = *(int *)b;
+
+    return _a - _b;
+}
+
+int aeron_cpuset_parse_cpulist(const char *cpulist_data, int **cpus, int *cpu_count)
+{
+    int *_cpus;
+    int _cpu_count = 0;
+    int capacity = 1024;
+
+    if (aeron_alloc((void **)&_cpus, sizeof(int) * capacity) < 0)
+    {
+        AERON_APPEND_ERR("%s", "");
+        return -1;
+    }
+
+    const char *curr_ptr = cpulist_data;
+    char *next_ptr = NULL;
+    char last_char = '\0';
+
+    do
+    {
+        long cpu = strtol(curr_ptr, &next_ptr, 10);
+
+        if (curr_ptr == next_ptr)
+        {
+            if ('\0' != *next_ptr)
+            {
+                last_char = *next_ptr;
+
+                if (',' == last_char)
+                {
+                    if (0 == _cpu_count)
+                    {
+                        AERON_SET_ERR(EINVAL, "%s", "leading comma");
+                        goto error;
+                    }
+                }
+                else if ('\n' == last_char)
+                {
+                    // Ignore
+                }
+                else if (last_char < '0' || '9' < last_char)
+                {
+                    AERON_SET_ERR(EINVAL, "%s: '%s'", "non-numeric CPU", cpulist_data);
+                    goto error;
+                }
+
+                curr_ptr++;
+            }
+        }
+        else
+        {
+            if (0 <= cpu)
+            {
+                if (capacity == _cpu_count)
+                {
+                    capacity *= 2;
+                    if (aeron_reallocf((void **)&_cpus, sizeof(int) * capacity) < 0)
+                    {
+                        AERON_APPEND_ERR("%s", "");
+                        return -1;
+                    }
+                }
+
+                _cpus[_cpu_count] = (int)cpu;
+                _cpu_count++;
+                last_char = '\0';
+            }
+            else
+            {
+                if (0 == _cpu_count || '\0' != last_char)
+                {
+                    AERON_SET_ERR(EINVAL, "%s", "negative CPU");
+                    goto error;
+                }
+
+                if (-cpu < _cpus[_cpu_count - 1])
+                {
+                    AERON_SET_ERR(EINVAL, "%s", "range end less than start");
+                    goto error;
+                }
+
+                for (int i = _cpus[_cpu_count - 1] + 1; i <= -cpu; i++)
+                {
+                    if (capacity == _cpu_count)
+                    {
+                        capacity *= 2;
+                        if (aeron_reallocf((void **)&_cpus, sizeof(int) * capacity) < 0)
+                        {
+                            AERON_APPEND_ERR("%s", "");
+                            return -1;
+                        }
+                    }
+
+                    _cpus[_cpu_count] = i;
+                    _cpu_count++;
+                    last_char = '\0';
+                }
+            }
+
+            curr_ptr = next_ptr;
+        }
+    }
+    while ('\0' != *next_ptr);
+
+    if (0 == _cpu_count)
+    {
+        AERON_SET_ERR(EINVAL, "%s", "empty string");
+        goto error;
+    }
+
+    if (',' == last_char)
+    {
+        AERON_SET_ERR(EINVAL, "%s", "trailing comma");
+        goto error;
+    }
+
+    qsort(_cpus, _cpu_count, sizeof(int), aeron_cpuset_cmp_int);
+
+    for (int i = 0; i < _cpu_count; i++)
+    {
+        for (int j = i + 1; j < _cpu_count; j++)
+        {
+            if (_cpus[i] == _cpus[j])
+            {
+                for (int k = j; k < _cpu_count - 1; k++)
+                {
+                    _cpus[k] = _cpus[k + 1];
+                }
+                _cpu_count--;
+                j--;
+            }
+        }
+    }
+
+    if (aeron_reallocf((void **)&_cpus, sizeof(int) * _cpu_count) < 0)
+    {
+        AERON_APPEND_ERR("%s", "");
+        return -1;
+    }
+
+    *cpus = _cpus;
+    *cpu_count = _cpu_count;
+    return 0;
+
+error:
+    aeron_free(_cpus);
+    return -1;
+}
+
+int aeron_cpuset_parse_cpulist_from_file(const char *cgroup_path, int **cpus, int *cpu_count)
+{
+    char *cpulist_data = aeron_cpuset_read_file(cgroup_path);
+    if (NULL == cpulist_data)
+    {
+        AERON_APPEND_ERR("%s", "");
+        goto error;
+    }
+
+    if (aeron_cpuset_parse_cpulist(cpulist_data, cpus, cpu_count) < 0)
+    {
+        AERON_APPEND_ERR("%s", "");
+        goto error;
+    }
+
+    aeron_free(cpulist_data);
+    return 0;
+
+error:
+    aeron_free(cpulist_data);
+    return -1;
+}
+
+int aeron_cpuset_cgroup_read_v2(const char *proc_cgroup_file, const char *mount_root, int **cpus, int *cpu_count)
+{
+    const char *cgroup_path = aeron_cpuset_find_cgroup_path(proc_cgroup_file);
+    if (NULL == cgroup_path)
+    {
+        AERON_APPEND_ERR("%s", "");
+        return -1;
+    }
+
+    char absolute_cgroup_path[4096];
+    const int written = snprintf(
+        absolute_cgroup_path, sizeof(absolute_cgroup_path), "%s%s/cpuset.cpus.effective", mount_root, cgroup_path);
+
+    printf("%s\n", absolute_cgroup_path);
+
+    if (written < 0 || sizeof(absolute_cgroup_path) <= (size_t)written)
+    {
+        AERON_SET_ERR(EINVAL, "%s", "cgroup path name too long");
+        goto error;
+    }
+
+    if (aeron_cpuset_parse_cpulist_from_file(absolute_cgroup_path, cpus, cpu_count) < 0)
+    {
+        AERON_APPEND_ERR("%s", "");
+        goto error;
+    }
+
+    aeron_free((void *)cgroup_path);
+    return 0;
+
+error:
+    aeron_free((void *)cgroup_path);
+    return -1;
+}

--- a/aeron-driver/src/main/c/aeron_cpuset.c
+++ b/aeron-driver/src/main/c/aeron_cpuset.c
@@ -157,12 +157,11 @@ static int aeron_cpuset_cmp_int(const void *a, const void *b)
     return _a - _b;
 }
 
-static int aeron_cpuset_validate_path_root(const char *path)
+static int aeron_cpuset_validate_path_root(const char *path, char *validated_path, size_t validated_path_len)
 {
-    char resolved_path[AERON_MAX_FILE_PATH_LENGTH];
     char tmp_path[AERON_MAX_FILE_PATH_LENGTH];
 
-    const char *realpath = aeron_realpath(path, resolved_path, sizeof(resolved_path));
+    const char *realpath = aeron_realpath(path, validated_path, validated_path_len);
     if (NULL == realpath)
     {
         AERON_SET_ERR(errno, "unable to resolve path for %s", path);
@@ -369,13 +368,14 @@ int aeron_cpuset_cgroup_read_v2(const char *proc_cgroup_file, const char *mount_
 
         if (aeron_file_exists(absolute_cgroup_path))
         {
-            if (aeron_cpuset_validate_path_root(absolute_cgroup_path) < 0)
+            char validated_path[AERON_MAX_FILE_PATH_LENGTH];
+            if (aeron_cpuset_validate_path_root(absolute_cgroup_path, validated_path, sizeof(validated_path)) < 0)
             {
                 AERON_APPEND_ERR("%s", "");
                 goto error;
             }
 
-            if (aeron_cpuset_parse_cpulist_from_file(absolute_cgroup_path, cpus, cpu_count) < 0)
+            if (aeron_cpuset_parse_cpulist_from_file(validated_path, cpus, cpu_count) < 0)
             {
                 AERON_APPEND_ERR("%s", "");
                 goto error;

--- a/aeron-driver/src/main/c/aeron_cpuset.c
+++ b/aeron-driver/src/main/c/aeron_cpuset.c
@@ -353,13 +353,13 @@ int aeron_cpuset_cgroup_read_v2(const char *proc_cgroup_file, const char *mount_
         if ('\0' == *cgroup_path)
         {
             AERON_APPEND_ERR("unable to find '%s' in path '%s'", "cpuset.cpus.effective", mount_root);
-            return -1;
+            goto error;
         }
 
         if (ENOMEM == aeron_errcode())
         {
             AERON_APPEND_ERR("%s", "");
-            return -1;
+            goto error;
         }
 
         char *last_slash = strrchr(cgroup_path, '/');
@@ -374,10 +374,10 @@ int aeron_cpuset_cgroup_read_v2(const char *proc_cgroup_file, const char *mount_
     }
     while (true);
 
-    aeron_free((void *)cgroup_path);
+    aeron_free(cgroup_path);
     return 0;
 
 error:
-    aeron_free((void *)cgroup_path);
+    aeron_free(cgroup_path);
     return -1;
 }

--- a/aeron-driver/src/main/c/aeron_cpuset.c
+++ b/aeron-driver/src/main/c/aeron_cpuset.c
@@ -22,6 +22,7 @@
 
 #include "aeron_alloc.h"
 #include "util/aeron_error.h"
+#include "util/aeron_fileutil.h"
 
 #define AERON_CGROUP_SYS_FILE_LENGTH_MAX (4096)
 
@@ -154,6 +155,29 @@ static int aeron_cpuset_cmp_int(const void *a, const void *b)
     const int _b = *(int *)b;
 
     return _a - _b;
+}
+
+static int aeron_cpuset_validate_path_root(const char *path)
+{
+    char resolved_path[AERON_MAX_FILE_PATH_LENGTH];
+    char tmp_path[AERON_MAX_FILE_PATH_LENGTH];
+
+    const char *realpath = aeron_realpath(path, resolved_path, sizeof(resolved_path));
+    if (NULL == realpath)
+    {
+        AERON_SET_ERR(errno, "unable to resolve path for %s", path);
+        return -1;
+    }
+
+    const char *tmpdir = aeron_tmpdir(tmp_path, sizeof(tmp_path));
+    if (0 != strncmp("/sys/", realpath, strlen("/sys/")) &&
+        (NULL == tmpdir || 0 != strncmp(tmpdir, realpath, strlen(tmpdir))))
+    {
+        AERON_SET_ERR(EINVAL, "file %s is from an invalid location", path);
+        return -1;
+    }
+
+    return 0;
 }
 
 int aeron_cpuset_parse_cpulist(const char *cpulist_data, int **cpus, int *cpu_count)
@@ -331,7 +355,7 @@ int aeron_cpuset_cgroup_read_v2(const char *proc_cgroup_file, const char *mount_
         return -1;
     }
 
-    char absolute_cgroup_path[4096];
+    char absolute_cgroup_path[AERON_MAX_FILE_PATH_LENGTH];
     do
     {
         const int written = snprintf(
@@ -343,8 +367,20 @@ int aeron_cpuset_cgroup_read_v2(const char *proc_cgroup_file, const char *mount_
             goto error;
         }
 
-        if (0 <= aeron_cpuset_parse_cpulist_from_file(absolute_cgroup_path, cpus, cpu_count))
+        if (aeron_file_exists(absolute_cgroup_path))
         {
+            if (aeron_cpuset_validate_path_root(absolute_cgroup_path) < 0)
+            {
+                AERON_APPEND_ERR("%s", "");
+                goto error;
+            }
+
+            if (aeron_cpuset_parse_cpulist_from_file(absolute_cgroup_path, cpus, cpu_count) < 0)
+            {
+                AERON_APPEND_ERR("%s", "");
+                goto error;
+            }
+
             break;
         }
 

--- a/aeron-driver/src/main/c/aeron_cpuset.c
+++ b/aeron-driver/src/main/c/aeron_cpuset.c
@@ -20,7 +20,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include <asm-generic/errno-base.h>
 
 #include "aeron_alloc.h"
 #include "util/aeron_error.h"

--- a/aeron-driver/src/main/c/aeron_cpuset.h
+++ b/aeron-driver/src/main/c/aeron_cpuset.h
@@ -18,6 +18,10 @@
 #ifndef AERON_CPUSET_H
 #define AERON_CPUSET_H
 
+#define AERON_CPUSET_CGROUP_MOUNT_V2 "/sys/fs/cgroup"
+#define AERON_CPUSET_CGROUP_MOUNT_V1 "/sys/fs/cgroup/cpuset"
+#define AERON_CPUSET_PROC_SELF_CGROUP "/proc/self/cgroup"
+
 /**
  * Parse a list of cpus, e.g. '1,3,4,5-19'.
  *

--- a/aeron-driver/src/main/c/aeron_cpuset.h
+++ b/aeron-driver/src/main/c/aeron_cpuset.h
@@ -1,0 +1,33 @@
+/*
+* Copyright 2026 Adaptive Financial Consulting Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#ifndef AERON_CPUSET_H
+#define AERON_CPUSET_H
+
+/**
+ * Parse a list of cpus, e.g. '1,3,4,5-19'.
+ *
+ * @param cpulist_data NUL terminated string that represents a cpulist.
+ * @param cpus array of cpus, allocated within this function
+ * @param cpu_count count of number of cpus
+ * @return 0 on success, -1 on failure
+ */
+int aeron_cpuset_parse_cpulist(const char *cpulist_data, int **cpus, int *cpu_count);
+
+int aeron_cpuset_cgroup_read_v2(const char *proc_cgroup_file, const char *mount_root, int **cpus, int *cpu_count);
+
+#endif //AERON_CPUSET_H

--- a/aeron-driver/src/main/c/aeron_driver.c
+++ b/aeron-driver/src/main/c/aeron_driver.c
@@ -1071,7 +1071,7 @@ int aeron_driver_apply_cpuset_affinity(aeron_driver_context_t *context)
     }
 
 #ifndef __linux__
-    AERON_SET_ERR("%s", "Cpuset affinity is only supported on Linux");
+    AERON_SET_ERR(EPERM, "%s", "Cpuset affinity is only supported on Linux");
     return -1;
 #endif
 

--- a/aeron-driver/src/main/c/aeron_driver.c
+++ b/aeron-driver/src/main/c/aeron_driver.c
@@ -44,6 +44,8 @@
 #include "aeron_driver.h"
 #include "aeron_socket.h"
 #include "util/aeron_dlopen.h"
+#include "aeron_cpuset.h"
+#include "aeron_topology.h"
 
 void aeron_log_func_stderr(const char *str)
 {
@@ -571,6 +573,8 @@ void aeron_driver_context_print_configuration(aeron_driver_context_t *context)
     fprintf(fpout, "\n    conductor_cpu_affinity_no=%" PRId32, context->conductor_cpu_affinity_no);
     fprintf(fpout, "\n    receiver_cpu_affinity_no=%" PRId32, context->receiver_cpu_affinity_no);
     fprintf(fpout, "\n    sender_cpu_affinity_no=%" PRId32, context->sender_cpu_affinity_no);
+    fprintf(fpout, "\n    cpuset_affinity=%" PRId32, context->cpuset_affinity);
+    fprintf(fpout, "\n    cpuset_warnings_as_errors=%" PRId32, context->cpuset_warnings_as_errors);
 
     fprintf(fpout, "\n    epoch_clock=%s",
         aeron_dlinfo_func((aeron_fptr_t)context->epoch_clock, buffer, sizeof(buffer)));
@@ -1056,6 +1060,65 @@ error:
         aeron_free(_driver);
     }
 
+    return -1;
+}
+
+int aeron_driver_apply_cpuset_affinity(aeron_driver_context_t *context)
+{
+    if (!context->cpuset_affinity)
+    {
+        return 0;
+    }
+
+#ifndef __linux__
+    AERON_SET_ERR("%s", "Cpuset affinity is only supported on Linux");
+    return -1;
+#endif
+
+    int *cpus = NULL;
+    int cpu_count = 0;
+
+    if (aeron_cpuset_cgroup_read_v2(AERON_CPUSET_PROC_SELF_CGROUP, AERON_CPUSET_CGROUP_MOUNT_V2, &cpus, &cpu_count) < 0)
+    {
+        AERON_APPEND_ERR("%s", "cpuset affinity enabled and failed to properly read cgroups and cpuset information");
+        goto error;
+    }
+
+    int alignment_warnings_count;
+    if ((alignment_warnings_count = aeron_topology_check_alignment(cpus, cpu_count, stdout)) < 0)
+    {
+        AERON_APPEND_ERR("%s", "failed to check cpu alignment");
+        goto error;
+    }
+
+    int cluster_locality_warnings_count;
+    if ((cluster_locality_warnings_count = aeron_topology_check_cluster_locality(cpus, cpu_count, stdout)) < 0)
+    {
+        AERON_APPEND_ERR("%s", "failed to check cpu cluster locality");
+        goto error;
+    }
+
+    int l3_locality_warnings_count;
+    if ((l3_locality_warnings_count = aeron_topology_check_l3_locality(cpus, cpu_count, stdout)) < 0)
+    {
+        AERON_APPEND_ERR("%s", "failed to check cpu l3 cache locality");
+        goto error;
+    }
+
+    const int total_warnings_count =
+        alignment_warnings_count + cluster_locality_warnings_count + l3_locality_warnings_count;
+
+    if (context->cpuset_warnings_as_errors && 0 < total_warnings_count)
+    {
+        AERON_SET_ERR(EINVAL, "cpuset warnings as errors, %d warnings", total_warnings_count);
+        goto error;
+    }
+
+    aeron_free(cpus);
+    return 0;
+
+    error:
+        aeron_free(cpus);
     return -1;
 }
 

--- a/aeron-driver/src/main/c/aeron_driver.c
+++ b/aeron-driver/src/main/c/aeron_driver.c
@@ -1085,21 +1085,24 @@ int aeron_driver_apply_cpuset_affinity(aeron_driver_context_t *context)
     }
 
     int alignment_warnings_count;
-    if ((alignment_warnings_count = aeron_topology_check_alignment(AERON_TOPOLOGY_SYS_CPU_PATH, cpus, cpu_count,stdout)) < 0)
+    if ((alignment_warnings_count = aeron_topology_check_alignment(
+        AERON_TOPOLOGY_SYS_CPU_PATH, cpus, cpu_count, stderr)) < 0)
     {
         AERON_APPEND_ERR("%s", "failed to check cpu alignment");
         goto error;
     }
 
     int cluster_locality_warnings_count;
-    if ((cluster_locality_warnings_count = aeron_topology_check_cluster_locality(AERON_TOPOLOGY_SYS_CPU_PATH, cpus, cpu_count, stdout)) < 0)
+    if ((cluster_locality_warnings_count = aeron_topology_check_cluster_locality(
+        AERON_TOPOLOGY_SYS_CPU_PATH, cpus, cpu_count, stderr)) < 0)
     {
         AERON_APPEND_ERR("%s", "failed to check cpu cluster locality");
         goto error;
     }
 
     int l3_locality_warnings_count;
-    if ((l3_locality_warnings_count = aeron_topology_check_l3_locality(AERON_TOPOLOGY_SYS_CPU_PATH, cpus, cpu_count,stdout)) < 0)
+    if ((l3_locality_warnings_count = aeron_topology_check_l3_locality(
+        AERON_TOPOLOGY_SYS_CPU_PATH, cpus, cpu_count, stderr)) < 0)
     {
         AERON_APPEND_ERR("%s", "failed to check cpu l3 cache locality");
         goto error;
@@ -1123,8 +1126,8 @@ int aeron_driver_apply_cpuset_affinity(aeron_driver_context_t *context)
     aeron_free(cpus);
     return 0;
 
-    error:
-        aeron_free(cpus);
+error:
+    aeron_free(cpus);
     return -1;
 }
 

--- a/aeron-driver/src/main/c/aeron_driver.c
+++ b/aeron-driver/src/main/c/aeron_driver.c
@@ -1114,6 +1114,12 @@ int aeron_driver_apply_cpuset_affinity(aeron_driver_context_t *context)
         goto error;
     }
 
+    if (aeron_driver_context_apply_cpuset_affinity(context, cpus, cpu_count) < 0)
+    {
+        AERON_APPEND_ERR("%s", "failed to apply cpuset affinity");
+        goto error;
+    }
+
     aeron_free(cpus);
     return 0;
 

--- a/aeron-driver/src/main/c/aeron_driver.c
+++ b/aeron-driver/src/main/c/aeron_driver.c
@@ -1085,21 +1085,21 @@ int aeron_driver_apply_cpuset_affinity(aeron_driver_context_t *context)
     }
 
     int alignment_warnings_count;
-    if ((alignment_warnings_count = aeron_topology_check_alignment(cpus, cpu_count, stdout)) < 0)
+    if ((alignment_warnings_count = aeron_topology_check_alignment(AERON_TOPOLOGY_SYS_CPU_PATH, cpus, cpu_count,stdout)) < 0)
     {
         AERON_APPEND_ERR("%s", "failed to check cpu alignment");
         goto error;
     }
 
     int cluster_locality_warnings_count;
-    if ((cluster_locality_warnings_count = aeron_topology_check_cluster_locality(cpus, cpu_count, stdout)) < 0)
+    if ((cluster_locality_warnings_count = aeron_topology_check_cluster_locality(AERON_TOPOLOGY_SYS_CPU_PATH, cpus, cpu_count, stdout)) < 0)
     {
         AERON_APPEND_ERR("%s", "failed to check cpu cluster locality");
         goto error;
     }
 
     int l3_locality_warnings_count;
-    if ((l3_locality_warnings_count = aeron_topology_check_l3_locality(cpus, cpu_count, stdout)) < 0)
+    if ((l3_locality_warnings_count = aeron_topology_check_l3_locality(AERON_TOPOLOGY_SYS_CPU_PATH, cpus, cpu_count,stdout)) < 0)
     {
         AERON_APPEND_ERR("%s", "failed to check cpu l3 cache locality");
         goto error;

--- a/aeron-driver/src/main/c/aeron_driver.h
+++ b/aeron-driver/src/main/c/aeron_driver.h
@@ -42,4 +42,6 @@ aeron_driver_t;
 bool aeron_is_driver_active_with_cnc(
     aeron_mapped_file_t *cnc_map, int64_t timeout_ms, int64_t now_ms, aeron_log_func_t log_func);
 
+int aeron_driver_apply_cpuset_affinity(aeron_driver_context_t *context);
+
 #endif //AERON_DRIVER_H

--- a/aeron-driver/src/main/c/aeron_driver_context.c
+++ b/aeron-driver/src/main/c/aeron_driver_context.c
@@ -219,7 +219,8 @@ static void aeron_driver_untethered_subscription_state_change_null(
 #define AERON_DRIVER_RESOURCE_FREE_LIMIT_DEFAULT UINT32_C(10)
 #define AERON_DRIVER_ASYNC_EXECUTOR_ENABLED_DEFAULT (true)
 #define AERON_CPU_AFFINITY_DEFAULT (-1)
-#define AERON_DRIVER_CPUSET_AFFINITY_DEFAULT (true)
+#define AERON_DRIVER_CPUSET_AFFINITY_DEFAULT (false)
+#define AERON_DRIVER_CPUSET_WARNINGS_AS_ERRORS_DEFAULT (false)
 #define AERON_DRIVER_CONNECT_DEFAULT (true)
 #define AERON_ENABLE_EXPERIMENTAL_FEATURES_DEFAULT (false)
 #define AERON_DRIVER_STREAM_SESSION_LIMIT_DEFAULT (INT32_MAX)
@@ -489,6 +490,7 @@ int aeron_driver_context_init(aeron_driver_context_t **context)
     _context->sender_cpu_affinity_no = AERON_CPU_AFFINITY_DEFAULT;
     _context->receiver_cpu_affinity_no = AERON_CPU_AFFINITY_DEFAULT;
     _context->cpuset_affinity = AERON_DRIVER_CPUSET_AFFINITY_DEFAULT;
+    _context->cpuset_warnings_as_errors = AERON_DRIVER_CPUSET_WARNINGS_AS_ERRORS_DEFAULT;
     _context->enable_experimental_features = AERON_ENABLE_EXPERIMENTAL_FEATURES_DEFAULT;
     _context->stream_session_limit = AERON_DRIVER_STREAM_SESSION_LIMIT_DEFAULT;
 
@@ -750,7 +752,10 @@ int aeron_driver_context_init(aeron_driver_context_t **context)
         255);
 
     _context->cpuset_affinity = aeron_parse_bool(
-        AERON_DRIVER_CPUSET_AFFINITY_ENV_VAR, AERON_DRIVER_CPUSET_AFFINITY_DEFAULT);
+        getenv(AERON_DRIVER_CPUSET_AFFINITY_ENV_VAR), AERON_DRIVER_CPUSET_AFFINITY_DEFAULT);
+
+    _context->cpuset_warnings_as_errors = aeron_parse_bool(
+        getenv(AERON_DRIVER_CPUSET_WARNINGS_AS_ERRORS_ENV_VAR), AERON_DRIVER_CPUSET_WARNINGS_AS_ERRORS_DEFAULT);
 
     _context->send_to_sm_poll_ratio = (uint8_t)aeron_config_parse_uint64(
         AERON_SEND_TO_STATUS_POLL_RATIO_ENV_VAR,
@@ -3478,4 +3483,20 @@ int aeron_driver_context_set_cpuset_affinity(aeron_driver_context_t *context, bo
 bool aeron_driver_context_get_cpuset_affinity(aeron_driver_context_t *context)
 {
     return NULL != context ? context->cpuset_affinity : AERON_DRIVER_CPUSET_AFFINITY_DEFAULT;
+}
+
+int aeron_driver_context_set_cpuset_warnings_as_errors(aeron_driver_context_t *context, bool value)
+{
+    if (NULL == context)
+    {
+        return -1;
+    }
+
+    context->cpuset_warnings_as_errors = value;
+    return 0;
+}
+
+bool aeron_driver_context_get_cpuset_warnings_as_errors(aeron_driver_context_t *context)
+{
+    return NULL != context ? context->cpuset_warnings_as_errors : AERON_DRIVER_CPUSET_WARNINGS_AS_ERRORS_DEFAULT;
 }

--- a/aeron-driver/src/main/c/aeron_driver_context.c
+++ b/aeron-driver/src/main/c/aeron_driver_context.c
@@ -3500,3 +3500,50 @@ bool aeron_driver_context_get_cpuset_warnings_as_errors(aeron_driver_context_t *
 {
     return NULL != context ? context->cpuset_warnings_as_errors : AERON_DRIVER_CPUSET_WARNINGS_AS_ERRORS_DEFAULT;
 }
+
+int aeron_driver_context_apply_cpuset_affinity(aeron_driver_context_t *context, const int *cpus, int cpu_count)
+{
+    const int32_t conductor_affinity = aeron_driver_context_get_conductor_cpu_affinity(context);
+    if (cpu_count <= conductor_affinity)
+    {
+        AERON_SET_ERR(
+            EINVAL, "conductor affinity %" PRId32 " must be less than cpuset count %d", conductor_affinity, cpu_count);
+        return -1;
+    }
+
+    if (-1 < conductor_affinity)
+    {
+        const int32_t cpuset_conductor_affinity = cpus[(int)conductor_affinity];
+        aeron_driver_context_set_conductor_cpu_affinity(context, cpuset_conductor_affinity);
+    }
+
+    const int32_t sender_affinity = aeron_driver_context_get_sender_cpu_affinity(context);
+    if (cpu_count <= sender_affinity)
+    {
+        AERON_SET_ERR(
+            EINVAL, "sender affinity %" PRId32 " must be less than cpuset count %d", sender_affinity, cpu_count);
+        return -1;
+    }
+
+    if (-1 < sender_affinity)
+    {
+        const int32_t cpuset_sender_affinity = cpus[(int)sender_affinity];
+        aeron_driver_context_set_sender_cpu_affinity(context, cpuset_sender_affinity);
+    }
+
+    const int32_t receiver_affinity = aeron_driver_context_get_receiver_cpu_affinity(context);
+    if (cpu_count <= receiver_affinity)
+    {
+        AERON_SET_ERR(
+            EINVAL, "receiver affinity %" PRId32 " must be less than cpuset count %d", receiver_affinity, cpu_count);
+        return -1;
+    }
+
+    if (-1 < receiver_affinity)
+    {
+        const int32_t cpuset_receiver_affinity = cpus[(int)receiver_affinity];
+        aeron_driver_context_set_receiver_cpu_affinity(context, cpuset_receiver_affinity);
+    }
+
+    return 0;
+}

--- a/aeron-driver/src/main/c/aeron_driver_context.c
+++ b/aeron-driver/src/main/c/aeron_driver_context.c
@@ -219,6 +219,7 @@ static void aeron_driver_untethered_subscription_state_change_null(
 #define AERON_DRIVER_RESOURCE_FREE_LIMIT_DEFAULT UINT32_C(10)
 #define AERON_DRIVER_ASYNC_EXECUTOR_ENABLED_DEFAULT (true)
 #define AERON_CPU_AFFINITY_DEFAULT (-1)
+#define AERON_DRIVER_CPUSET_AFFINITY_DEFAULT (true)
 #define AERON_DRIVER_CONNECT_DEFAULT (true)
 #define AERON_ENABLE_EXPERIMENTAL_FEATURES_DEFAULT (false)
 #define AERON_DRIVER_STREAM_SESSION_LIMIT_DEFAULT (INT32_MAX)
@@ -487,6 +488,7 @@ int aeron_driver_context_init(aeron_driver_context_t **context)
     _context->conductor_cpu_affinity_no = AERON_CPU_AFFINITY_DEFAULT;
     _context->sender_cpu_affinity_no = AERON_CPU_AFFINITY_DEFAULT;
     _context->receiver_cpu_affinity_no = AERON_CPU_AFFINITY_DEFAULT;
+    _context->cpuset_affinity = AERON_DRIVER_CPUSET_AFFINITY_DEFAULT;
     _context->enable_experimental_features = AERON_ENABLE_EXPERIMENTAL_FEATURES_DEFAULT;
     _context->stream_session_limit = AERON_DRIVER_STREAM_SESSION_LIMIT_DEFAULT;
 
@@ -746,6 +748,9 @@ int aeron_driver_context_init(aeron_driver_context_t **context)
         _context->sender_cpu_affinity_no,
         -1,
         255);
+
+    _context->cpuset_affinity = aeron_parse_bool(
+        AERON_DRIVER_CPUSET_AFFINITY_ENV_VAR, AERON_DRIVER_CPUSET_AFFINITY_DEFAULT);
 
     _context->send_to_sm_poll_ratio = (uint8_t)aeron_config_parse_uint64(
         AERON_SEND_TO_STATUS_POLL_RATIO_ENV_VAR,
@@ -3456,5 +3461,21 @@ int aeron_driver_context_set_receiver_cpu_affinity(aeron_driver_context_t *conte
 
 int32_t aeron_driver_context_get_receiver_cpu_affinity(aeron_driver_context_t *context)
 {
-    return NULL != context ? context->receiver_cpu_affinity_no :AERON_CPU_AFFINITY_DEFAULT;
+    return NULL != context ? context->receiver_cpu_affinity_no : AERON_CPU_AFFINITY_DEFAULT;
+}
+
+int aeron_driver_context_set_cpuset_affinity(aeron_driver_context_t *context, bool value)
+{
+    if (NULL == context)
+    {
+        return -1;
+    }
+
+    context->cpuset_affinity = value;
+    return 0;
+}
+
+bool aeron_driver_context_get_cpuset_affinity(aeron_driver_context_t *context)
+{
+    return NULL != context ? context->cpuset_affinity : AERON_DRIVER_CPUSET_AFFINITY_DEFAULT;
 }

--- a/aeron-driver/src/main/c/aeron_driver_context.h
+++ b/aeron-driver/src/main/c/aeron_driver_context.h
@@ -213,6 +213,7 @@ typedef struct aeron_driver_context_stct
     int32_t receiver_cpu_affinity_no;                       /* aeron.receiver.cpu.affinity = -1 */
     int32_t sender_cpu_affinity_no;                         /* aeron.sender.cpu.affinity = -1 */
     int32_t stream_session_limit;                           /* aeron.driver.stream.session.limit = INT32_MAX */
+    bool cpuset_affinity;                                   /* aeron.driver.cpuset.affinity = false */
     bool enable_experimental_features;                      /* aeron.enable.experimental.features = false */
 
     struct                                                  /* aeron.receiver.receiver.tag = <unset> */

--- a/aeron-driver/src/main/c/aeron_driver_context.h
+++ b/aeron-driver/src/main/c/aeron_driver_context.h
@@ -427,6 +427,8 @@ int aeron_driver_context_set_receive_channel_loss_supplier(
     aeron_receive_channel_loss_supplier_func_t func,
     void *clientd);
 
+int aeron_driver_context_apply_cpuset_affinity(aeron_driver_context_t *context, const int *cpus, int cpu_count);
+
 inline void aeron_cnc_version_signal_cnc_ready(aeron_cnc_metadata_t *metadata, int32_t cnc_version)
 {
     AERON_SET_RELEASE(metadata->cnc_version, cnc_version);

--- a/aeron-driver/src/main/c/aeron_driver_context.h
+++ b/aeron-driver/src/main/c/aeron_driver_context.h
@@ -214,6 +214,7 @@ typedef struct aeron_driver_context_stct
     int32_t sender_cpu_affinity_no;                         /* aeron.sender.cpu.affinity = -1 */
     int32_t stream_session_limit;                           /* aeron.driver.stream.session.limit = INT32_MAX */
     bool cpuset_affinity;                                   /* aeron.driver.cpuset.affinity = false */
+    bool cpuset_warnings_as_errors;                         /* aeron.driver.cpuset.warnings_as_errors = false */
     bool enable_experimental_features;                      /* aeron.enable.experimental.features = false */
 
     struct                                                  /* aeron.receiver.receiver.tag = <unset> */

--- a/aeron-driver/src/main/c/aeron_topology.c
+++ b/aeron-driver/src/main/c/aeron_topology.c
@@ -493,6 +493,8 @@ int aeron_topology_check_alignment(const int *cpus, const int cpu_count, FILE *o
         }
     }
 
+    aeron_topology_core_groups_free(groups, group_count);
+
     return result;
 }
 
@@ -534,6 +536,7 @@ int aeron_topology_check_l3_locality(const int *cpus, const int cpu_count, FILE*
         aeron_err_clear();
     }
 
+    aeron_free(peers);
     return 0;
 }
 

--- a/aeron-driver/src/main/c/aeron_topology.c
+++ b/aeron-driver/src/main/c/aeron_topology.c
@@ -1,0 +1,674 @@
+/*
+* Copyright 2026 Adaptive Financial Consulting Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "aeron_topology.h"
+#include "aeron_cpuset.h"
+#include "aeron_alloc.h"
+#include "util/aeron_error.h"
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define AERON_TOPOLOGY_MAX_CPU_ID 8192
+#define AERON_TOPOLOGY_FILE_BUF_SIZE 4096
+
+const char *aeron_topology_sys_cpu_path = AERON_TOPOLOGY_SYS_CPU_PATH;
+
+typedef struct aeron_topology_core_group_st
+{
+    int *present;
+    int present_count;
+    int *missing;
+    int missing_count;
+}
+aeron_topology_core_group_t;
+
+static int cmp_int(const void *a, const void *b)
+{
+    return *(const int *)a - *(const int *)b;
+}
+
+static int cmp_core_by_prime(const void *a, const void *b)
+{
+    const aeron_topology_core_t *ca = (const aeron_topology_core_t *)a;
+    const aeron_topology_core_t *cb = (const aeron_topology_core_t *)b;
+    if (0 == ca->cpu_count)
+    {
+        return 1;
+    }
+    if (0 == cb->cpu_count)
+    {
+        return -1;
+    }
+    return ca->cpus[0] - cb->cpus[0];
+}
+
+static int read_sysfs_cpu_file(int cpu, const char *suffix, char *buf, size_t buf_size)
+{
+    char path[4096];
+    int n = snprintf(path, sizeof(path), "%s/cpu%d/%s", aeron_topology_sys_cpu_path, cpu, suffix);
+    if (n < 0 || (size_t)n >= sizeof(path))
+    {
+        AERON_SET_ERR(EINVAL, "path too long for CPU %d", cpu);
+        return -1;
+    }
+
+    FILE *f = fopen(path, "r");
+    if (NULL == f)
+    {
+        AERON_SET_ERR(errno, "unable to open: %s", path);
+        return -1;
+    }
+
+    size_t read = fread(buf, 1, buf_size - 1, f);
+    fclose(f);
+    buf[read] = '\0';
+    return (int)read;
+}
+
+static int read_siblings(int cpu, int **siblings, int *sibling_count)
+{
+    char buf[AERON_TOPOLOGY_FILE_BUF_SIZE];
+    if (read_sysfs_cpu_file(cpu, "topology/thread_siblings_list", buf, sizeof(buf)) < 0)
+    {
+        AERON_APPEND_ERR("reading topology for CPU %d", cpu);
+        return -1;
+    }
+    if (aeron_cpuset_parse_cpulist(buf, siblings, sibling_count) < 0)
+    {
+        AERON_APPEND_ERR("parsing sibling list for CPU %d", cpu);
+        return -1;
+    }
+    return 0;
+}
+
+static int read_l3_peers(int cpu, int **peers, int *peer_count)
+{
+    char buf[AERON_TOPOLOGY_FILE_BUF_SIZE];
+    if (read_sysfs_cpu_file(cpu, "cache/index3/shared_cpu_list", buf, sizeof(buf)) < 0)
+    {
+        return -1;
+    }
+    if (aeron_cpuset_parse_cpulist(buf, peers, peer_count) < 0)
+    {
+        return -1;
+    }
+    return 0;
+}
+
+static int read_cluster_id(int cpu, int *cluster_id)
+{
+    char buf[64];
+    if (read_sysfs_cpu_file(cpu, "topology/cluster_id", buf, sizeof(buf)) < 0)
+    {
+        return -1;
+    }
+    char *end = buf;
+    long val = strtol(buf, &end, 10);
+    if (end == buf)
+    {
+        AERON_SET_ERR(EINVAL, "parsing cluster_id for CPU %d: '%s'", cpu, buf);
+        return -1;
+    }
+    *cluster_id = (int)val;
+    return 0;
+}
+
+static void core_groups_free(aeron_topology_core_group_t *groups, int group_count)
+{
+    if (NULL == groups)
+    {
+        return;
+    }
+    for (int i = 0; i < group_count; i++)
+    {
+        aeron_free(groups[i].present);
+        aeron_free(groups[i].missing);
+    }
+    aeron_free(groups);
+}
+
+static int read_core_groups(
+    const int *cpus,
+    int cpu_count,
+    aeron_topology_core_group_t **groups_out,
+    int *group_count_out)
+{
+    uint8_t cpu_set[AERON_TOPOLOGY_MAX_CPU_ID] = { 0 };
+    uint8_t seen[AERON_TOPOLOGY_MAX_CPU_ID] = { 0 };
+    aeron_topology_core_group_t *groups = NULL;
+    int group_count = 0;
+    int group_capacity = 16;
+    int result = 0;
+
+    if (aeron_alloc((void **)&groups, sizeof(aeron_topology_core_group_t) * group_capacity) < 0)
+    {
+        AERON_APPEND_ERR("%s", "");
+        result = -1;
+        goto done;
+    }
+
+    for (int i = 0; i < cpu_count; i++)
+    {
+        if (0 <= cpus[i] && cpus[i] < AERON_TOPOLOGY_MAX_CPU_ID)
+        {
+            cpu_set[cpus[i]] = 1;
+        }
+    }
+
+    for (int i = 0; i < cpu_count; i++)
+    {
+        int cpu = cpus[i];
+        if (0 <= cpu && cpu < AERON_TOPOLOGY_MAX_CPU_ID && seen[cpu])
+        {
+            continue;
+        }
+
+        int *siblings = NULL;
+        int sibling_count = 0;
+        if (read_siblings(cpu, &siblings, &sibling_count) < 0)
+        {
+            AERON_APPEND_ERR("%s", "");
+            result = -1;
+            goto done;
+        }
+
+        for (int j = 0; j < sibling_count; j++)
+        {
+            if (0 <= siblings[j] && siblings[j] < AERON_TOPOLOGY_MAX_CPU_ID)
+            {
+                seen[siblings[j]] = 1;
+            }
+        }
+
+        int *present = NULL;
+        int present_count = 0;
+        int *missing = NULL;
+        int missing_count = 0;
+
+        if (0 < sibling_count)
+        {
+            if (aeron_alloc((void **)&present, sizeof(int) * sibling_count) < 0)
+            {
+                AERON_APPEND_ERR("%s", "");
+                aeron_free(siblings);
+                result = -1;
+                goto done;
+            }
+            if (aeron_alloc((void **)&missing, sizeof(int) * sibling_count) < 0)
+            {
+                AERON_APPEND_ERR("%s", "");
+                aeron_free(siblings);
+                aeron_free(present);
+                result = -1;
+                goto done;
+            }
+        }
+
+        for (int j = 0; j < sibling_count; j++)
+        {
+            int s = siblings[j];
+            if (0 <= s && s < AERON_TOPOLOGY_MAX_CPU_ID && cpu_set[s])
+            {
+                present[present_count++] = s;
+            }
+            else
+            {
+                missing[missing_count++] = s;
+            }
+        }
+
+        aeron_free(siblings);
+
+        if (0 == present_count)
+        {
+            aeron_free(present);
+            present = NULL;
+        }
+        else if (aeron_reallocf((void **)&present, sizeof(int) * present_count) < 0)
+        {
+            AERON_APPEND_ERR("%s", "");
+            aeron_free(missing);
+            result = -1;
+            goto done;
+        }
+
+        if (0 == missing_count)
+        {
+            aeron_free(missing);
+            missing = NULL;
+        }
+        else if (aeron_reallocf((void **)&missing, sizeof(int) * missing_count) < 0)
+        {
+            AERON_APPEND_ERR("%s", "");
+            aeron_free(present);
+            result = -1;
+            goto done;
+        }
+
+        if (group_count == group_capacity)
+        {
+            group_capacity *= 2;
+            if (aeron_reallocf((void **)&groups, sizeof(aeron_topology_core_group_t) * group_capacity) < 0)
+            {
+                AERON_APPEND_ERR("%s", "");
+                aeron_free(present);
+                aeron_free(missing);
+                result = -1;
+                goto done;
+            }
+        }
+
+        groups[group_count].present = present;
+        groups[group_count].present_count = present_count;
+        groups[group_count].missing = missing;
+        groups[group_count].missing_count = missing_count;
+        group_count++;
+    }
+
+done:
+    *groups_out = groups;
+    *group_count_out = group_count;
+    return result;
+}
+
+static int format_cpulist(const int *cpus, int cpu_count, char *buf, size_t buf_size)
+{
+    int written = 0;
+    int i = 0;
+    while (i < cpu_count)
+    {
+        int j = i;
+        while (j + 1 < cpu_count && cpus[j + 1] == cpus[j] + 1)
+        {
+            j++;
+        }
+
+        if (written > 0)
+        {
+            if ((size_t)(written + 1) >= buf_size)
+            {
+                return -1;
+            }
+            buf[written++] = ',';
+        }
+
+        int n;
+        if (i == j)
+        {
+            n = snprintf(buf + written, buf_size - (size_t)written, "%d", cpus[i]);
+        }
+        else
+        {
+            n = snprintf(buf + written, buf_size - (size_t)written, "%d-%d", cpus[i], cpus[j]);
+        }
+
+        if (n < 0 || (size_t)(written + n) >= buf_size)
+        {
+            return -1;
+        }
+        written += n;
+        i = j + 1;
+    }
+    return written;
+}
+
+static int append_warning(char ***warnings, int *count, int *capacity, const char *msg)
+{
+    if (*count == *capacity)
+    {
+        int new_capacity = *capacity == 0 ? 4 : *capacity * 2;
+        if (aeron_reallocf((void **)warnings, sizeof(char *) * new_capacity) < 0)
+        {
+            AERON_APPEND_ERR("%s", "");
+            return -1;
+        }
+        *capacity = new_capacity;
+    }
+
+    size_t len = strlen(msg);
+    char *copy = NULL;
+    if (aeron_alloc((void **)&copy, len + 1) < 0)
+    {
+        AERON_APPEND_ERR("%s", "");
+        return -1;
+    }
+    memcpy(copy, msg, len + 1);
+    (*warnings)[(*count)++] = copy;
+    return 0;
+}
+
+void aeron_topology_cores_free(aeron_topology_core_t *cores, int core_count)
+{
+    if (NULL == cores)
+    {
+        return;
+    }
+    for (int i = 0; i < core_count; i++)
+    {
+        aeron_free(cores[i].cpus);
+    }
+    aeron_free(cores);
+}
+
+void aeron_topology_warnings_free(char **warnings, int warning_count)
+{
+    if (NULL == warnings)
+    {
+        return;
+    }
+    for (int i = 0; i < warning_count; i++)
+    {
+        aeron_free(warnings[i]);
+    }
+    aeron_free(warnings);
+}
+
+int aeron_topology_read(
+    const int *cpus,
+    int cpu_count,
+    aeron_topology_core_t **cores_out,
+    int *core_count_out)
+{
+    aeron_topology_core_group_t *groups = NULL;
+    int group_count = 0;
+    aeron_topology_core_t *cores = NULL;
+    int core_count = 0;
+
+    if (read_core_groups(cpus, cpu_count, &groups, &group_count) < 0)
+    {
+        AERON_APPEND_ERR("%s", "");
+        core_groups_free(groups, group_count);
+        return -1;
+    }
+
+    if (group_count > 0 && aeron_alloc((void **)&cores, sizeof(aeron_topology_core_t) * group_count) < 0)
+    {
+        AERON_APPEND_ERR("%s", "");
+        core_groups_free(groups, group_count);
+        return -1;
+    }
+
+    for (int i = 0; i < group_count; i++)
+    {
+        if (groups[i].present_count > 0)
+        {
+            cores[core_count].cpus = groups[i].present;
+            cores[core_count].cpu_count = groups[i].present_count;
+            groups[i].present = NULL; // ownership transferred to cores[]
+            core_count++;
+        }
+        aeron_free(groups[i].missing);
+        groups[i].missing = NULL;
+    }
+    aeron_free(groups);
+
+    qsort(cores, core_count, sizeof(aeron_topology_core_t), cmp_core_by_prime);
+
+    *cores_out = cores;
+    *core_count_out = core_count;
+    return 0;
+}
+
+int aeron_topology_primes_of(
+    const aeron_topology_core_t *cores,
+    int core_count,
+    int **primes_out,
+    int *prime_count_out)
+{
+    if (0 == core_count)
+    {
+        *primes_out = NULL;
+        *prime_count_out = 0;
+        return 0;
+    }
+
+    int *primes = NULL;
+    if (aeron_alloc((void **)&primes, sizeof(int) * core_count) < 0)
+    {
+        AERON_APPEND_ERR("%s", "");
+        return -1;
+    }
+
+    int count = 0;
+    for (int i = 0; i < core_count; i++)
+    {
+        if (cores[i].cpu_count > 0)
+        {
+            primes[count++] = cores[i].cpus[0];
+        }
+    }
+
+    *primes_out = primes;
+    *prime_count_out = count;
+    return 0;
+}
+
+int aeron_topology_all_of(
+    const aeron_topology_core_t *cores,
+    int core_count,
+    int **cpus_out,
+    int *cpu_count_out)
+{
+    int total = 0;
+    for (int i = 0; i < core_count; i++)
+    {
+        total += cores[i].cpu_count;
+    }
+
+    if (0 == total)
+    {
+        *cpus_out = NULL;
+        *cpu_count_out = 0;
+        return 0;
+    }
+
+    int *cpus = NULL;
+    if (aeron_alloc((void **)&cpus, sizeof(int) * total) < 0)
+    {
+        AERON_APPEND_ERR("%s", "");
+        return -1;
+    }
+
+    int pos = 0;
+    for (int i = 0; i < core_count; i++)
+    {
+        memcpy(cpus + pos, cores[i].cpus, sizeof(int) * cores[i].cpu_count);
+        pos += cores[i].cpu_count;
+    }
+
+    *cpus_out = cpus;
+    *cpu_count_out = total;
+    return 0;
+}
+
+int aeron_topology_check_alignment(
+    const int *cpus,
+    int cpu_count,
+    char ***warnings_out,
+    int *warning_count_out)
+{
+    char **warnings = NULL;
+    int warning_count = 0;
+    int warning_capacity = 0;
+
+    aeron_topology_core_group_t *groups = NULL;
+    int group_count = 0;
+    read_core_groups(cpus, cpu_count, &groups, &group_count); // best-effort
+
+    for (int i = 0; i < group_count; i++)
+    {
+        if (groups[i].missing_count > 0 && groups[i].present_count > 0)
+        {
+            char cpulist_buf[4096];
+            format_cpulist(groups[i].missing, groups[i].missing_count, cpulist_buf, sizeof(cpulist_buf));
+
+            char warning_buf[4096 + 128];
+            snprintf(
+                warning_buf, sizeof(warning_buf),
+                "cpuset is missing sibling CPU(s) %s of the core containing CPU %d (partial core in cpuset)",
+                cpulist_buf, groups[i].present[0]);
+
+            if (append_warning(&warnings, &warning_count, &warning_capacity, warning_buf) < 0)
+            {
+                core_groups_free(groups, group_count);
+                aeron_topology_warnings_free(warnings, warning_count);
+                return -1;
+            }
+        }
+    }
+
+    core_groups_free(groups, group_count);
+    *warnings_out = warnings;
+    *warning_count_out = warning_count;
+    return 0;
+}
+
+int aeron_topology_check_locality(
+    const int *cpus,
+    int cpu_count,
+    char ***warnings_out,
+    int *warning_count_out)
+{
+    if (cpu_count < 2)
+    {
+        *warnings_out = NULL;
+        *warning_count_out = 0;
+        return 0;
+    }
+
+    if (AERON_TOPOLOGY_MAX_CPU_ID < cpu_count)
+    {
+        AERON_SET_ERR(EINVAL, "cpu count %d is greater than max cpu count", cpu_count);
+        return -1;
+    }
+
+    char **warnings = NULL;
+    int warning_count = 0;
+    int warning_capacity = 0;
+
+    uint8_t cpu_set[AERON_TOPOLOGY_MAX_CPU_ID] = { 0 };
+    uint8_t seen[AERON_TOPOLOGY_MAX_CPU_ID] = { 0 };
+    int result = 0;
+
+    for (int i = 0; i < cpu_count; i++)
+    {
+        cpu_set[cpus[i]] = 1;
+    }
+
+    int *peers = NULL;
+    int peer_count = 0;
+
+    if (0 <= read_l3_peers(cpus[0], &peers, &peer_count))
+    {
+        for (int i = 0; i < peer_count; i++)
+        {
+            seen[peers[i]] = 1;
+        }
+
+        for (int j = 1; j < cpu_count; j++)
+        {
+            if (!seen[cpus[j]])
+            {
+                if (append_warning(
+                    &warnings, &warning_count, &warning_capacity, "cpuset spans multiple L3 cache domains") < 0)
+                {
+                    AERON_APPEND_ERR("%s", "");
+                    result = -1;
+                    goto done;
+                }
+            }
+        }
+    }
+    else
+    {
+        aeron_err_clear();
+    }
+
+    // --- Cluster check ---
+    int cluster_ids[256];
+    int cluster_id_count = 0;
+    int cluster_ok = 1;
+
+    for (int i = 0; i < cpu_count; i++)
+    {
+        int id = 0;
+        if (read_cluster_id(cpus[i], &id) < 0)
+        {
+            cluster_ok = 0;
+            aeron_err_clear();
+            break;
+        }
+
+        int found = 0;
+        for (int j = 0; j < cluster_id_count; j++)
+        {
+            if (cluster_ids[j] == id)
+            {
+                found = 1;
+                break;
+            }
+        }
+        if (!found && cluster_id_count < 256)
+        {
+            cluster_ids[cluster_id_count++] = id;
+        }
+    }
+
+    if (cluster_ok && cluster_id_count > 1)
+    {
+        qsort(cluster_ids, cluster_id_count, sizeof(int), cmp_int);
+
+        char id_list_buf[512];
+        int written = 0;
+        for (int i = 0; i < cluster_id_count; i++)
+        {
+            int n = snprintf(
+                id_list_buf + written, sizeof(id_list_buf) - (size_t)written,
+                "%s%d", i > 0 ? ", " : "", cluster_ids[i]);
+            if (n > 0)
+            {
+                written += n;
+            }
+        }
+
+        char warning_buf[512 + 64];
+        snprintf(
+            warning_buf, sizeof(warning_buf),
+            "cpuset spans %d CPU clusters (cluster IDs: %s)",
+            cluster_id_count, id_list_buf);
+
+        if (append_warning(&warnings, &warning_count, &warning_capacity, warning_buf) < 0)
+        {
+            result = -1;
+            goto done;
+        }
+    }
+
+done:
+    if (result < 0)
+    {
+        aeron_topology_warnings_free(warnings, warning_count);
+        return -1;
+    }
+
+    *warnings_out = warnings;
+    *warning_count_out = warning_count;
+    return 0;
+}

--- a/aeron-driver/src/main/c/aeron_topology.c
+++ b/aeron-driver/src/main/c/aeron_topology.c
@@ -59,10 +59,15 @@ static int aeron_topology_cmp_core_by_prime(const void *a, const void *b)
     return ca->cpus[0] - cb->cpus[0];
 }
 
-static int aeron_topology_read_sysfs_cpu_file(int cpu, const char *suffix, char *buf, size_t buf_size)
+static int aeron_topology_read_sysfs_cpu_file(
+    const char *sys_cpu_root,
+    const int cpu,
+    const char *suffix,
+    char *buf,
+    const size_t buf_size)
 {
     char path[4096];
-    int n = snprintf(path, sizeof(path), "%s/cpu%d/%s", aeron_topology_sys_cpu_path, cpu, suffix);
+    int n = snprintf(path, sizeof(path), "%s/cpu%d/%s", sys_cpu_root, cpu, suffix);
     if (n < 0 || (size_t)n >= sizeof(path))
     {
         AERON_SET_ERR(EINVAL, "path too long for CPU %d", cpu);
@@ -82,10 +87,10 @@ static int aeron_topology_read_sysfs_cpu_file(int cpu, const char *suffix, char 
     return (int)read;
 }
 
-static int aeron_topology_read_siblings(int cpu, int **siblings, int *sibling_count)
+static int aeron_topology_read_sibling(const char *sys_cpu_root, int cpu, int **siblings, int *sibling_count)
 {
     char buf[AERON_TOPOLOGY_FILE_BUF_SIZE];
-    if (aeron_topology_read_sysfs_cpu_file(cpu, "topology/thread_siblings_list", buf, sizeof(buf)) < 0)
+    if (aeron_topology_read_sysfs_cpu_file(sys_cpu_root, cpu, "topology/thread_siblings_list", buf, sizeof(buf)) < 0)
     {
         AERON_APPEND_ERR("reading topology for CPU %d", cpu);
         return -1;
@@ -98,10 +103,10 @@ static int aeron_topology_read_siblings(int cpu, int **siblings, int *sibling_co
     return 0;
 }
 
-static int aeron_topology_read_l3_peers(int cpu, int **peers, int *peer_count)
+static int aeron_topology_read_l3_peers(const char *sys_cpu_root, int cpu, int **peers, int *peer_count)
 {
     char buf[AERON_TOPOLOGY_FILE_BUF_SIZE];
-    if (aeron_topology_read_sysfs_cpu_file(cpu, "cache/index3/shared_cpu_list", buf, sizeof(buf)) < 0)
+    if (aeron_topology_read_sysfs_cpu_file(sys_cpu_root, cpu, "cache/index3/shared_cpu_list", buf, sizeof(buf)) < 0)
     {
         return -1;
     }
@@ -112,10 +117,10 @@ static int aeron_topology_read_l3_peers(int cpu, int **peers, int *peer_count)
     return 0;
 }
 
-static int aeron_topology_read_cluster_id(int cpu, int *cluster_id)
+static int aeron_topology_read_cluster_id(const char *sys_cpu_root, int cpu, int *cluster_id)
 {
     char buf[64];
-    if (aeron_topology_read_sysfs_cpu_file(cpu, "topology/cluster_id", buf, sizeof(buf)) < 0)
+    if (aeron_topology_read_sysfs_cpu_file(sys_cpu_root, cpu, "topology/cluster_id", buf, sizeof(buf)) < 0)
     {
         return -1;
     }
@@ -145,8 +150,9 @@ static void aeron_topology_core_groups_free(aeron_topology_core_group_t *groups,
 }
 
 static int aeron_topology_read_core_groups(
+    const char* sys_cpu_root,
     const int *cpus,
-    int cpu_count,
+    const int cpu_count,
     aeron_topology_core_group_t **groups_out,
     int *group_count_out)
 {
@@ -179,7 +185,7 @@ static int aeron_topology_read_core_groups(
 
         int *siblings = NULL;
         int sibling_count = 0;
-        if (aeron_topology_read_siblings(cpu, &siblings, &sibling_count) < 0)
+        if (aeron_topology_read_sibling(sys_cpu_root, cpu, &siblings, &sibling_count) < 0)
         {
             AERON_APPEND_ERR("%s", "");
             result = -1;
@@ -340,6 +346,7 @@ void aeron_topology_cores_free(aeron_topology_core_t *cores, int core_count)
 }
 
 int aeron_topology_read(
+    const char *sys_cpu_root,
     const int *cpus,
     int cpu_count,
     aeron_topology_core_t **cores_out,
@@ -350,7 +357,7 @@ int aeron_topology_read(
     aeron_topology_core_t *cores = NULL;
     int core_count = 0;
 
-    if (aeron_topology_read_core_groups(cpus, cpu_count, &groups, &group_count) < 0)
+    if (aeron_topology_read_core_groups(sys_cpu_root, cpus, cpu_count, &groups, &group_count) < 0)
     {
         AERON_APPEND_ERR("%s", "");
         aeron_topology_core_groups_free(groups, group_count);
@@ -457,7 +464,7 @@ int aeron_topology_all_of(
     return 0;
 }
 
-int aeron_topology_check_alignment(const int *cpus, const int cpu_count, FILE *output)
+int aeron_topology_check_alignment(const char* sys_cpu_root, const int *cpus, const int cpu_count, FILE *output)
 {
     int result = 0;
 
@@ -475,7 +482,7 @@ int aeron_topology_check_alignment(const int *cpus, const int cpu_count, FILE *o
         return 0;
     }
 
-    aeron_topology_read_core_groups(cpus, cpu_count, &groups, &group_count); // best-effort
+    aeron_topology_read_core_groups(sys_cpu_root, cpus, cpu_count, &groups, &group_count); // best-effort
 
     for (int i = 0; i < group_count; i++)
     {
@@ -498,7 +505,7 @@ int aeron_topology_check_alignment(const int *cpus, const int cpu_count, FILE *o
     return result;
 }
 
-int aeron_topology_check_l3_locality(const int *cpus, const int cpu_count, FILE* output)
+int aeron_topology_check_l3_locality(const char* sys_cpu_root, const int *cpus, const int cpu_count, FILE* output)
 {
     if (AERON_TOPOLOGY_MAX_CPU_ID < cpu_count)
     {
@@ -516,7 +523,7 @@ int aeron_topology_check_l3_locality(const int *cpus, const int cpu_count, FILE*
     int *peers = NULL;
     int peer_count = 0;
 
-    if (0 <= aeron_topology_read_l3_peers(cpus[0], &peers, &peer_count))
+    if (0 <= aeron_topology_read_l3_peers(sys_cpu_root, cpus[0], &peers, &peer_count))
     {
         for (int i = 0; i < peer_count; i++)
         {
@@ -540,7 +547,7 @@ int aeron_topology_check_l3_locality(const int *cpus, const int cpu_count, FILE*
     return 0;
 }
 
-int aeron_topology_check_cluster_locality(const int *cpus, int cpu_count, FILE* output)
+int aeron_topology_check_cluster_locality(const char* sys_cpu_root, const int *cpus, int cpu_count, FILE* output)
 {
     if (AERON_TOPOLOGY_MAX_CPU_ID < cpu_count)
     {
@@ -563,7 +570,7 @@ int aeron_topology_check_cluster_locality(const int *cpus, int cpu_count, FILE* 
     for (int i = 0; i < cpu_count; i++)
     {
         int id = 0;
-        if (aeron_topology_read_cluster_id(cpus[i], &id) < 0)
+        if (aeron_topology_read_cluster_id(sys_cpu_root, cpus[i], &id) < 0)
         {
             cluster_ok = 0;
             aeron_err_clear();

--- a/aeron-driver/src/main/c/aeron_topology.c
+++ b/aeron-driver/src/main/c/aeron_topology.c
@@ -482,7 +482,11 @@ int aeron_topology_check_alignment(const char* sys_cpu_root, const int *cpus, co
         return 0;
     }
 
-    aeron_topology_read_core_groups(sys_cpu_root, cpus, cpu_count, &groups, &group_count); // best-effort
+    if (-1 == aeron_topology_read_core_groups(sys_cpu_root, cpus, cpu_count, &groups, &group_count))
+    {
+        AERON_APPEND_ERR("%s", "");
+        return -1;
+    }
 
     for (int i = 0; i < group_count; i++)
     {

--- a/aeron-driver/src/main/c/aeron_topology.c
+++ b/aeron-driver/src/main/c/aeron_topology.c
@@ -30,7 +30,7 @@
 
 const char *aeron_topology_sys_cpu_path = AERON_TOPOLOGY_SYS_CPU_PATH;
 
-typedef struct aeron_topology_core_group_st
+typedef struct aeron_topology_core_group_stct
 {
     int *present;
     int present_count;
@@ -39,12 +39,12 @@ typedef struct aeron_topology_core_group_st
 }
 aeron_topology_core_group_t;
 
-static int cmp_int(const void *a, const void *b)
+static int aeron_topology_cmp_int(const void *a, const void *b)
 {
     return *(const int *)a - *(const int *)b;
 }
 
-static int cmp_core_by_prime(const void *a, const void *b)
+static int aeron_topology_cmp_core_by_prime(const void *a, const void *b)
 {
     const aeron_topology_core_t *ca = (const aeron_topology_core_t *)a;
     const aeron_topology_core_t *cb = (const aeron_topology_core_t *)b;
@@ -59,7 +59,7 @@ static int cmp_core_by_prime(const void *a, const void *b)
     return ca->cpus[0] - cb->cpus[0];
 }
 
-static int read_sysfs_cpu_file(int cpu, const char *suffix, char *buf, size_t buf_size)
+static int aeron_topology_read_sysfs_cpu_file(int cpu, const char *suffix, char *buf, size_t buf_size)
 {
     char path[4096];
     int n = snprintf(path, sizeof(path), "%s/cpu%d/%s", aeron_topology_sys_cpu_path, cpu, suffix);
@@ -82,10 +82,10 @@ static int read_sysfs_cpu_file(int cpu, const char *suffix, char *buf, size_t bu
     return (int)read;
 }
 
-static int read_siblings(int cpu, int **siblings, int *sibling_count)
+static int aeron_topology_read_siblings(int cpu, int **siblings, int *sibling_count)
 {
     char buf[AERON_TOPOLOGY_FILE_BUF_SIZE];
-    if (read_sysfs_cpu_file(cpu, "topology/thread_siblings_list", buf, sizeof(buf)) < 0)
+    if (aeron_topology_read_sysfs_cpu_file(cpu, "topology/thread_siblings_list", buf, sizeof(buf)) < 0)
     {
         AERON_APPEND_ERR("reading topology for CPU %d", cpu);
         return -1;
@@ -98,10 +98,10 @@ static int read_siblings(int cpu, int **siblings, int *sibling_count)
     return 0;
 }
 
-static int read_l3_peers(int cpu, int **peers, int *peer_count)
+static int aeron_topology_read_l3_peers(int cpu, int **peers, int *peer_count)
 {
     char buf[AERON_TOPOLOGY_FILE_BUF_SIZE];
-    if (read_sysfs_cpu_file(cpu, "cache/index3/shared_cpu_list", buf, sizeof(buf)) < 0)
+    if (aeron_topology_read_sysfs_cpu_file(cpu, "cache/index3/shared_cpu_list", buf, sizeof(buf)) < 0)
     {
         return -1;
     }
@@ -112,10 +112,10 @@ static int read_l3_peers(int cpu, int **peers, int *peer_count)
     return 0;
 }
 
-static int read_cluster_id(int cpu, int *cluster_id)
+static int aeron_topology_read_cluster_id(int cpu, int *cluster_id)
 {
     char buf[64];
-    if (read_sysfs_cpu_file(cpu, "topology/cluster_id", buf, sizeof(buf)) < 0)
+    if (aeron_topology_read_sysfs_cpu_file(cpu, "topology/cluster_id", buf, sizeof(buf)) < 0)
     {
         return -1;
     }
@@ -130,7 +130,7 @@ static int read_cluster_id(int cpu, int *cluster_id)
     return 0;
 }
 
-static void core_groups_free(aeron_topology_core_group_t *groups, int group_count)
+static void aeron_topology_core_groups_free(aeron_topology_core_group_t *groups, int group_count)
 {
     if (NULL == groups)
     {
@@ -144,7 +144,7 @@ static void core_groups_free(aeron_topology_core_group_t *groups, int group_coun
     aeron_free(groups);
 }
 
-static int read_core_groups(
+static int aeron_topology_read_core_groups(
     const int *cpus,
     int cpu_count,
     aeron_topology_core_group_t **groups_out,
@@ -166,23 +166,20 @@ static int read_core_groups(
 
     for (int i = 0; i < cpu_count; i++)
     {
-        if (0 <= cpus[i] && cpus[i] < AERON_TOPOLOGY_MAX_CPU_ID)
-        {
-            cpu_set[cpus[i]] = 1;
-        }
+        cpu_set[cpus[i]] = 1;
     }
 
     for (int i = 0; i < cpu_count; i++)
     {
         int cpu = cpus[i];
-        if (0 <= cpu && cpu < AERON_TOPOLOGY_MAX_CPU_ID && seen[cpu])
+        if (seen[cpu])
         {
             continue;
         }
 
         int *siblings = NULL;
         int sibling_count = 0;
-        if (read_siblings(cpu, &siblings, &sibling_count) < 0)
+        if (aeron_topology_read_siblings(cpu, &siblings, &sibling_count) < 0)
         {
             AERON_APPEND_ERR("%s", "");
             result = -1;
@@ -288,7 +285,7 @@ done:
     return result;
 }
 
-static int format_cpulist(const int *cpus, int cpu_count, char *buf, size_t buf_size)
+static int aeron_topology_format_cpulist(const int *cpus, int cpu_count, char *buf, size_t buf_size)
 {
     int written = 0;
     int i = 0;
@@ -329,7 +326,7 @@ static int format_cpulist(const int *cpus, int cpu_count, char *buf, size_t buf_
     return written;
 }
 
-static int append_warning(char ***warnings, int *count, int *capacity, const char *msg)
+static int aeron_topology_append_warning(char ***warnings, int *count, int *capacity, const char *msg)
 {
     if (*count == *capacity)
     {
@@ -391,17 +388,17 @@ int aeron_topology_read(
     aeron_topology_core_t *cores = NULL;
     int core_count = 0;
 
-    if (read_core_groups(cpus, cpu_count, &groups, &group_count) < 0)
+    if (aeron_topology_read_core_groups(cpus, cpu_count, &groups, &group_count) < 0)
     {
         AERON_APPEND_ERR("%s", "");
-        core_groups_free(groups, group_count);
+        aeron_topology_core_groups_free(groups, group_count);
         return -1;
     }
 
     if (group_count > 0 && aeron_alloc((void **)&cores, sizeof(aeron_topology_core_t) * group_count) < 0)
     {
         AERON_APPEND_ERR("%s", "");
-        core_groups_free(groups, group_count);
+        aeron_topology_core_groups_free(groups, group_count);
         return -1;
     }
 
@@ -419,7 +416,7 @@ int aeron_topology_read(
     }
     aeron_free(groups);
 
-    qsort(cores, core_count, sizeof(aeron_topology_core_t), cmp_core_by_prime);
+    qsort(cores, core_count, sizeof(aeron_topology_core_t), aeron_topology_cmp_core_by_prime);
 
     *cores_out = cores;
     *core_count_out = core_count;
@@ -500,7 +497,7 @@ int aeron_topology_all_of(
 
 int aeron_topology_check_alignment(
     const int *cpus,
-    int cpu_count,
+    const int cpu_count,
     char ***warnings_out,
     int *warning_count_out)
 {
@@ -510,14 +507,26 @@ int aeron_topology_check_alignment(
 
     aeron_topology_core_group_t *groups = NULL;
     int group_count = 0;
-    read_core_groups(cpus, cpu_count, &groups, &group_count); // best-effort
+
+    if (AERON_TOPOLOGY_MAX_CPU_ID < cpu_count)
+    {
+        AERON_SET_ERR(EINVAL, "cpu count %d is greater than max cpu count", cpu_count);
+        return -1;
+    }
+
+    if (cpu_count < 2)
+    {
+        return 0;
+    }
+
+    aeron_topology_read_core_groups(cpus, cpu_count, &groups, &group_count); // best-effort
 
     for (int i = 0; i < group_count; i++)
     {
-        if (groups[i].missing_count > 0 && groups[i].present_count > 0)
+        if (0 < groups[i].missing_count && 0 < groups[i].present_count)
         {
             char cpulist_buf[4096];
-            format_cpulist(groups[i].missing, groups[i].missing_count, cpulist_buf, sizeof(cpulist_buf));
+            aeron_topology_format_cpulist(groups[i].missing, groups[i].missing_count, cpulist_buf, sizeof(cpulist_buf));
 
             char warning_buf[4096 + 128];
             snprintf(
@@ -525,32 +534,31 @@ int aeron_topology_check_alignment(
                 "cpuset is missing sibling CPU(s) %s of the core containing CPU %d (partial core in cpuset)",
                 cpulist_buf, groups[i].present[0]);
 
-            if (append_warning(&warnings, &warning_count, &warning_capacity, warning_buf) < 0)
+            if (aeron_topology_append_warning(&warnings, &warning_count, &warning_capacity, warning_buf) < 0)
             {
-                core_groups_free(groups, group_count);
+                aeron_topology_core_groups_free(groups, group_count);
                 aeron_topology_warnings_free(warnings, warning_count);
                 return -1;
             }
         }
     }
 
-    core_groups_free(groups, group_count);
+    aeron_topology_core_groups_free(groups, group_count);
     *warnings_out = warnings;
     *warning_count_out = warning_count;
     return 0;
 }
 
-int aeron_topology_check_locality(
+int aeron_topology_check_l3_locality(
     const int *cpus,
-    int cpu_count,
-    char ***warnings_out,
-    int *warning_count_out)
+    const int cpu_count,
+    char *warning_buf,
+    const int warning_buf_len)
 {
-    if (cpu_count < 2)
+    if (!(NULL != warning_buf && 0 < warning_buf_len))
     {
-        *warnings_out = NULL;
-        *warning_count_out = 0;
-        return 0;
+        AERON_SET_ERR(EINVAL, "%s", "invalid warning buffer");
+        return -1;
     }
 
     if (AERON_TOPOLOGY_MAX_CPU_ID < cpu_count)
@@ -559,23 +567,19 @@ int aeron_topology_check_locality(
         return -1;
     }
 
-    char **warnings = NULL;
-    int warning_count = 0;
-    int warning_capacity = 0;
+    warning_buf[0] = '\0';
 
-    uint8_t cpu_set[AERON_TOPOLOGY_MAX_CPU_ID] = { 0 };
-    uint8_t seen[AERON_TOPOLOGY_MAX_CPU_ID] = { 0 };
-    int result = 0;
-
-    for (int i = 0; i < cpu_count; i++)
+    if (cpu_count < 2)
     {
-        cpu_set[cpus[i]] = 1;
+        return 0;
     }
+
+    uint8_t seen[AERON_TOPOLOGY_MAX_CPU_ID] = { 0 };
 
     int *peers = NULL;
     int peer_count = 0;
 
-    if (0 <= read_l3_peers(cpus[0], &peers, &peer_count))
+    if (0 <= aeron_topology_read_l3_peers(cpus[0], &peers, &peer_count))
     {
         for (int i = 0; i < peer_count; i++)
         {
@@ -586,19 +590,41 @@ int aeron_topology_check_locality(
         {
             if (!seen[cpus[j]])
             {
-                if (append_warning(
-                    &warnings, &warning_count, &warning_capacity, "cpuset spans multiple L3 cache domains") < 0)
-                {
-                    AERON_APPEND_ERR("%s", "");
-                    result = -1;
-                    goto done;
-                }
+                snprintf(warning_buf, warning_buf_len, "%s", "cpuset spans multiple L3 cache domains");
             }
         }
     }
     else
     {
         aeron_err_clear();
+    }
+
+    return 0;
+}
+
+int aeron_topology_check_cluster_locality(
+    const int *cpus,
+    int cpu_count,
+    char *warning_buf,
+    const int warning_buf_len)
+{
+    if (!(NULL != warning_buf && 0 < warning_buf_len))
+    {
+        AERON_SET_ERR(EINVAL, "%s", "invalid warning buffer");
+        return -1;
+    }
+
+    if (AERON_TOPOLOGY_MAX_CPU_ID < cpu_count)
+    {
+        AERON_SET_ERR(EINVAL, "cpu count %d is greater than max cpu count", cpu_count);
+        return -1;
+    }
+
+    warning_buf[0] = '\0';
+
+    if (cpu_count < 2)
+    {
+        return 0;
     }
 
     // --- Cluster check ---
@@ -609,7 +635,7 @@ int aeron_topology_check_locality(
     for (int i = 0; i < cpu_count; i++)
     {
         int id = 0;
-        if (read_cluster_id(cpus[i], &id) < 0)
+        if (aeron_topology_read_cluster_id(cpus[i], &id) < 0)
         {
             cluster_ok = 0;
             aeron_err_clear();
@@ -633,7 +659,7 @@ int aeron_topology_check_locality(
 
     if (cluster_ok && cluster_id_count > 1)
     {
-        qsort(cluster_ids, cluster_id_count, sizeof(int), cmp_int);
+        qsort(cluster_ids, cluster_id_count, sizeof(int), aeron_topology_cmp_int);
 
         char id_list_buf[512];
         int written = 0;
@@ -648,27 +674,11 @@ int aeron_topology_check_locality(
             }
         }
 
-        char warning_buf[512 + 64];
         snprintf(
-            warning_buf, sizeof(warning_buf),
+            warning_buf, warning_buf_len,
             "cpuset spans %d CPU clusters (cluster IDs: %s)",
             cluster_id_count, id_list_buf);
-
-        if (append_warning(&warnings, &warning_count, &warning_capacity, warning_buf) < 0)
-        {
-            result = -1;
-            goto done;
-        }
     }
 
-done:
-    if (result < 0)
-    {
-        aeron_topology_warnings_free(warnings, warning_count);
-        return -1;
-    }
-
-    *warnings_out = warnings;
-    *warning_count_out = warning_count;
     return 0;
 }

--- a/aeron-driver/src/main/c/aeron_topology.c
+++ b/aeron-driver/src/main/c/aeron_topology.c
@@ -466,7 +466,7 @@ int aeron_topology_check_alignment(const int *cpus, const int cpu_count, FILE *o
 
     if (AERON_TOPOLOGY_MAX_CPU_ID < cpu_count)
     {
-        AERON_SET_ERR(EINVAL, "cpu count %d is greater than max cpu count", cpu_count);
+        AERON_SET_ERR(EINVAL, "WARNING: cpu count %d is greater than max cpu count", cpu_count);
         return -1;
     }
 
@@ -486,7 +486,7 @@ int aeron_topology_check_alignment(const int *cpus, const int cpu_count, FILE *o
 
             fprintf(
                 output,
-                "cpuset is missing sibling CPU(s) %s of the core containing CPU %d (partial core in cpuset)",
+                "WARNING: cpuset is missing sibling CPU(s) %s of the core containing CPU %d (partial core in cpuset)\n",
                 cpulist_buf, groups[i].present[0]);
 
             result++;
@@ -527,7 +527,7 @@ int aeron_topology_check_l3_locality(const int *cpus, const int cpu_count, FILE*
         {
             if (!seen[cpus[j]])
             {
-                fprintf(output, "%s", "cpuset spans multiple L3 cache domains");
+                fprintf(output, "%s", "WARNING: cpuset spans multiple L3 cache domains\n");
             }
         }
     }
@@ -602,7 +602,7 @@ int aeron_topology_check_cluster_locality(const int *cpus, int cpu_count, FILE* 
             }
         }
 
-        fprintf(output, "cpuset spans %d CPU clusters (cluster IDs: %s)", cluster_id_count, id_list_buf);
+        fprintf(output, "cpuset spans %d CPU clusters (cluster IDs: %s)\n", cluster_id_count, id_list_buf);
         result++;
     }
 

--- a/aeron-driver/src/main/c/aeron_topology.c
+++ b/aeron-driver/src/main/c/aeron_topology.c
@@ -46,8 +46,8 @@ static int aeron_topology_cmp_int(const void *a, const void *b)
 
 static int aeron_topology_cmp_core_by_prime(const void *a, const void *b)
 {
-    const aeron_topology_core_t *ca = (const aeron_topology_core_t *)a;
-    const aeron_topology_core_t *cb = (const aeron_topology_core_t *)b;
+    const aeron_topology_core_t *ca = a;
+    const aeron_topology_core_t *cb = b;
     if (0 == ca->cpu_count)
     {
         return 1;
@@ -326,31 +326,6 @@ static int aeron_topology_format_cpulist(const int *cpus, int cpu_count, char *b
     return written;
 }
 
-static int aeron_topology_append_warning(char ***warnings, int *count, int *capacity, const char *msg)
-{
-    if (*count == *capacity)
-    {
-        int new_capacity = *capacity == 0 ? 4 : *capacity * 2;
-        if (aeron_reallocf((void **)warnings, sizeof(char *) * new_capacity) < 0)
-        {
-            AERON_APPEND_ERR("%s", "");
-            return -1;
-        }
-        *capacity = new_capacity;
-    }
-
-    size_t len = strlen(msg);
-    char *copy = NULL;
-    if (aeron_alloc((void **)&copy, len + 1) < 0)
-    {
-        AERON_APPEND_ERR("%s", "");
-        return -1;
-    }
-    memcpy(copy, msg, len + 1);
-    (*warnings)[(*count)++] = copy;
-    return 0;
-}
-
 void aeron_topology_cores_free(aeron_topology_core_t *cores, int core_count)
 {
     if (NULL == cores)
@@ -362,19 +337,6 @@ void aeron_topology_cores_free(aeron_topology_core_t *cores, int core_count)
         aeron_free(cores[i].cpus);
     }
     aeron_free(cores);
-}
-
-void aeron_topology_warnings_free(char **warnings, int warning_count)
-{
-    if (NULL == warnings)
-    {
-        return;
-    }
-    for (int i = 0; i < warning_count; i++)
-    {
-        aeron_free(warnings[i]);
-    }
-    aeron_free(warnings);
 }
 
 int aeron_topology_read(
@@ -495,15 +457,9 @@ int aeron_topology_all_of(
     return 0;
 }
 
-int aeron_topology_check_alignment(
-    const int *cpus,
-    const int cpu_count,
-    char ***warnings_out,
-    int *warning_count_out)
+int aeron_topology_check_alignment(const int *cpus, const int cpu_count, FILE *output)
 {
-    char **warnings = NULL;
-    int warning_count = 0;
-    int warning_capacity = 0;
+    int result = 0;
 
     aeron_topology_core_group_t *groups = NULL;
     int group_count = 0;
@@ -528,46 +484,25 @@ int aeron_topology_check_alignment(
             char cpulist_buf[4096];
             aeron_topology_format_cpulist(groups[i].missing, groups[i].missing_count, cpulist_buf, sizeof(cpulist_buf));
 
-            char warning_buf[4096 + 128];
-            snprintf(
-                warning_buf, sizeof(warning_buf),
+            fprintf(
+                output,
                 "cpuset is missing sibling CPU(s) %s of the core containing CPU %d (partial core in cpuset)",
                 cpulist_buf, groups[i].present[0]);
 
-            if (aeron_topology_append_warning(&warnings, &warning_count, &warning_capacity, warning_buf) < 0)
-            {
-                aeron_topology_core_groups_free(groups, group_count);
-                aeron_topology_warnings_free(warnings, warning_count);
-                return -1;
-            }
+            result++;
         }
     }
 
-    aeron_topology_core_groups_free(groups, group_count);
-    *warnings_out = warnings;
-    *warning_count_out = warning_count;
-    return 0;
+    return result;
 }
 
-int aeron_topology_check_l3_locality(
-    const int *cpus,
-    const int cpu_count,
-    char *warning_buf,
-    const int warning_buf_len)
+int aeron_topology_check_l3_locality(const int *cpus, const int cpu_count, FILE* output)
 {
-    if (!(NULL != warning_buf && 0 < warning_buf_len))
-    {
-        AERON_SET_ERR(EINVAL, "%s", "invalid warning buffer");
-        return -1;
-    }
-
     if (AERON_TOPOLOGY_MAX_CPU_ID < cpu_count)
     {
         AERON_SET_ERR(EINVAL, "cpu count %d is greater than max cpu count", cpu_count);
         return -1;
     }
-
-    warning_buf[0] = '\0';
 
     if (cpu_count < 2)
     {
@@ -590,7 +525,7 @@ int aeron_topology_check_l3_locality(
         {
             if (!seen[cpus[j]])
             {
-                snprintf(warning_buf, warning_buf_len, "%s", "cpuset spans multiple L3 cache domains");
+                fprintf(output, "%s", "cpuset spans multiple L3 cache domains");
             }
         }
     }
@@ -602,29 +537,19 @@ int aeron_topology_check_l3_locality(
     return 0;
 }
 
-int aeron_topology_check_cluster_locality(
-    const int *cpus,
-    int cpu_count,
-    char *warning_buf,
-    const int warning_buf_len)
+int aeron_topology_check_cluster_locality(const int *cpus, int cpu_count, FILE* output)
 {
-    if (!(NULL != warning_buf && 0 < warning_buf_len))
-    {
-        AERON_SET_ERR(EINVAL, "%s", "invalid warning buffer");
-        return -1;
-    }
-
     if (AERON_TOPOLOGY_MAX_CPU_ID < cpu_count)
     {
         AERON_SET_ERR(EINVAL, "cpu count %d is greater than max cpu count", cpu_count);
         return -1;
     }
 
-    warning_buf[0] = '\0';
+    int result = 0;
 
     if (cpu_count < 2)
     {
-        return 0;
+        return result;
     }
 
     // --- Cluster check ---
@@ -674,11 +599,9 @@ int aeron_topology_check_cluster_locality(
             }
         }
 
-        snprintf(
-            warning_buf, warning_buf_len,
-            "cpuset spans %d CPU clusters (cluster IDs: %s)",
-            cluster_id_count, id_list_buf);
+        fprintf(output, "cpuset spans %d CPU clusters (cluster IDs: %s)", cluster_id_count, id_list_buf);
+        result++;
     }
 
-    return 0;
+    return result;
 }

--- a/aeron-driver/src/main/c/aeron_topology.c
+++ b/aeron-driver/src/main/c/aeron_topology.c
@@ -513,9 +513,11 @@ int aeron_topology_check_l3_locality(const char* sys_cpu_root, const int *cpus, 
         return -1;
     }
 
+    int warnings = 0;
+
     if (cpu_count < 2)
     {
-        return 0;
+        return warnings;
     }
 
     uint8_t seen[AERON_TOPOLOGY_MAX_CPU_ID] = { 0 };
@@ -535,6 +537,8 @@ int aeron_topology_check_l3_locality(const char* sys_cpu_root, const int *cpus, 
             if (!seen[cpus[j]])
             {
                 fprintf(output, "%s", "WARNING: cpuset spans multiple L3 cache domains\n");
+                warnings++;
+                break;
             }
         }
     }
@@ -544,7 +548,7 @@ int aeron_topology_check_l3_locality(const char* sys_cpu_root, const int *cpus, 
     }
 
     aeron_free(peers);
-    return 0;
+    return warnings;
 }
 
 int aeron_topology_check_cluster_locality(const char* sys_cpu_root, const int *cpus, int cpu_count, FILE* output)

--- a/aeron-driver/src/main/c/aeron_topology.h
+++ b/aeron-driver/src/main/c/aeron_topology.h
@@ -22,12 +22,6 @@
 #define AERON_TOPOLOGY_SYS_CPU_PATH "/sys/devices/system/cpu"
 
 /**
- * Overrideable root of the kernel's per-CPU sysfs tree. Defaults to
- * AERON_TOPOLOGY_SYS_CPU_PATH; tests may redirect to a fake sysfs directory.
- */
-extern const char *aeron_topology_sys_cpu_path;
-
-/**
  * The set of logical CPU siblings that share a physical core, filtered to
  * only those present in the cpuset being processed. Sorted ascending;
  * cpus[0] is the prime (lowest-numbered) thread.
@@ -44,6 +38,7 @@ aeron_topology_core_t;
  * Each returned Core contains only the CPUs from cpus that belong to that
  * physical core, sorted ascending. The returned array is sorted by prime thread.
  *
+ * @param sys_cpu_root of the sys fs filesystem to access cpu information.
  * @param cpus input array of logical CPU IDs to inspect
  * @param cpu_count number of entries in cpus
  * @param cores output array allocated within this function; free with aeron_topology_cores_free
@@ -51,6 +46,7 @@ aeron_topology_core_t;
  * @return 0 on success, -1 on failure
  */
 int aeron_topology_read(
+    const char *sys_cpu_root,
     const int *cpus,
     int cpu_count,
     aeron_topology_core_t **cores,
@@ -91,32 +87,35 @@ int aeron_topology_all_of(
  * logical sibling threads are in cpus. Returns one warning string per partial
  * core. Best-effort: if sysfs is unavailable warnings will be empty.
  *
+ * @param sys_cpu_root of the sys fs filesystem to access cpu information.
  * @param cpus input array of CPU IDs
  * @param cpu_count number of entries in cpus
  * @param output to write the warnings to.
  * @return the count of the number of warnings or -1 on error.
  */
-int aeron_topology_check_alignment(const int *cpus, int cpu_count, FILE *output);
+int aeron_topology_check_alignment(const char* sys_cpu_root, const int *cpus, int cpu_count, FILE *output);
 
 /**
  * Check that all CPUs in cpus share the same L3 cache domain.
  *
- * @param cpus input array of CPU IDs
- * @param cpu_count number of entries in cpus
- * @param output buffer to write the warning to, if any. Will be length 0 if no warnings.
+ * @param sys_cpu_root  of the sys fs filesystem to access cpu information.
+ * @param cpus          input array of CPU IDs
+ * @param cpu_count     number of entries in cpus
+ * @param output        buffer to write the warning to, if any. Will be length 0 if no warnings.
  * @return the count of the number of warnings or -1 on error.
  */
-int aeron_topology_check_cluster_locality(const int *cpus, int cpu_count, FILE* output);
+int aeron_topology_check_cluster_locality(const char* sys_cpu_root, const int *cpus, int cpu_count, FILE* output);
 
 /**
  * Check that all CPUs in cpus share the same CPU cluster.
  *
+ * @param sys_cpu_root of the sys fs filesystem to access cpu information.
  * @param cpus input array of CPU IDs
  * @param cpu_count number of entries in cpus
  * @param output
  * @return the count of the number of warnings or -1 on error.
  */
-int aeron_topology_check_l3_locality(const int *cpus, int cpu_count, FILE* output);
+int aeron_topology_check_l3_locality(const char* sys_cpu_root, const int *cpus, int cpu_count, FILE* output);
 
 /**
  * Free an array of cores allocated by aeron_topology_read.

--- a/aeron-driver/src/main/c/aeron_topology.h
+++ b/aeron-driver/src/main/c/aeron_topology.h
@@ -30,7 +30,7 @@ extern const char *aeron_topology_sys_cpu_path;
  * only those present in the cpuset being processed. Sorted ascending;
  * cpus[0] is the prime (lowest-numbered) thread.
  */
-typedef struct aeron_topology_core_st
+typedef struct aeron_topology_core_stct
 {
     int *cpus;
     int cpu_count;
@@ -103,31 +103,40 @@ int aeron_topology_check_alignment(
     int *warning_count);
 
 /**
- * Check that all CPUs in cpus share the same L3 cache domain and CPU cluster.
- * Returns at most one warning per violation (two total). Best-effort: if the
- * relevant sysfs files are absent the corresponding check is skipped silently.
+ * Check that all CPUs in cpus share the same L3 cache domain.
  *
  * @param cpus input array of CPU IDs
  * @param cpu_count number of entries in cpus
- * @param warnings output array of warning strings allocated within this function;
- *                 free with aeron_topology_warnings_free
- * @param warning_count number of warnings
+ * @param warning_buf buffer to write the warning to, if any. Will be length 0 if no warnings.
+ * @param warning_buf_len available bytes in supplied buffer.
  * @return 0 on success (even with warnings), -1 on memory allocation failure
  */
-int aeron_topology_check_locality(
+int aeron_topology_check_cluster_locality(
     const int *cpus,
     int cpu_count,
-    char ***warnings,
-    int *warning_count);
+    char *warning_buf,
+    int warning_buf_len);
+
+/**
+ * Check that all CPUs in cpus share the same CPU cluster.
+ *
+ * @param cpus input array of CPU IDs
+ * @param cpu_count number of entries in cpus
+ * @param warning_buf buffer to write the warning to, if any. Will be length 0 if no warnings.
+ * @param warning_buf_len available bytes in supplied buffer.
+ * @return 0 on success (even with warnings), -1 on memory allocation failure
+ */
+int aeron_topology_check_l3_locality(
+    const int *cpus,
+    int cpu_count,
+    char *warning_buf,
+    int warning_buf_len);
 
 /**
  * Free an array of cores allocated by aeron_topology_read.
  */
 void aeron_topology_cores_free(aeron_topology_core_t *cores, int core_count);
 
-/**
- * Free an array of warning strings allocated by aeron_topology_check_*.
- */
 void aeron_topology_warnings_free(char **warnings, int warning_count);
 
 #endif //AERON_TOPOLOGY_H

--- a/aeron-driver/src/main/c/aeron_topology.h
+++ b/aeron-driver/src/main/c/aeron_topology.h
@@ -17,6 +17,8 @@
 #ifndef AERON_TOPOLOGY_H
 #define AERON_TOPOLOGY_H
 
+#include <stdio.h>
+
 #define AERON_TOPOLOGY_SYS_CPU_PATH "/sys/devices/system/cpu"
 
 /**
@@ -91,52 +93,34 @@ int aeron_topology_all_of(
  *
  * @param cpus input array of CPU IDs
  * @param cpu_count number of entries in cpus
- * @param warnings output array of warning strings allocated within this function;
- *                 free with aeron_topology_warnings_free
- * @param warning_count number of warnings
- * @return 0 on success (even with warnings), -1 on memory allocation failure
+ * @param output to write the warnings to.
+ * @return the count of the number of warnings or -1 on error.
  */
-int aeron_topology_check_alignment(
-    const int *cpus,
-    int cpu_count,
-    char ***warnings,
-    int *warning_count);
+int aeron_topology_check_alignment(const int *cpus, int cpu_count, FILE *output);
 
 /**
  * Check that all CPUs in cpus share the same L3 cache domain.
  *
  * @param cpus input array of CPU IDs
  * @param cpu_count number of entries in cpus
- * @param warning_buf buffer to write the warning to, if any. Will be length 0 if no warnings.
- * @param warning_buf_len available bytes in supplied buffer.
- * @return 0 on success (even with warnings), -1 on memory allocation failure
+ * @param output buffer to write the warning to, if any. Will be length 0 if no warnings.
+ * @return the count of the number of warnings or -1 on error.
  */
-int aeron_topology_check_cluster_locality(
-    const int *cpus,
-    int cpu_count,
-    char *warning_buf,
-    int warning_buf_len);
+int aeron_topology_check_cluster_locality(const int *cpus, int cpu_count, FILE* output);
 
 /**
  * Check that all CPUs in cpus share the same CPU cluster.
  *
  * @param cpus input array of CPU IDs
  * @param cpu_count number of entries in cpus
- * @param warning_buf buffer to write the warning to, if any. Will be length 0 if no warnings.
- * @param warning_buf_len available bytes in supplied buffer.
- * @return 0 on success (even with warnings), -1 on memory allocation failure
+ * @param output
+ * @return the count of the number of warnings or -1 on error.
  */
-int aeron_topology_check_l3_locality(
-    const int *cpus,
-    int cpu_count,
-    char *warning_buf,
-    int warning_buf_len);
+int aeron_topology_check_l3_locality(const int *cpus, int cpu_count, FILE* output);
 
 /**
  * Free an array of cores allocated by aeron_topology_read.
  */
 void aeron_topology_cores_free(aeron_topology_core_t *cores, int core_count);
-
-void aeron_topology_warnings_free(char **warnings, int warning_count);
 
 #endif //AERON_TOPOLOGY_H

--- a/aeron-driver/src/main/c/aeron_topology.h
+++ b/aeron-driver/src/main/c/aeron_topology.h
@@ -1,0 +1,133 @@
+/*
+* Copyright 2026 Adaptive Financial Consulting Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef AERON_TOPOLOGY_H
+#define AERON_TOPOLOGY_H
+
+#define AERON_TOPOLOGY_SYS_CPU_PATH "/sys/devices/system/cpu"
+
+/**
+ * Overrideable root of the kernel's per-CPU sysfs tree. Defaults to
+ * AERON_TOPOLOGY_SYS_CPU_PATH; tests may redirect to a fake sysfs directory.
+ */
+extern const char *aeron_topology_sys_cpu_path;
+
+/**
+ * The set of logical CPU siblings that share a physical core, filtered to
+ * only those present in the cpuset being processed. Sorted ascending;
+ * cpus[0] is the prime (lowest-numbered) thread.
+ */
+typedef struct aeron_topology_core_st
+{
+    int *cpus;
+    int cpu_count;
+}
+aeron_topology_core_t;
+
+/**
+ * Read one Core per physical core that has at least one CPU in cpus.
+ * Each returned Core contains only the CPUs from cpus that belong to that
+ * physical core, sorted ascending. The returned array is sorted by prime thread.
+ *
+ * @param cpus input array of logical CPU IDs to inspect
+ * @param cpu_count number of entries in cpus
+ * @param cores output array allocated within this function; free with aeron_topology_cores_free
+ * @param core_count number of entries in cores
+ * @return 0 on success, -1 on failure
+ */
+int aeron_topology_read(
+    const int *cpus,
+    int cpu_count,
+    aeron_topology_core_t **cores,
+    int *core_count);
+
+/**
+ * Return the prime (lowest-numbered) sibling of each core.
+ *
+ * @param cores input array of cores
+ * @param core_count number of entries in cores
+ * @param primes output array allocated within this function
+ * @param prime_count number of entries in primes
+ * @return 0 on success, -1 on failure
+ */
+int aeron_topology_primes_of(
+    const aeron_topology_core_t *cores,
+    int core_count,
+    int **primes,
+    int *prime_count);
+
+/**
+ * Return all logical CPUs across all provided cores, in core-then-sibling order.
+ *
+ * @param cores input array of cores
+ * @param core_count number of entries in cores
+ * @param cpus output array allocated within this function
+ * @param cpu_count number of entries in cpus
+ * @return 0 on success, -1 on failure
+ */
+int aeron_topology_all_of(
+    const aeron_topology_core_t *cores,
+    int core_count,
+    int **cpus,
+    int *cpu_count);
+
+/**
+ * Check that for every physical core touching cpus, either all or none of its
+ * logical sibling threads are in cpus. Returns one warning string per partial
+ * core. Best-effort: if sysfs is unavailable warnings will be empty.
+ *
+ * @param cpus input array of CPU IDs
+ * @param cpu_count number of entries in cpus
+ * @param warnings output array of warning strings allocated within this function;
+ *                 free with aeron_topology_warnings_free
+ * @param warning_count number of warnings
+ * @return 0 on success (even with warnings), -1 on memory allocation failure
+ */
+int aeron_topology_check_alignment(
+    const int *cpus,
+    int cpu_count,
+    char ***warnings,
+    int *warning_count);
+
+/**
+ * Check that all CPUs in cpus share the same L3 cache domain and CPU cluster.
+ * Returns at most one warning per violation (two total). Best-effort: if the
+ * relevant sysfs files are absent the corresponding check is skipped silently.
+ *
+ * @param cpus input array of CPU IDs
+ * @param cpu_count number of entries in cpus
+ * @param warnings output array of warning strings allocated within this function;
+ *                 free with aeron_topology_warnings_free
+ * @param warning_count number of warnings
+ * @return 0 on success (even with warnings), -1 on memory allocation failure
+ */
+int aeron_topology_check_locality(
+    const int *cpus,
+    int cpu_count,
+    char ***warnings,
+    int *warning_count);
+
+/**
+ * Free an array of cores allocated by aeron_topology_read.
+ */
+void aeron_topology_cores_free(aeron_topology_core_t *cores, int core_count);
+
+/**
+ * Free an array of warning strings allocated by aeron_topology_check_*.
+ */
+void aeron_topology_warnings_free(char **warnings, int warning_count);
+
+#endif //AERON_TOPOLOGY_H

--- a/aeron-driver/src/main/c/aeronmd.c
+++ b/aeron-driver/src/main/c/aeronmd.c
@@ -126,6 +126,8 @@ int main(int argc, char **argv)
         goto cleanup;
     }
 
+    // aeron_cpuset_affinity.....
+
     // preserve overridden start function and state
     context->agent_on_start_func_delegate = context->agent_on_start_func;
     context->agent_on_start_state_delegate = context->agent_on_start_state;

--- a/aeron-driver/src/main/c/aeronmd.c
+++ b/aeron-driver/src/main/c/aeronmd.c
@@ -32,7 +32,7 @@
 #include "aeron_driver_context.h"
 #include "util/aeron_properties_util.h"
 #include "util/aeron_strutil.h"
-#include "util/aeron_error.h"
+#include "aeron_driver.h"
 
 volatile int exit_status = AERON_NULL_VALUE;
 
@@ -126,7 +126,12 @@ int main(int argc, char **argv)
         goto cleanup;
     }
 
-    // aeron_cpuset_affinity.....
+    if (aeron_driver_apply_cpuset_affinity(context) < 0)
+    {
+        fprintf(stderr, "ERROR: apply cpuset affinity %s\n", aeron_errmsg());
+        AERON_SET_RELEASE(exit_status, EXIT_FAILURE);
+        goto cleanup;
+    }
 
     // preserve overridden start function and state
     context->agent_on_start_func_delegate = context->agent_on_start_func;

--- a/aeron-driver/src/main/c/aeronmd.h
+++ b/aeron-driver/src/main/c/aeronmd.h
@@ -957,6 +957,10 @@ int32_t aeron_driver_context_get_receiver_cpu_affinity(aeron_driver_context_t *c
 int aeron_driver_context_set_sender_cpu_affinity(aeron_driver_context_t *context, int32_t value);
 int32_t aeron_driver_context_get_sender_cpu_affinity(aeron_driver_context_t *context);
 
+#define AERON_DRIVER_CPUSET_AFFINITY_ENV_VAR "AERON_DRIVER_CPUSET_AFFINITY"
+int aeron_driver_context_set_cpuset_affinity(aeron_driver_context_t *context, bool value);
+bool aeron_driver_context_get_cpuset_affinity(aeron_driver_context_t *context);
+
 /**
  * Set the list of filenames to dynamic libraries to load upon context init.
  */

--- a/aeron-driver/src/main/c/aeronmd.h
+++ b/aeron-driver/src/main/c/aeronmd.h
@@ -961,6 +961,10 @@ int32_t aeron_driver_context_get_sender_cpu_affinity(aeron_driver_context_t *con
 int aeron_driver_context_set_cpuset_affinity(aeron_driver_context_t *context, bool value);
 bool aeron_driver_context_get_cpuset_affinity(aeron_driver_context_t *context);
 
+#define AERON_DRIVER_CPUSET_WARNINGS_AS_ERRORS_ENV_VAR "AERON_DRIVER_CPUSET_WARNINGS_AS_ERRORS"
+int aeron_driver_context_set_cpuset_warnings_as_errors(aeron_driver_context_t *context, bool value);
+bool aeron_driver_context_get_cpuset_warnings_as_errors(aeron_driver_context_t *context);
+
 /**
  * Set the list of filenames to dynamic libraries to load upon context init.
  */

--- a/aeron-driver/src/test/c/CMakeLists.txt
+++ b/aeron-driver/src/test/c/CMakeLists.txt
@@ -94,6 +94,8 @@ if (AERON_UNIT_TESTS)
     set_tests_properties(c_terminate_test PROPERTIES TIMEOUT 60)
     set_tests_properties(c_terminate_test PROPERTIES RUN_SERIAL TRUE)
 
+    aeron_driver_test(cpuset_test aeron_cpuset_test.cpp)
+
     aeron_driver_test(c_system_test aeron_c_system_test.cpp)
     set_tests_properties(c_system_test PROPERTIES TIMEOUT 120)
     set_tests_properties(c_system_test PROPERTIES RUN_SERIAL TRUE)
@@ -135,5 +137,9 @@ if (AERON_UNIT_TESTS)
         target_link_libraries(aeronmd_signal_test aeron gmock_main ${CMAKE_THREAD_LIBS_INIT} ${AERON_LIB_WINSOCK_LIBS})
         add_test(NAME aeronmd_signal_test COMMAND aeronmd_signal_test $<TARGET_FILE:aeronmd>)
     endif ()
+
+#    aeron_driver_test(cpuset_test aeron_cpuset_test.cpp)
+#    if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
+#    endif ()
 
 endif ()

--- a/aeron-driver/src/test/c/CMakeLists.txt
+++ b/aeron-driver/src/test/c/CMakeLists.txt
@@ -94,8 +94,6 @@ if (AERON_UNIT_TESTS)
     set_tests_properties(c_terminate_test PROPERTIES TIMEOUT 60)
     set_tests_properties(c_terminate_test PROPERTIES RUN_SERIAL TRUE)
 
-    aeron_driver_test(cpuset_test aeron_cpuset_test.cpp)
-
     aeron_driver_test(c_system_test aeron_c_system_test.cpp)
     set_tests_properties(c_system_test PROPERTIES TIMEOUT 120)
     set_tests_properties(c_system_test PROPERTIES RUN_SERIAL TRUE)
@@ -136,6 +134,10 @@ if (AERON_UNIT_TESTS)
         target_compile_definitions(aeronmd_signal_test PUBLIC "_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING")
         target_link_libraries(aeronmd_signal_test aeron gmock_main ${CMAKE_THREAD_LIBS_INIT} ${AERON_LIB_WINSOCK_LIBS})
         add_test(NAME aeronmd_signal_test COMMAND aeronmd_signal_test $<TARGET_FILE:aeronmd>)
+
+
+        aeron_driver_test(cpuset_test aeron_cpuset_test.cpp)
+        aeron_driver_test(topology_test aeron_topology_test.cpp)
     endif ()
 
 #    aeron_driver_test(cpuset_test aeron_cpuset_test.cpp)

--- a/aeron-driver/src/test/c/aeron_cpuset_test.cpp
+++ b/aeron-driver/src/test/c/aeron_cpuset_test.cpp
@@ -83,6 +83,10 @@ protected:
 
 TEST_F(CpusetTest, shouldReadV2Cgroups)
 {
+#ifndef __linux__
+    GTEST_SKIP() << "CGroups only supported on Linux";
+#endif
+
     std::string mountRoot = std::string(m_tempDir) + "/cgroup";
     std::string cgroupRoot = mountRoot + "/user.slice/user-1000.slice";
     ASSERT_EQ(0, aeron_mkdir_recursive(cgroupRoot.c_str(), 0700));
@@ -112,6 +116,10 @@ TEST_F(CpusetTest, shouldReadV2Cgroups)
 
 TEST_F(CpusetTest, shouldReadV2CgroupsInParent)
 {
+#ifndef __linux__
+    GTEST_SKIP() << "CGroups only supported on Linux";
+#endif
+
     std::string mountRoot = std::string(m_tempDir) + "/cgroup";
     std::string cgroupRoot = mountRoot + "/user.slice/user-1000.slice";
     ASSERT_EQ(0, aeron_mkdir_recursive(cgroupRoot.c_str(), 0700));
@@ -141,6 +149,10 @@ TEST_F(CpusetTest, shouldReadV2CgroupsInParent)
 
 TEST_F(CpusetTest, shouldErrorIfNotFoundReadV2Cgroups)
 {
+#ifndef __linux__
+    GTEST_SKIP() << "CGroups only supported on Linux";
+#endif
+
     std::string mountRoot = std::string(m_tempDir) + "/cgroup";
     std::string cgroupRoot = mountRoot + "/user.slice/user-1000.slice";
     ASSERT_EQ(0, aeron_mkdir_recursive(cgroupRoot.c_str(), 0700));
@@ -166,6 +178,10 @@ TEST_F(CpusetTest, shouldErrorIfNotFoundReadV2Cgroups)
 
 TEST_F(CpusetTest, shouldParseCpulist)
 {
+#ifndef __linux__
+    GTEST_SKIP() << "CGroups only supported on Linux";
+#endif
+
     EXPECT_THAT(parseCpulist("0"), ElementsAre(0)) << aeron_errmsg();
     EXPECT_THAT(parseCpulist("7"), ElementsAre(7)) << aeron_errmsg();
     EXPECT_THAT(parseCpulist("3,1,2"), ElementsAre(1, 2, 3)) << aeron_errmsg();
@@ -179,6 +195,10 @@ TEST_F(CpusetTest, shouldParseCpulist)
 
 TEST_F(CpusetTest, shouldNotParseCpulist)
 {
+#ifndef __linux__
+    GTEST_SKIP() << "CGroups only supported on Linux";
+#endif
+
     EXPECT_EQ(-1, parseCpulistError(""));
     EXPECT_THAT(aeron_errmsg(), ContainsRegex("empty string"));
 
@@ -206,6 +226,10 @@ TEST_F(CpusetTest, shouldNotParseCpulist)
 
 TEST_F(CpusetTest, shouldReadCore)
 {
+#ifndef __linux__
+    GTEST_SKIP() << "CGroups only supported on Linux";
+#endif
+
     int *cpus = nullptr;
     int cpu_count = 0;
 

--- a/aeron-driver/src/test/c/aeron_cpuset_test.cpp
+++ b/aeron-driver/src/test/c/aeron_cpuset_test.cpp
@@ -212,4 +212,10 @@ TEST_F(CpusetTest, shouldReadCore)
     aeron_cpuset_cgroup_read_v2(AERON_CPUSET_PROC_SELF_CGROUP, AERON_CPUSET_CGROUP_MOUNT_V2, &cpus, &cpu_count);
 
     EXPECT_NE(0, cpu_count) << aeron_errmsg();
+
+    for (int i = 0; i < cpu_count; i++)
+    {
+        printf("%d ", cpus[i]);
+    }
+    printf("\n");
 }

--- a/aeron-driver/src/test/c/aeron_cpuset_test.cpp
+++ b/aeron-driver/src/test/c/aeron_cpuset_test.cpp
@@ -1,0 +1,151 @@
+/*
+* Copyright 2026 Adaptive Financial Consulting Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <stdlib.h>
+#include <iostream>
+#include <fstream>
+#include <string>
+
+
+extern "C"
+{
+#include "aeron_alloc.h"
+#include "aeron_cpuset.h"
+#include "util/aeron_error.h"
+#include "util/aeron_fileutil.h"
+}
+
+
+#define AERON_CPUSET_TEST_TEMPLATE "cpuset_XXXXXX"
+
+using namespace testing;
+
+class CpusetTest : public Test
+{
+public:
+    CpusetTest() : m_tempDir(nullptr)
+    {
+    }
+
+protected:
+    void SetUp() override
+    {
+        m_tempDir = mkdtemp(m_tempDirArray);
+        std::cout << "m_tempDir: " << m_tempDir << " " << m_tempDirArray << std::endl;
+    }
+
+    void TearDown() override
+    {
+        EXPECT_EQ(0, aeron_delete_directory(m_tempDir)) << aeron_errmsg();
+    }
+
+    static std::vector<int> parseCpulist(const char* text)
+    {
+        int *cpus = nullptr;
+        int cpu_count = 0;
+
+        EXPECT_EQ(0, aeron_cpuset_parse_cpulist(text, &cpus, &cpu_count)) << aeron_errmsg();
+        std::vector<int> actual{cpus, cpus + cpu_count};
+
+        aeron_free(cpus);
+
+        return actual;
+    }
+
+    static int parseCpulistError(const char* text)
+    {
+        int *cpus = nullptr;
+        int cpu_count = 0;
+        int result = aeron_cpuset_parse_cpulist(text, &cpus, &cpu_count);
+        EXPECT_EQ(nullptr, cpus);
+
+        return result;
+    }
+
+    char m_tempDirArray[19] = { "/tmp/cpuset_XXXXXX" };
+    char *m_tempDir;
+};
+
+TEST_F(CpusetTest, shouldReadV2Cgroups)
+{
+    std::string mountRoot = std::string(m_tempDir) + "/cgroup";
+    std::string cgroupRoot = mountRoot + "/user.slice/user-1000.slice";
+    ASSERT_EQ(0, aeron_mkdir_recursive(cgroupRoot.c_str(), 0700));
+
+    std::string cgroupFilename = std::string(m_tempDir) + "/proc-cgroup";
+    std::string effectiveCpusFilename = cgroupRoot + "/cpuset.cpus.effective";
+
+    std::ofstream cgroupFile(cgroupFilename.c_str(), std::ios::out);
+    cgroupFile << "0::/user.slice/user-1000.slice" << std::endl;
+    cgroupFile.close();
+
+    std::ofstream effectiveCgroupFile(effectiveCpusFilename.c_str(), std::ios::out);
+    effectiveCgroupFile << "5-10" << std::endl;
+    effectiveCgroupFile.close();
+
+    int *cpus = nullptr;
+    int cpu_count = 0;
+
+    aeron_cpuset_cgroup_read_v2(cgroupFilename.c_str(), mountRoot.c_str(), &cpus, &cpu_count);
+    ASSERT_NE(nullptr, cpus) << aeron_errmsg();
+
+    std::vector<int> actual{cpus, cpus + cpu_count};
+    EXPECT_THAT(actual, ElementsAre(5, 6, 7, 8, 9, 10));
+
+    aeron_free(cpus);
+}
+
+TEST_F(CpusetTest, shouldParseCpulist)
+{
+    EXPECT_THAT(parseCpulist("0"), ElementsAre(0)) << aeron_errmsg();
+    EXPECT_THAT(parseCpulist("7"), ElementsAre(7)) << aeron_errmsg();
+    EXPECT_THAT(parseCpulist("3,1,2"), ElementsAre(1, 2, 3)) << aeron_errmsg();
+    EXPECT_THAT(parseCpulist("0,0,1"), ElementsAre(0, 1)) << aeron_errmsg();
+    EXPECT_THAT(parseCpulist("0-3"), ElementsAre(0, 1, 2, 3)) << aeron_errmsg();
+    EXPECT_THAT(parseCpulist("4"), ElementsAre(4)) << aeron_errmsg();
+    EXPECT_THAT(parseCpulist("0,2,4-6"), ElementsAre(0, 2, 4, 5, 6)) << aeron_errmsg();
+    EXPECT_THAT(parseCpulist("0-2,6"), ElementsAre(0, 1, 2, 6)) << aeron_errmsg();
+    EXPECT_EQ(2048, parseCpulist("0-2047").size()) << aeron_errmsg();
+}
+
+TEST_F(CpusetTest, shouldNotParseCpulist)
+{
+    EXPECT_EQ(-1, parseCpulistError(""));
+    EXPECT_THAT(aeron_errmsg(), ContainsRegex("empty string"));
+
+    EXPECT_EQ(-1, parseCpulistError("0,"));
+    EXPECT_THAT(aeron_errmsg(), ContainsRegex("trailing comma"));
+
+    EXPECT_EQ(-1, parseCpulistError(",0"));
+    EXPECT_THAT(aeron_errmsg(), ContainsRegex("leading comma"));
+
+    EXPECT_EQ(-1, parseCpulistError("-1"));
+    EXPECT_THAT(aeron_errmsg(), ContainsRegex("negative CPU"));
+
+    EXPECT_EQ(-1, parseCpulistError("0,-1"));
+    EXPECT_THAT(aeron_errmsg(), ContainsRegex("negative CPU"));
+
+    EXPECT_EQ(-1, parseCpulistError("a"));
+    EXPECT_THAT(aeron_errmsg(), ContainsRegex("non-numeric CPU"));
+
+    EXPECT_EQ(-1, parseCpulistError("0-a"));
+    EXPECT_THAT(aeron_errmsg(), ContainsRegex("non-numeric CPU"));
+
+    EXPECT_EQ(-1, parseCpulistError("4-2"));
+    EXPECT_THAT(aeron_errmsg(), ContainsRegex("range end less than start"));
+}

--- a/aeron-driver/src/test/c/aeron_cpuset_test.cpp
+++ b/aeron-driver/src/test/c/aeron_cpuset_test.cpp
@@ -218,4 +218,6 @@ TEST_F(CpusetTest, shouldReadCore)
         printf("%d ", cpus[i]);
     }
     printf("\n");
+
+    aeron_free(cpus);
 }

--- a/aeron-driver/src/test/c/aeron_cpuset_test.cpp
+++ b/aeron-driver/src/test/c/aeron_cpuset_test.cpp
@@ -89,7 +89,7 @@ TEST_F(CpusetTest, shouldReadV2Cgroups)
 
     std::string mountRoot = std::string(m_tempDir) + "/cgroup";
     std::string cgroupRoot = mountRoot + "/user.slice/user-1000.slice";
-    ASSERT_EQ(0, aeron_mkdir_recursive(cgroupRoot.c_str(), 0700));
+    aeron_mkdir_recursive(cgroupRoot.c_str(), 0700);
 
     std::string cgroupFilename = std::string(m_tempDir) + "/proc-cgroup";
     std::string effectiveCpusFilename = cgroupRoot + "/cpuset.cpus.effective";

--- a/aeron-driver/src/test/c/aeron_cpuset_test.cpp
+++ b/aeron-driver/src/test/c/aeron_cpuset_test.cpp
@@ -110,6 +110,60 @@ TEST_F(CpusetTest, shouldReadV2Cgroups)
     aeron_free(cpus);
 }
 
+TEST_F(CpusetTest, shouldReadV2CgroupsInParent)
+{
+    std::string mountRoot = std::string(m_tempDir) + "/cgroup";
+    std::string cgroupRoot = mountRoot + "/user.slice/user-1000.slice";
+    ASSERT_EQ(0, aeron_mkdir_recursive(cgroupRoot.c_str(), 0700));
+
+    std::string cgroupFilename = std::string(m_tempDir) + "/proc-cgroup";
+    std::string effectiveCpusFilename = mountRoot + "/user.slice/cpuset.cpus.effective";
+
+    std::ofstream cgroupFile(cgroupFilename.c_str(), std::ios::out);
+    cgroupFile << "0::/user.slice/user-1000.slice" << std::endl;
+    cgroupFile.close();
+
+    std::ofstream effectiveCgroupFile(effectiveCpusFilename.c_str(), std::ios::out);
+    effectiveCgroupFile << "5-10" << std::endl;
+    effectiveCgroupFile.close();
+
+    int *cpus = nullptr;
+    int cpu_count = 0;
+
+    aeron_cpuset_cgroup_read_v2(cgroupFilename.c_str(), mountRoot.c_str(), &cpus, &cpu_count);
+    ASSERT_NE(nullptr, cpus) << aeron_errmsg();
+
+    std::vector<int> actual{cpus, cpus + cpu_count};
+    EXPECT_THAT(actual, ElementsAre(5, 6, 7, 8, 9, 10));
+
+    aeron_free(cpus);
+}
+
+TEST_F(CpusetTest, shouldErrorIfNotFoundReadV2Cgroups)
+{
+    std::string mountRoot = std::string(m_tempDir) + "/cgroup";
+    std::string cgroupRoot = mountRoot + "/user.slice/user-1000.slice";
+    ASSERT_EQ(0, aeron_mkdir_recursive(cgroupRoot.c_str(), 0700));
+
+    std::string cgroupFilename = std::string(m_tempDir) + "/proc-cgroup";
+    // std::string effectiveCpusFilename = cgroupRoot + "/cpuset.cpus.effective";
+
+    std::ofstream cgroupFile(cgroupFilename.c_str(), std::ios::out);
+    cgroupFile << "0::/user.slice/user-1000.slice" << std::endl;
+    cgroupFile.close();
+
+    // std::ofstream effectiveCgroupFile(effectiveCpusFilename.c_str(), std::ios::out);
+    // effectiveCgroupFile << "5-10" << std::endl;
+    // effectiveCgroupFile.close();
+
+    int *cpus = nullptr;
+    int cpu_count = 0;
+
+    EXPECT_EQ(-1, aeron_cpuset_cgroup_read_v2(cgroupFilename.c_str(), mountRoot.c_str(), &cpus, &cpu_count));
+    EXPECT_EQ(nullptr, cpus);
+}
+
+
 TEST_F(CpusetTest, shouldParseCpulist)
 {
     EXPECT_THAT(parseCpulist("0"), ElementsAre(0)) << aeron_errmsg();
@@ -148,4 +202,14 @@ TEST_F(CpusetTest, shouldNotParseCpulist)
 
     EXPECT_EQ(-1, parseCpulistError("4-2"));
     EXPECT_THAT(aeron_errmsg(), ContainsRegex("range end less than start"));
+}
+
+TEST_F(CpusetTest, shouldReadCore)
+{
+    int *cpus = nullptr;
+    int cpu_count = 0;
+
+    aeron_cpuset_cgroup_read_v2(AERON_CPUSET_PROC_SELF_CGROUP, AERON_CPUSET_CGROUP_MOUNT_V2, &cpus, &cpu_count);
+
+    EXPECT_NE(0, cpu_count) << aeron_errmsg();
 }

--- a/aeron-driver/src/test/c/aeron_cpuset_test.cpp
+++ b/aeron-driver/src/test/c/aeron_cpuset_test.cpp
@@ -46,7 +46,6 @@ protected:
     void SetUp() override
     {
         m_tempDir = mkdtemp(m_tempDirArray);
-        std::cout << "m_tempDir: " << m_tempDir << " " << m_tempDirArray << std::endl;
     }
 
     void TearDown() override
@@ -158,15 +157,10 @@ TEST_F(CpusetTest, shouldErrorIfNotFoundReadV2Cgroups)
     ASSERT_EQ(0, aeron_mkdir_recursive(cgroupRoot.c_str(), 0700));
 
     std::string cgroupFilename = std::string(m_tempDir) + "/proc-cgroup";
-    // std::string effectiveCpusFilename = cgroupRoot + "/cpuset.cpus.effective";
 
     std::ofstream cgroupFile(cgroupFilename.c_str(), std::ios::out);
     cgroupFile << "0::/user.slice/user-1000.slice" << std::endl;
     cgroupFile.close();
-
-    // std::ofstream effectiveCgroupFile(effectiveCpusFilename.c_str(), std::ios::out);
-    // effectiveCgroupFile << "5-10" << std::endl;
-    // effectiveCgroupFile.close();
 
     int *cpus = nullptr;
     int cpu_count = 0;
@@ -224,24 +218,3 @@ TEST_F(CpusetTest, shouldNotParseCpulist)
     EXPECT_THAT(aeron_errmsg(), ContainsRegex("range end less than start"));
 }
 
-TEST_F(CpusetTest, shouldReadCore)
-{
-#ifndef __linux__
-    GTEST_SKIP() << "CGroups only supported on Linux";
-#endif
-
-    int *cpus = nullptr;
-    int cpu_count = 0;
-
-    aeron_cpuset_cgroup_read_v2(AERON_CPUSET_PROC_SELF_CGROUP, AERON_CPUSET_CGROUP_MOUNT_V2, &cpus, &cpu_count);
-
-    EXPECT_NE(0, cpu_count) << aeron_errmsg();
-
-    for (int i = 0; i < cpu_count; i++)
-    {
-        printf("%d ", cpus[i]);
-    }
-    printf("\n");
-
-    aeron_free(cpus);
-}

--- a/aeron-driver/src/test/c/aeron_driver_context_config_test.cpp
+++ b/aeron-driver/src/test/c/aeron_driver_context_config_test.cpp
@@ -22,6 +22,11 @@
 #include "aeron_test_base.h"
 #include "aeronmd.h"
 
+extern "C"
+{
+#include "aeron_driver_context.h"
+}
+
 using namespace aeron;
 
 static const uint32_t DEFAULT_VALUE = UINT32_C(4);
@@ -35,6 +40,9 @@ protected:
     {
         aeron_env_unset(AERON_RECEIVER_IO_VECTOR_CAPACITY_ENV_VAR);
         aeron_env_unset(AERON_SENDER_IO_VECTOR_CAPACITY_ENV_VAR);
+        aeron_env_unset(AERON_LOW_FILE_STORE_WARNING_THRESHOLD_ENV_VAR);
+        aeron_env_unset(AERON_NAK_UNICAST_DELAY_ENV_VAR);
+        aeron_env_unset(AERON_NAK_UNICAST_RETRY_DELAY_RATIO_ENV_VAR);
     }
 };
 
@@ -303,4 +311,77 @@ TEST_F(DriverContextConfigTest, shouldFailInitIfNakDelayComboIsOutOfBounds)
     EXPECT_NE(
         std::string::npos,
         std::string(aeron_errmsg()).find("nak_unicast_delay_ns (1000000000000000) * nak_unicast_retry_delay_ratio (567890473482340000) exceeds 9223372036854775807"));
+}
+
+TEST_F(DriverContextConfigTest, shouldApplyCpusetAffinity)
+{
+    aeron_driver_context_t *context;
+    aeron_env_set(AERON_CONDUCTOR_CPU_AFFINITY_ENV_VAR, "1");
+    aeron_env_set(AERON_SENDER_CPU_AFFINITY_ENV_VAR, "2");
+    aeron_env_set(AERON_RECEIVER_CPU_AFFINITY_ENV_VAR, "3");
+
+    EXPECT_EQ(0, aeron_driver_context_init(&context)) << aeron_errmsg();
+    EXPECT_EQ(1, aeron_driver_context_get_conductor_cpu_affinity(context));
+    EXPECT_EQ(2, aeron_driver_context_get_sender_cpu_affinity(context));
+    EXPECT_EQ(3, aeron_driver_context_get_receiver_cpu_affinity(context));
+
+    int cpus[4] = { 9, 11, 13, 17 };
+    EXPECT_EQ(0, aeron_driver_context_apply_cpuset_affinity(context, cpus, 4)) << aeron_errmsg();
+
+    EXPECT_EQ(11, aeron_driver_context_get_conductor_cpu_affinity(context));
+    EXPECT_EQ(13, aeron_driver_context_get_sender_cpu_affinity(context));
+    EXPECT_EQ(17, aeron_driver_context_get_receiver_cpu_affinity(context));
+
+    aeron_driver_context_close(context);
+}
+
+TEST_F(DriverContextConfigTest, shouldErrorWithInvalidCpusetAffinity)
+{
+    aeron_driver_context_t *context;
+    int cpus[4] = { 9, 11, 13, 17 };
+
+    EXPECT_EQ(0, aeron_driver_context_init(&context)) << aeron_errmsg();
+
+    aeron_driver_context_set_conductor_cpu_affinity(context, 5);
+    aeron_driver_context_set_sender_cpu_affinity(context, 2);
+    aeron_driver_context_set_receiver_cpu_affinity(context, 3);
+
+    EXPECT_EQ(-1, aeron_driver_context_apply_cpuset_affinity(context, cpus, 4)) << aeron_errmsg();
+
+    aeron_driver_context_set_conductor_cpu_affinity(context, 1);
+    aeron_driver_context_set_sender_cpu_affinity(context, 5);
+    aeron_driver_context_set_receiver_cpu_affinity(context, 3);
+
+    EXPECT_EQ(-1, aeron_driver_context_apply_cpuset_affinity(context, cpus, 4)) << aeron_errmsg();
+
+    aeron_driver_context_set_conductor_cpu_affinity(context, 1);
+    aeron_driver_context_set_sender_cpu_affinity(context, 2);
+    aeron_driver_context_set_receiver_cpu_affinity(context, 5);
+
+    EXPECT_EQ(-1, aeron_driver_context_apply_cpuset_affinity(context, cpus, 4)) << aeron_errmsg();
+
+    aeron_driver_context_close(context);
+}
+
+TEST_F(DriverContextConfigTest, shouldNotChangeAffinityWhenUnset)
+{
+    aeron_driver_context_t *context;
+    int cpus[4] = { 9, 11, 13, 17 };
+
+    EXPECT_EQ(0, aeron_driver_context_init(&context)) << aeron_errmsg();
+
+    aeron_driver_context_set_conductor_cpu_affinity(context, -1);
+    aeron_driver_context_set_sender_cpu_affinity(context, -1);
+    aeron_driver_context_set_receiver_cpu_affinity(context, -1);
+    EXPECT_EQ(-1, aeron_driver_context_get_conductor_cpu_affinity(context));
+    EXPECT_EQ(-1, aeron_driver_context_get_sender_cpu_affinity(context));
+    EXPECT_EQ(-1, aeron_driver_context_get_receiver_cpu_affinity(context));
+
+    EXPECT_EQ(0, aeron_driver_context_apply_cpuset_affinity(context, cpus, 4)) << aeron_errmsg();
+
+    EXPECT_EQ(-1, aeron_driver_context_get_conductor_cpu_affinity(context));
+    EXPECT_EQ(-1, aeron_driver_context_get_sender_cpu_affinity(context));
+    EXPECT_EQ(-1, aeron_driver_context_get_receiver_cpu_affinity(context));
+
+    aeron_driver_context_close(context);
 }

--- a/aeron-driver/src/test/c/aeron_topology_test.cpp
+++ b/aeron-driver/src/test/c/aeron_topology_test.cpp
@@ -66,6 +66,10 @@ protected:
 
 TEST_F(TopologyTest, shouldReadV2Cgroups)
 {
+#ifndef __linux__
+    GTEST_SKIP() << "CGroups only supported on Linux";
+#endif
+
     int *cpus = nullptr;
     int cpu_count = 8;
 

--- a/aeron-driver/src/test/c/aeron_topology_test.cpp
+++ b/aeron-driver/src/test/c/aeron_topology_test.cpp
@@ -104,10 +104,14 @@ TEST_F(TopologyTest, shouldReadV2Cgroups)
 
     aeron_free(warnings);
 
-    warnings = nullptr;
-    warning_count = 0;
+    char warning_buf[4096] = { 0 };
+    const int warning_len = sizeof(warning_buf);
 
-    aeron_topology_check_locality(cpus, cpu_count, &warnings, &warning_count);
+    aeron_topology_check_l3_locality(cpus, cpu_count, warning_buf, warning_len);
+    EXPECT_EQ('\0', warning_buf[0]) << warning_buf;
+
+    aeron_topology_check_cluster_locality(cpus, cpu_count, warning_buf, warning_len);
+    EXPECT_EQ('\0', warning_buf[0]) << warning_buf;
 
     for (int i = 0; i < warning_count; i++)
     {

--- a/aeron-driver/src/test/c/aeron_topology_test.cpp
+++ b/aeron-driver/src/test/c/aeron_topology_test.cpp
@@ -143,7 +143,8 @@ TEST_F(TopologyTest, shouldCheckAlignment)
     int *cpus = nullptr;
     int cpu_count = 8;
 
-    aeron_cpuset_cgroup_read_v2(cgroupFilename.c_str(), mountRoot.c_str(), &cpus, &cpu_count);
+    ASSERT_NE(-1, aeron_cpuset_cgroup_read_v2(cgroupFilename.c_str(), mountRoot.c_str(), &cpus, &cpu_count))
+        << aeron_errmsg();
 
     const int warnings = aeron_topology_check_alignment(sysfsRoot.c_str(), cpus, cpu_count, m_output);
     ASSERT_NE(-1, warnings) << aeron_errmsg();
@@ -178,7 +179,8 @@ TEST_F(TopologyTest, shouldCheckL3Locality)
     int *cpus = nullptr;
     int cpu_count = 8;
 
-    aeron_cpuset_cgroup_read_v2(cgroupFilename.c_str(), mountRoot.c_str(), &cpus, &cpu_count);
+    ASSERT_NE(-1, aeron_cpuset_cgroup_read_v2(cgroupFilename.c_str(), mountRoot.c_str(), &cpus, &cpu_count))
+        << aeron_errmsg();
 
     const int warnings = aeron_topology_check_l3_locality(sysfsRoot.c_str(), cpus, cpu_count, m_output);
     ASSERT_NE(-1, warnings) << aeron_errmsg();
@@ -212,7 +214,8 @@ TEST_F(TopologyTest, shouldCheckClusterLocality)
     int *cpus = nullptr;
     int cpu_count = 8;
 
-    aeron_cpuset_cgroup_read_v2(cgroupFilename.c_str(), mountRoot.c_str(), &cpus, &cpu_count);
+    ASSERT_NE(-1, aeron_cpuset_cgroup_read_v2(cgroupFilename.c_str(), mountRoot.c_str(), &cpus, &cpu_count))
+        << aeron_errmsg();
 
     const int warnings = aeron_topology_check_cluster_locality(sysfsRoot.c_str(), cpus, cpu_count, m_output);
     ASSERT_NE(-1, warnings) << aeron_errmsg();

--- a/aeron-driver/src/test/c/aeron_topology_test.cpp
+++ b/aeron-driver/src/test/c/aeron_topology_test.cpp
@@ -104,4 +104,6 @@ TEST_F(TopologyTest, shouldReadV2Cgroups)
 
     fflush(m_output);
     printf("%s", m_output_ptr);
+    aeron_free(cpus);
+    aeron_topology_cores_free(topology, core_count);
 }

--- a/aeron-driver/src/test/c/aeron_topology_test.cpp
+++ b/aeron-driver/src/test/c/aeron_topology_test.cpp
@@ -1,0 +1,116 @@
+/*
+* Copyright 2026 Adaptive Financial Consulting Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <stdlib.h>
+#include <iostream>
+#include <fstream>
+#include <string>
+
+
+extern "C"
+{
+#include "aeron_alloc.h"
+#include "aeron_cpuset.h"
+#include "aeron_topology.h"
+#include "util/aeron_error.h"
+#include "util/aeron_fileutil.h"
+}
+
+#define AERON_CPUSET_TEST_TEMPLATE "cpuset_XXXXXX"
+
+using namespace testing;
+
+class TopologyTest : public Test
+{
+public:
+    TopologyTest() : m_tempDir(nullptr)
+    {
+    }
+
+protected:
+    void SetUp() override
+    {
+        m_tempDir = mkdtemp(m_tempDirArray);
+        std::cout << "m_tempDir: " << m_tempDir << " " << m_tempDirArray << std::endl;
+    }
+
+    void TearDown() override
+    {
+        EXPECT_EQ(0, aeron_delete_directory(m_tempDir)) << aeron_errmsg();
+    }
+
+    char m_tempDirArray[19] = { "/tmp/cpuset_XXXXXX" };
+    char *m_tempDir;
+};
+
+TEST_F(TopologyTest, shouldReadV2Cgroups)
+{
+    int *cpus = nullptr;
+    int cpu_count = 8;
+
+    aeron_cpuset_cgroup_read_v2(AERON_CPUSET_PROC_SELF_CGROUP, AERON_CPUSET_CGROUP_MOUNT_V2, &cpus, &cpu_count);
+
+    aeron_topology_core_t *topology = nullptr;
+    int core_count = 0;
+
+    ASSERT_NE(-1, aeron_topology_read(cpus, cpu_count, &topology, &core_count)) << aeron_errmsg();
+
+
+    char **warnings = nullptr;
+    int warning_count = 0;
+
+    aeron_topology_check_alignment(cpus, cpu_count, &warnings, &warning_count);
+
+    printf("%s ", "cpus");
+    for (int i = 0; i < cpu_count; i++)
+    {
+        printf("%d ", cpus[i]);
+    }
+    printf("\n");
+
+    printf("%s ", "cores");
+    for (int i = 0; i < core_count; i++)
+    {
+        const int *core_cpus = topology[i].cpus;
+        const int core_cpu_count = topology[i].cpu_count;
+
+        for (int j = 0; j < core_cpu_count; j++)
+        {
+            printf("%d ", core_cpus[j]);
+        }
+        printf("\n");
+    }
+    printf("\n");
+
+    for (int i = 0; i < warning_count; i++)
+    {
+        printf("%s\n", warnings[i]);
+    }
+
+    aeron_free(warnings);
+
+    warnings = nullptr;
+    warning_count = 0;
+
+    aeron_topology_check_locality(cpus, cpu_count, &warnings, &warning_count);
+
+    for (int i = 0; i < warning_count; i++)
+    {
+        printf("%s\n", warnings[i]);
+    }
+}

--- a/aeron-driver/src/test/c/aeron_topology_test.cpp
+++ b/aeron-driver/src/test/c/aeron_topology_test.cpp
@@ -46,7 +46,6 @@ protected:
     void SetUp() override
     {
         m_tempDir = mkdtemp(m_tempDirArray);
-        std::cout << "m_tempDir: " << m_tempDir << " " << m_tempDirArray << std::endl;
         m_output = open_memstream(&m_output_ptr, &m_output_size);
     }
 
@@ -57,6 +56,64 @@ protected:
         free(m_output_ptr);
     }
 
+    static void setupCgroupCpuset(
+        std::string &procSelfCgroupFilename,
+        std::string &cgroupMountRoot,
+        const char *cpuset)
+    {
+        std::string cgroupRoot = cgroupMountRoot + "/user.slice/user-1000.slice";
+        ASSERT_EQ(0, aeron_mkdir_recursive(cgroupRoot.c_str(), 0700));
+
+        std::string effectiveCpusFilename = cgroupMountRoot + "/user.slice/cpuset.cpus.effective";
+
+        std::ofstream cgroupFile(procSelfCgroupFilename.c_str(), std::ios::out);
+        cgroupFile << "0::/user.slice/user-1000.slice" << std::endl;
+        cgroupFile.close();
+
+        std::ofstream effectiveCgroupFile(effectiveCpusFilename.c_str(), std::ios::out);
+        effectiveCgroupFile << cpuset << std::endl;
+        effectiveCgroupFile.close();
+    }
+
+    static void setupSiblings(std::string &sysfsRoot, std::vector<std::pair<int, int>> &siblings)
+    {
+        for (int i = 0; i < static_cast<int>(siblings.size()); i++)
+        {
+            std::string cpuDirectory = sysfsRoot + "/cpu" + std::to_string(i) + "/topology";
+            std::string threadSiblingsList = cpuDirectory + "/thread_siblings_list";
+            aeron_mkdir_recursive(cpuDirectory.c_str(), 0700);
+            std::ofstream os(threadSiblingsList.c_str(), std::ios::out);
+            os << siblings[i].first << '-' << siblings[i].second << std::endl;
+            os.close();
+        }
+    }
+
+    static void setupL3Shared(std::string &sysfsRoot, std::vector<std::pair<int, int>> &l3Peers)
+    {
+        for (int i = 0; i < static_cast<int>(l3Peers.size()); i++)
+        {
+            std::string cpuDirectory = sysfsRoot + "/cpu" + std::to_string(i) + "/cache/index3";
+            std::string threadSiblingsList = cpuDirectory + "/shared_cpu_list";
+            aeron_mkdir_recursive(cpuDirectory.c_str(), 0700);
+            std::ofstream os(threadSiblingsList.c_str(), std::ios::out);
+            os << l3Peers[i].first << '-' << l3Peers[i].second << std::endl;
+            os.close();
+        }
+    }
+
+    static void setupClusterShared(std::string &sysfsRoot, std::vector<int> &clusters)
+    {
+        for (int i = 0; i < static_cast<int>(clusters.size()); i++)
+        {
+            std::string cpuDirectory = sysfsRoot + "/cpu" + std::to_string(i) + "/topology";
+            std::string threadSiblingsList = cpuDirectory + "/cluster_id";
+            aeron_mkdir_recursive(cpuDirectory.c_str(), 0700);
+            std::ofstream os(threadSiblingsList.c_str(), std::ios::out);
+            os << clusters[i] << std::endl;
+            os.close();
+        }
+    }
+
     char m_tempDirArray[19] = { "/tmp/cpuset_XXXXXX" };
     char *m_tempDir;
     FILE *m_output;
@@ -64,51 +121,106 @@ protected:
     size_t m_output_size;
 };
 
-TEST_F(TopologyTest, shouldReadV2Cgroups)
+TEST_F(TopologyTest, shouldCheckAlignment)
 {
 #ifndef __linux__
     GTEST_SKIP() << "CGroups only supported on Linux";
 #endif
 
+    ASSERT_NE(nullptr, m_output);
+
+    std::string mountRoot = std::string(m_tempDir) + "/cgroup";
+    std::string cgroupFilename = std::string(m_tempDir) + "/proc-cgroup";
+    std::string sysfsRoot = std::string(m_tempDir) + "/sysfs";
+    setupCgroupCpuset(cgroupFilename, mountRoot, "5-10");
+    std::vector<std::pair<int, int>> a = {
+        {0, 1}, {0, 1}, {2, 3}, {2, 3}, {4, 5}, {4, 5},
+        {6, 7}, {6, 7}, {8, 9}, {8, 9}, {10, 11}, {10, 11},
+        {12, 13}, {12, 13}, {14, 15}, {14, 15}
+    };
+    setupSiblings(sysfsRoot, a);
+
     int *cpus = nullptr;
     int cpu_count = 8;
 
-    aeron_cpuset_cgroup_read_v2(AERON_CPUSET_PROC_SELF_CGROUP, AERON_CPUSET_CGROUP_MOUNT_V2, &cpus, &cpu_count);
+    aeron_cpuset_cgroup_read_v2(cgroupFilename.c_str(), mountRoot.c_str(), &cpus, &cpu_count);
 
-    aeron_topology_core_t *topology = nullptr;
-    int core_count = 0;
-
-    ASSERT_NE(-1, aeron_topology_read(AERON_TOPOLOGY_SYS_CPU_PATH, cpus, cpu_count, &topology, &core_count))
-        << aeron_errmsg();
-
-    aeron_topology_check_alignment(AERON_TOPOLOGY_SYS_CPU_PATH, cpus, cpu_count, m_output);
-
-    printf("%s ", "cpus");
-    for (int i = 0; i < cpu_count; i++)
-    {
-        printf("%d ", cpus[i]);
-    }
-    printf("\n");
-
-    printf("%s ", "cores");
-    for (int i = 0; i < core_count; i++)
-    {
-        const int *core_cpus = topology[i].cpus;
-        const int core_cpu_count = topology[i].cpu_count;
-
-        for (int j = 0; j < core_cpu_count; j++)
-        {
-            printf("%d ", core_cpus[j]);
-        }
-        printf("\n");
-    }
-    printf("\n");
-
-    aeron_topology_check_l3_locality(AERON_TOPOLOGY_SYS_CPU_PATH, cpus, cpu_count, m_output);
-    aeron_topology_check_cluster_locality(AERON_TOPOLOGY_SYS_CPU_PATH, cpus, cpu_count, m_output);
-
+    const int warnings = aeron_topology_check_alignment(sysfsRoot.c_str(), cpus, cpu_count, m_output);
+    ASSERT_NE(-1, warnings) << aeron_errmsg();
+    EXPECT_EQ(2, warnings);
     fflush(m_output);
-    printf("%s", m_output_ptr);
+
+    ASSERT_NE(nullptr, m_output_ptr);
+    EXPECT_NE(nullptr, strstr(m_output_ptr, "cpuset is missing sibling CPU(s) 4"));
+    EXPECT_NE(nullptr, strstr(m_output_ptr, "cpuset is missing sibling CPU(s) 11"));
+
     aeron_free(cpus);
-    aeron_topology_cores_free(topology, core_count);
+}
+
+TEST_F(TopologyTest, shouldCheckL3Locality)
+{
+#ifndef __linux__
+    GTEST_SKIP() << "CGroups only supported on Linux";
+#endif
+
+    ASSERT_NE(nullptr, m_output);
+
+    std::string mountRoot = std::string(m_tempDir) + "/cgroup";
+    std::string cgroupFilename = std::string(m_tempDir) + "/proc-cgroup";
+    std::string sysfsRoot = std::string(m_tempDir) + "/sysfs";
+    setupCgroupCpuset(cgroupFilename, mountRoot, "5-10");
+    std::vector<std::pair<int, int>> a = {
+        {0, 7}, {0, 7}, {0, 7}, {0, 7}, {0, 7}, {0, 7}, {0, 7}, {0, 7},
+        {8, 15}, {8, 15}, {8, 15}, {8, 15}, {8, 15}, {8, 15}, {8, 15}, {8, 15}
+    };
+    setupL3Shared(sysfsRoot, a);
+
+    int *cpus = nullptr;
+    int cpu_count = 8;
+
+    aeron_cpuset_cgroup_read_v2(cgroupFilename.c_str(), mountRoot.c_str(), &cpus, &cpu_count);
+
+    const int warnings = aeron_topology_check_l3_locality(sysfsRoot.c_str(), cpus, cpu_count, m_output);
+    ASSERT_NE(-1, warnings) << aeron_errmsg();
+    EXPECT_EQ(1, warnings);
+    fflush(m_output);
+
+    ASSERT_NE(nullptr, m_output_ptr);
+    EXPECT_NE(nullptr, strstr(m_output_ptr, "cpuset spans multiple L3 cache domains"));
+
+    aeron_free(cpus);
+}
+
+TEST_F(TopologyTest, shouldCheckClusterLocality)
+{
+#ifndef __linux__
+    GTEST_SKIP() << "CGroups only supported on Linux";
+#endif
+
+    ASSERT_NE(nullptr, m_output);
+
+    std::string mountRoot = std::string(m_tempDir) + "/cgroup";
+    std::string cgroupFilename = std::string(m_tempDir) + "/proc-cgroup";
+    std::string sysfsRoot = std::string(m_tempDir) + "/sysfs";
+    setupCgroupCpuset(cgroupFilename, mountRoot, "5-10");
+    std::vector<int> a = {
+        65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
+        0, 0, 0, 0, 0, 0, 0, 0
+    };
+    setupClusterShared(sysfsRoot, a);
+
+    int *cpus = nullptr;
+    int cpu_count = 8;
+
+    aeron_cpuset_cgroup_read_v2(cgroupFilename.c_str(), mountRoot.c_str(), &cpus, &cpu_count);
+
+    const int warnings = aeron_topology_check_cluster_locality(sysfsRoot.c_str(), cpus, cpu_count, m_output);
+    ASSERT_NE(-1, warnings) << aeron_errmsg();
+    EXPECT_EQ(1, warnings);
+    fflush(m_output);
+
+    ASSERT_NE(nullptr, m_output_ptr);
+    EXPECT_NE(nullptr, strstr(m_output_ptr, "cpuset spans 2 CPU clusters"));
+
+    aeron_free(cpus);
 }

--- a/aeron-driver/src/test/c/aeron_topology_test.cpp
+++ b/aeron-driver/src/test/c/aeron_topology_test.cpp
@@ -78,9 +78,10 @@ TEST_F(TopologyTest, shouldReadV2Cgroups)
     aeron_topology_core_t *topology = nullptr;
     int core_count = 0;
 
-    ASSERT_NE(-1, aeron_topology_read(cpus, cpu_count, &topology, &core_count)) << aeron_errmsg();
+    ASSERT_NE(-1, aeron_topology_read(AERON_TOPOLOGY_SYS_CPU_PATH, cpus, cpu_count, &topology, &core_count))
+        << aeron_errmsg();
 
-    aeron_topology_check_alignment(cpus, cpu_count, m_output);
+    aeron_topology_check_alignment(AERON_TOPOLOGY_SYS_CPU_PATH, cpus, cpu_count, m_output);
 
     printf("%s ", "cpus");
     for (int i = 0; i < cpu_count; i++)
@@ -103,8 +104,8 @@ TEST_F(TopologyTest, shouldReadV2Cgroups)
     }
     printf("\n");
 
-    aeron_topology_check_l3_locality(cpus, cpu_count, m_output);
-    aeron_topology_check_cluster_locality(cpus, cpu_count, m_output);
+    aeron_topology_check_l3_locality(AERON_TOPOLOGY_SYS_CPU_PATH, cpus, cpu_count, m_output);
+    aeron_topology_check_cluster_locality(AERON_TOPOLOGY_SYS_CPU_PATH, cpus, cpu_count, m_output);
 
     fflush(m_output);
     printf("%s", m_output_ptr);

--- a/aeron-driver/src/test/c/aeron_topology_test.cpp
+++ b/aeron-driver/src/test/c/aeron_topology_test.cpp
@@ -16,7 +16,7 @@
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
-#include <stdlib.h>
+#include <cstdio>
 #include <iostream>
 #include <fstream>
 #include <string>
@@ -38,7 +38,7 @@ using namespace testing;
 class TopologyTest : public Test
 {
 public:
-    TopologyTest() : m_tempDir(nullptr)
+    TopologyTest() : m_tempDir(nullptr), m_output(nullptr), m_output_ptr(nullptr), m_output_size(0)
     {
     }
 
@@ -47,15 +47,21 @@ protected:
     {
         m_tempDir = mkdtemp(m_tempDirArray);
         std::cout << "m_tempDir: " << m_tempDir << " " << m_tempDirArray << std::endl;
+        m_output = open_memstream(&m_output_ptr, &m_output_size);
     }
 
     void TearDown() override
     {
         EXPECT_EQ(0, aeron_delete_directory(m_tempDir)) << aeron_errmsg();
+        fclose(m_output);
+        free(m_output_ptr);
     }
 
     char m_tempDirArray[19] = { "/tmp/cpuset_XXXXXX" };
     char *m_tempDir;
+    FILE *m_output;
+    char *m_output_ptr;
+    size_t m_output_size;
 };
 
 TEST_F(TopologyTest, shouldReadV2Cgroups)
@@ -70,11 +76,7 @@ TEST_F(TopologyTest, shouldReadV2Cgroups)
 
     ASSERT_NE(-1, aeron_topology_read(cpus, cpu_count, &topology, &core_count)) << aeron_errmsg();
 
-
-    char **warnings = nullptr;
-    int warning_count = 0;
-
-    aeron_topology_check_alignment(cpus, cpu_count, &warnings, &warning_count);
+    aeron_topology_check_alignment(cpus, cpu_count, m_output);
 
     printf("%s ", "cpus");
     for (int i = 0; i < cpu_count; i++)
@@ -97,24 +99,9 @@ TEST_F(TopologyTest, shouldReadV2Cgroups)
     }
     printf("\n");
 
-    for (int i = 0; i < warning_count; i++)
-    {
-        printf("%s\n", warnings[i]);
-    }
+    aeron_topology_check_l3_locality(cpus, cpu_count, m_output);
+    aeron_topology_check_cluster_locality(cpus, cpu_count, m_output);
 
-    aeron_free(warnings);
-
-    char warning_buf[4096] = { 0 };
-    const int warning_len = sizeof(warning_buf);
-
-    aeron_topology_check_l3_locality(cpus, cpu_count, warning_buf, warning_len);
-    EXPECT_EQ('\0', warning_buf[0]) << warning_buf;
-
-    aeron_topology_check_cluster_locality(cpus, cpu_count, warning_buf, warning_len);
-    EXPECT_EQ('\0', warning_buf[0]) << warning_buf;
-
-    for (int i = 0; i < warning_count; i++)
-    {
-        printf("%s\n", warnings[i]);
-    }
+    fflush(m_output);
+    printf("%s", m_output_ptr);
 }


### PR DESCRIPTION
- Read the current process's cgroup and effective cpuset.
- Use the thread affinity setting as an offset into the cpuset.
- Validate that all siblings are in the same cpuset.
- Validate that all of the cpus share the same L3.
- Validate that all of the cpus share the same cluster.
- Toggle the ability to fail if any warnings detected.