### PR TITLE
fix a race condition in client conductor

### DIFF
--- a/aeron-client/src/main/c/aeron_client_conductor.c
+++ b/aeron-client/src/main/c/aeron_client_conductor.c
@@ -1437,7 +1437,7 @@ static int aeron_client_conductor_check_registering_resources(aeron_client_condu
     {
         aeron_client_registering_resource_t *resource = conductor->registering_resources.array[index].resource;
         aeron_client_registration_status_t status;
-        AERON_GET_ACQUIRE(status, resource->registeration_status);
+        AERON_GET_ACQUIRE(status, resource->registration_status);
 
         if (AERON_CLIENT_REGISTRATION_STATUS_AWAITING == status && now_ns > resource->registration_deadline_ns)
         {

--- a/aeron-client/src/main/c/aeron_client_conductor.c
+++ b/aeron-client/src/main/c/aeron_client_conductor.c
@@ -1436,14 +1436,15 @@ static int aeron_client_conductor_check_registering_resources(aeron_client_condu
     for (size_t size = conductor->registering_resources.length, last_index = size - 1, i = size, index = i - 1; i > 0; i--, index--)
     {
         aeron_client_registering_resource_t *resource = conductor->registering_resources.array[index].resource;
+        aeron_client_registration_status_t status;
+        AERON_GET_ACQUIRE(status, resource->registeration_status);
 
-        if (AERON_CLIENT_REGISTRATION_STATUS_AWAITING == resource->registration_status &&
-            now_ns > resource->registration_deadline_ns)
+        if (AERON_CLIENT_REGISTRATION_STATUS_AWAITING == status && now_ns > resource->registration_deadline_ns)
         {
-            AERON_SET_RELEASE(resource->registration_status, AERON_CLIENT_REGISTRATION_STATUS_TIMED_OUT);
+            AERON_SET_RELEASE(status, AERON_CLIENT_REGISTRATION_STATUS_TIMED_OUT);
             work_count++;
         }
-        else if (AERON_CLIENT_REGISTRATION_STATUS_POLL_COMPLETED == resource->registration_status)
+        else if (AERON_CLIENT_REGISTRATION_STATUS_POLL_COMPLETED == status)
         {
             aeron_array_fast_unordered_remove(
                 (uint8_t*)conductor->registering_resources.array,

--- a/aeron-client/src/main/c/aeron_client_conductor.c
+++ b/aeron-client/src/main/c/aeron_client_conductor.c
@@ -1441,7 +1441,7 @@ static int aeron_client_conductor_check_registering_resources(aeron_client_condu
 
         if (AERON_CLIENT_REGISTRATION_STATUS_AWAITING == status && now_ns > resource->registration_deadline_ns)
         {
-            AERON_SET_RELEASE(status, AERON_CLIENT_REGISTRATION_STATUS_TIMED_OUT);
+            AERON_SET_RELEASE(resource->registration_status, AERON_CLIENT_REGISTRATION_STATUS_TIMED_OUT);
             work_count++;
         }
         else if (AERON_CLIENT_REGISTRATION_STATUS_POLL_COMPLETED == status)

--- a/aeron-client/src/main/c/aeron_client_conductor.c
+++ b/aeron-client/src/main/c/aeron_client_conductor.c
@@ -358,7 +358,9 @@ static int aeron_client_conductor_on_error(aeron_client_conductor_t *conductor, 
     for (size_t i = 0, size = conductor->registering_resources.length; i <  size; i++)
     {
         aeron_client_registering_resource_t *resource = conductor->registering_resources.array[i].resource;
-        if (AERON_CLIENT_REGISTRATION_STATUS_AWAITING == resource->registration_status &&
+        aeron_client_registration_status_t status;
+        AERON_GET_ACQUIRE(status, resource->registration_status);
+        if (AERON_CLIENT_REGISTRATION_STATUS_AWAITING == status &&
             response->offending_command_correlation_id == resource->registration_id)
         {
             aeron_client_conductor_on_resource_registration_error(
@@ -441,7 +443,9 @@ static int aeron_client_conductor_on_publication_ready(
     for (size_t i = 0, size = conductor->registering_resources.length, last_index = size - 1; i < size; i++)
     {
         aeron_client_registering_resource_t *resource = conductor->registering_resources.array[i].resource;
-        if (AERON_CLIENT_REGISTRATION_STATUS_AWAITING == resource->registration_status &&
+        aeron_client_registration_status_t status;
+        AERON_GET_ACQUIRE(status, resource->registration_status);
+        if (AERON_CLIENT_REGISTRATION_STATUS_AWAITING == status &&
             response->correlation_id == resource->registration_id)
         {
             char log_file[AERON_MAX_PATH];
@@ -606,7 +610,9 @@ static int aeron_client_conductor_on_subscription_ready(
     for (size_t i = 0, size = conductor->registering_resources.length, last_index = size - 1; i < size; i++)
     {
         aeron_client_registering_resource_t *resource = conductor->registering_resources.array[i].resource;
-        if (AERON_CLIENT_REGISTRATION_STATUS_AWAITING == resource->registration_status &&
+        aeron_client_registration_status_t status;
+        AERON_GET_ACQUIRE(status, resource->registration_status);
+        if (AERON_CLIENT_REGISTRATION_STATUS_AWAITING == status &&
             response->correlation_id == resource->registration_id)
         {
             const char *channel = resource->uri;
@@ -846,7 +852,9 @@ static int aeron_client_conductor_on_counter_ready(aeron_client_conductor_t *con
     for (size_t i = 0, size = conductor->registering_resources.length; i <  size; i++)
     {
         aeron_client_registering_resource_t *resource = conductor->registering_resources.array[i].resource;
-        if (AERON_CLIENT_REGISTRATION_STATUS_AWAITING == resource->registration_status &&
+        aeron_client_registration_status_t status;
+        AERON_GET_ACQUIRE(status, resource->registration_status);
+        if (AERON_CLIENT_REGISTRATION_STATUS_AWAITING == status &&
             response->correlation_id == resource->registration_id)
         {
             aeron_counter_t *counter;
@@ -903,7 +911,9 @@ static int aeron_client_conductor_on_static_counter(aeron_client_conductor_t *co
     for (size_t i = 0, size = conductor->registering_resources.length; i < size; i++)
     {
         aeron_client_registering_resource_t *resource = conductor->registering_resources.array[i].resource;
-        if (AERON_CLIENT_REGISTRATION_STATUS_AWAITING == resource->registration_status &&
+        aeron_client_registration_status_t status;
+        AERON_GET_ACQUIRE(status, resource->registration_status);
+        if (AERON_CLIENT_REGISTRATION_STATUS_AWAITING == status &&
             response->correlation_id == resource->registration_id)
         {
             aeron_counter_t *counter;
@@ -949,7 +959,9 @@ static int aeron_client_conductor_on_next_available_session_id(
     for (size_t i = 0, size = conductor->registering_resources.length; i < size; i++)
     {
         aeron_client_registering_resource_t *resource = conductor->registering_resources.array[i].resource;
-        if (AERON_CLIENT_REGISTRATION_STATUS_AWAITING == resource->registration_status &&
+        aeron_client_registration_status_t status;
+        AERON_GET_ACQUIRE(status, resource->registration_status);
+        if (AERON_CLIENT_REGISTRATION_STATUS_AWAITING == status &&
             response->correlation_id == resource->registration_id)
         {
             resource->resource.next_session_id = response->next_session_id;
@@ -967,7 +979,9 @@ static int aeron_client_conductor_on_operation_success(
     for (size_t i = 0, size = conductor->registering_resources.length; i < size; i++)
     {
         aeron_client_registering_resource_t *resource = conductor->registering_resources.array[i].resource;
-        if (AERON_CLIENT_REGISTRATION_STATUS_AWAITING == resource->registration_status &&
+        aeron_client_registration_status_t status;
+        AERON_GET_ACQUIRE(status, resource->registration_status);
+        if (AERON_CLIENT_REGISTRATION_STATUS_AWAITING == status &&
             response->correlation_id == resource->registration_id)
         {
             AERON_SET_RELEASE(resource->registration_status, AERON_CLIENT_REGISTRATION_STATUS_REGISTERED);

--- a/aeron-driver/src/main/c/aeron_network_publication.c
+++ b/aeron-driver/src/main/c/aeron_network_publication.c
@@ -488,7 +488,9 @@ int aeron_network_publication_setup_message_check(
 
         publication->time_of_last_setup_ns = now_ns;
 
-        if (publication->has_receivers)
+        bool has_receivers;
+        AERON_GET_ACQUIRE(has_receivers, publication->has_receivers);
+        if (has_receivers)
         {
             publication->is_setup_elicited = false;
         }
@@ -666,7 +668,10 @@ int aeron_network_publication_send(aeron_network_publication_t *publication, int
         bool has_spies;
         AERON_GET_ACQUIRE(has_spies, publication->has_spies);
 
-        if (publication->spies_simulate_connection && has_spies && !publication->has_receivers)
+        bool has_receivers;
+        AERON_GET_ACQUIRE(has_receivers, publication->has_receivers);
+
+        if (publication->spies_simulate_connection && has_spies && !has_receivers)
         {
             const int64_t new_snd_pos = aeron_network_publication_max_spy_position(publication, snd_pos);
             aeron_counter_set_release(publication->snd_pos_position.value_addr, new_snd_pos);

--- a/aeron-driver/src/main/c/aeron_publication_image.c
+++ b/aeron-driver/src/main/c/aeron_publication_image.c
@@ -728,7 +728,9 @@ int aeron_publication_image_insert_packet(
                 AERON_SET_RELEASE(image->time_of_last_packet_ns, now_ns);
 
                 const bool is_eos = aeron_publication_image_is_end_of_stream(buffer, length);
-                if (is_eos && !image->is_end_of_stream)
+                bool is_end_of_stream;
+                AERON_GET_ACQUIRE(is_end_of_stream, image->is_end_of_stream);
+                if (is_eos && !is_end_of_stream)
                 {
                     if (aeron_publication_image_all_eos(image, destination, packet_position))
                     {


### PR DESCRIPTION
## [C] Fix TSan race conditions from missing AERON_GET_ACQUIRE

Replace plain reads of cross-thread-shared fields with `AERON_GET_ACQUIRE` to ensure correct memory ordering and prevent stale values detected by ThreadSanitizer.

### `aeron_client_conductor.c`

Eight sites iterating `registering_resources` and reading `resource->registration_status` now acquire-read into a local `status` before the comparison:

| `aeron_client_conductor.c` function | Field | Thread interaction |
|---|---|---|
| `check_registering_resources` | `registration_status` | conductor side of registration state machine |
| `on_error` | `registration_status` | driver response handler reads state written by conductor |
| `on_publication_ready` | `registration_status` | same |
| `on_subscription_ready` | `registration_status` | same |
| `on_counter_ready` | `registration_status` | same |
| `on_static_counter` | `registration_status` | same |
| `on_next_available_session_id` | `registration_status` | same |
| `on_operation_success` | `registration_status` | same |

### `aeron_network_publication.c`

Two sender-thread reads of `has_receivers` now use `AERON_GET_ACQUIRE`, matching `AERON_SET_RELEASE` writes from the conductor thread:

| Location | Field | Thread interaction |
|---|---|---|
| `setup_message_check` | `has_receivers` | sender reads, conductor writes via `AERON_SET_RELEASE` |
| `send` | `has_receivers` | same |

### `aeron_publication_image.c`

One receiver-thread read of `is_end_of_stream` now uses `AERON_GET_ACQUIRE`, matching the `AERON_SET_RELEASE` write from the conductor thread:

| Location | Field | Thread interaction |
|---|---|---|
| `insert_packet` | `is_end_of_stream` | receiver reads, conductor writes via `AERON_SET_RELEASE` |

courtesy of TSAN, deepseek v4 pro and GLM 5.1.

---

> old pr description:
> fix a race condition in client conductor
> <img width="1392" height="608" alt="image" src="https://github.com/user-attachments/assets/2699de6e-0269-4e41-9aa3-46eee05dbf0a" />
> discovered by tsan, didn't run the full test case, but you get the idea.