### PR TITLE
[Java] Quiet close components of PersistentSubscription.

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/client/PersistentSubscription.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/client/PersistentSubscription.java
@@ -336,7 +336,7 @@ public final class PersistentSubscription implements AutoCloseable
      */
     public void close()
     {
-        CloseHelper.closeAll(this::closeLive, this::closeReplay, asyncAeronArchive, ctx::close);
+        CloseHelper.quietCloseAll(this::closeLive, this::closeReplay, asyncAeronArchive, ctx::close);
     }
 
     private void closeLive()


### PR DESCRIPTION
Make the closing of the resources consistent with the .Net implementation.  Quiet close is the safer option.