### PR TITLE
Fixed issue where conductor command drain loop might break out early

### DIFF
--- a/aeron-client/src/main/c/aeron_client_conductor.c
+++ b/aeron-client/src/main/c/aeron_client_conductor.c
@@ -2746,10 +2746,10 @@ void aeron_client_conductor_on_close(aeron_client_conductor_t *conductor)
     /* Free any remove_resource cmds still in the command queue. Every queued remove cmd is
      * an inline message. The drain runs after resource teardown so on_complete fires after the resource is gone,
      * matching the ordering in aeron_client_conductor_on_cmd_remove_resource. */
-    while (0 != aeron_mpsc_rb_read(
-        conductor->command_rb, aeron_client_conductor_drain_pending_cmd_on_close, conductor, SIZE_MAX))
+    while (0 < aeron_mpsc_rb_size(conductor->command_rb))
     {
-        // loop.
+        aeron_mpsc_rb_read(
+            conductor->command_rb, aeron_client_conductor_drain_pending_cmd_on_close, conductor, SIZE_MAX);
     }
 
     aeron_int64_to_ptr_hash_map_for_each(


### PR DESCRIPTION
The previous loop checked for `0 != aeron_mpsc_rb_read()` , assuming `aeron_mpsc_rb_read()` only returns `0` when nothing is left in the queue.  Turns out, `aeron_mpsc_rb_read()` also returns `0` if it hits a padding entry in the queue... meaning "no work done on this call", not "nothing left in the queue".

Found via an intermittent failure in the `shouldDrainQueuedRemoveCmdsFromProducerThreadOnClose` test: https://github.com/aeron-io/aeron/actions/runs/25476783841/job/74794180497