### PR TITLE
[Driver/Java] Rewrite client commands using state machines.

### DIFF
--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -16,7 +16,6 @@
 package io.aeron.driver;
 
 import io.aeron.ChannelUri;
-import io.aeron.ErrorCode;
 import io.aeron.driver.MediaDriver.Context;
 import io.aeron.driver.buffer.LogFactory;
 import io.aeron.driver.buffer.RawLog;
@@ -222,7 +221,7 @@ public final class DriverConductor implements Agent
     private final AtomicCounter imagesRejected;
     private final DutyCycleTracker dutyCycleTracker;
     private final AgentInvoker asyncTaskExecutorInvoker;
-    private boolean asyncClientCommandInFlight;
+    private ClientCommand clientCommand;
 
     DriverConductor(
         final MediaDriver.Context ctx, final AgentInvoker asyncTaskExecutorInvoker, final NameResolver nameResolver)
@@ -315,10 +314,7 @@ public final class DriverConductor implements Agent
 
         int workCount = 0;
         workCount += processTimers(nowNs);
-        if (!asyncClientCommandInFlight)
-        {
-            workCount += clientCommandAdapter.receive();
-        }
+        workCount += processClientCommands();
         workCount += drainCommandQueue();
         workCount += trackStreamPositions(workCount, nowNs);
         workCount += freeEndOfLifeResources(ctx.resourceFreeLimit());
@@ -515,27 +511,11 @@ public final class DriverConductor implements Agent
     void onReResolveEndpoint(
         final String endpoint, final SendChannelEndpoint channelEndpoint, final InetSocketAddress address)
     {
-        executeAsyncTask(
-            () -> UdpChannel.resolve(endpoint, ENDPOINT_PARAM_NAME, true, nameResolver),
-            (asyncResult) ->
-            {
-                try
-                {
-                    final InetSocketAddress newAddress = asyncResult.get();
-                    if (newAddress.isUnresolved())
-                    {
-                        recordError(new AeronEvent("could not re-resolve: endpoint=" + endpoint));
-                    }
-                    else if (address != null && !address.equals(newAddress))
-                    {
-                        senderProxy.onResolutionChange(channelEndpoint, endpoint, newAddress);
-                    }
-                }
-                catch (final Exception ex)
-                {
-                    recordError(ex);
-                }
-            });
+        reResolveEndpointAddress(
+            endpoint,
+            ENDPOINT_PARAM_NAME,
+            address,
+            (newAddress) -> senderProxy.onResolutionChange(channelEndpoint, endpoint, newAddress));
     }
 
     void onReResolveControl(
@@ -544,27 +524,11 @@ public final class DriverConductor implements Agent
         final ReceiveChannelEndpoint channelEndpoint,
         final InetSocketAddress address)
     {
-        executeAsyncTask(
-            () -> UdpChannel.resolve(control, MDC_CONTROL_PARAM_NAME, true, nameResolver),
-            (asyncResult) ->
-            {
-                try
-                {
-                    final InetSocketAddress newAddress = asyncResult.get();
-                    if (newAddress.isUnresolved())
-                    {
-                        recordError(new AeronEvent("could not re-resolve: control=" + control));
-                    }
-                    else if (!address.equals(newAddress))
-                    {
-                        receiverProxy.onResolutionChange(channelEndpoint, udpChannel, newAddress);
-                    }
-                }
-                catch (final Exception ex)
-                {
-                    recordError(ex);
-                }
-            });
+        reResolveEndpointAddress(
+            control,
+            MDC_CONTROL_PARAM_NAME,
+            address,
+            (newAddress) -> receiverProxy.onResolutionChange(channelEndpoint, udpChannel, newAddress));
     }
 
     IpcPublication getSharedIpcPublication(final long streamId, final long responseCorrelationId)
@@ -623,79 +587,49 @@ public final class DriverConductor implements Agent
         final long clientId,
         final boolean isExclusive)
     {
-        executeAsyncClientTask(
-            correlationId,
-            () -> UdpChannel.parse(channel, nameResolver, false),
-            (asyncResult) ->
-            {
-                final UdpChannel udpChannel = asyncResult.get();
-                final ChannelUri channelUri = udpChannel.channelUri();
-                final PublicationParams params =
-                    getPublicationParams(channelUri, ctx, this, streamId, udpChannel.canonicalForm());
-                validateExperimentalFeatures(ctx.enableExperimentalFeatures(), udpChannel);
-                validateEndpointForPublication(udpChannel);
-                validateControlForPublication(udpChannel);
-                validateResponseSubscription(params);
-
-                final SendChannelEndpoint channelEndpoint =
-                    getOrCreateSendChannelEndpoint(params, udpChannel, correlationId);
-
-                NetworkPublication publication = null;
-                if (!isExclusive)
-                {
-                    publication =
-                        findPublication(networkPublications, streamId, channelEndpoint, params.responseCorrelationId);
-                }
-
-                final PublicationImage responsePublicationImage = findResponsePublicationImage(params);
-
-                boolean isNewPublication = false;
-                if (null == publication)
-                {
-                    checkForSessionClash(params.sessionId, streamId, udpChannel.canonicalForm(), channel);
-                    publication = newNetworkPublication(
-                        correlationId, clientId, streamId, channel, udpChannel, channelEndpoint, params, isExclusive);
-                    isNewPublication = true;
-                }
-                else
-                {
-                    confirmMatch(
-                        channelUri,
-                        params,
-                        publication.rawLog(),
-                        publication.sessionId(),
-                        publication.channel(),
-                        publication.initialTermId(),
-                        publication.startingTermId(),
-                        publication.startingTermOffset());
-
-                    validateSpiesSimulateConnection(
-                        params, publication.spiesSimulateConnection(), channel, publication.channel());
-                }
-
-                publicationLinks.add(new PublicationLink(correlationId, getOrAddClient(clientId), publication));
-
-                clientProxy.onPublicationReady(
-                    correlationId,
-                    publication.registrationId(),
-                    streamId,
-                    publication.sessionId(),
-                    publication.rawLog().fileName(),
-                    publication.publisherLimitId(),
-                    channelEndpoint.statusIndicatorCounterId(),
-                    isExclusive);
-
-                if (isNewPublication)
-                {
-                    linkSpies(subscriptionLinks, publication);
-                }
-
-                if (null != responsePublicationImage)
-                {
-                    responsePublicationImage.responseSessionId(publication.sessionId());
-                }
-            });
+        scheduleClientCommand(new AddNetworkPublicationCommand(
+            channel, streamId, correlationId, clientId, isExclusive));
     }
+
+    private void reResolveEndpointAddress(
+        final String endpoint,
+        final String uriParamName,
+        final InetSocketAddress existingAddress,
+        final Consumer<InetSocketAddress> onAddressChange)
+    {
+        asyncExecutorProxy.offer(() ->
+        {
+            try
+            {
+                final InetSocketAddress newAddress = UdpChannel.resolve(endpoint, uriParamName, true, nameResolver);
+                executeOnConductorThread(() ->
+                {
+                    if (newAddress.isUnresolved())
+                    {
+                        recordError(new AeronEvent("could not re-resolve: " + uriParamName + "=" + endpoint));
+                    }
+                    else if (null != existingAddress && !existingAddress.equals(newAddress))
+                    {
+                        onAddressChange.accept(newAddress);
+                    }
+                });
+            }
+            catch (final Exception ex)
+            {
+                recordError(ex); // thread-safe
+            }
+        });
+    }
+
+    private void executeOnConductorThread(final Runnable task)
+    {
+        if (!driverCmdQueue.offer(task))
+        {
+            // unreachable for ManyToOneConcurrentLinkedQueue
+            throw new IllegalStateException(driverCmdQueue.getClass().getSimpleName() + ".offer failed!");
+        }
+    }
+
 
     private PublicationImage findResponsePublicationImage(final PublicationParams params)
     {
@@ -844,6 +778,7 @@ public final class DriverConductor implements Agent
         final SendChannelEndpoint channelEndpoint = publication.channelEndpoint();
         if (channelEndpoint.shouldBeClosed())
         {
+            channelEndpoint.indicateClosing();
             senderProxy.closeSendChannelEndpoint(channelEndpoint);
         }
 
@@ -851,6 +786,7 @@ public final class DriverConductor implements Agent
         activeSessionSet.remove(new SessionKey(publication.sessionId(), publication.streamId(), channel));
     }
 
+    // TODO rename, as it isn't closed yet
     void sendChannelEndpointClosed(final SendChannelEndpoint channelEndpoint)
     {
         final String channel = channelEndpoint.udpChannel().canonicalForm();
@@ -959,6 +895,7 @@ public final class DriverConductor implements Agent
         }
     }
 
+    // TODO rename, as it isn't closed yet
     void receiveChannelEndpointClosed(final ReceiveChannelEndpoint channelEndpoint)
     {
         final String channel = channelEndpoint.subscriptionUdpChannel().canonicalForm();
@@ -1060,39 +997,12 @@ public final class DriverConductor implements Agent
 
     void onAddSendDestination(final long registrationId, final String destinationChannel, final long correlationId)
     {
-        final ChannelUri channelUri = parseUri(destinationChannel);
-        validateDestinationUri(channelUri, destinationChannel);
-        validateSendDestinationUri(channelUri, destinationChannel);
-
-        final SendChannelEndpoint sendChannelEndpoint = findExistingManualSendChannelEndpoint(registrationId);
-
-        executeAsyncClientTask(
-            correlationId,
-            () -> UdpChannel.destinationAddress(channelUri, nameResolver),
-            (asyncResult) ->
-            {
-                final InetSocketAddress dstAddress = asyncResult.get();
-                senderProxy.addDestination(sendChannelEndpoint, channelUri, dstAddress, correlationId);
-                clientProxy.operationSucceeded(correlationId);
-            }
-        );
+        scheduleClientCommand(new AddSendDestinationCommand(registrationId, destinationChannel, correlationId));
     }
 
     void onRemoveSendDestination(final long registrationId, final String destinationChannel, final long correlationId)
     {
-        final ChannelUri channelUri = parseUri(destinationChannel);
-        final SendChannelEndpoint sendChannelEndpoint = findExistingManualSendChannelEndpoint(registrationId);
-
-        executeAsyncClientTask(
-            correlationId,
-            () -> UdpChannel.destinationAddress(channelUri, nameResolver),
-            (asyncResult) ->
-            {
-                final InetSocketAddress dstAddress = asyncResult.get();
-                senderProxy.removeDestination(sendChannelEndpoint, channelUri, dstAddress);
-                clientProxy.operationSucceeded(correlationId);
-            }
-        );
+        scheduleClientCommand(new RemoveSendDestinationCommand(registrationId, destinationChannel, correlationId));
     }
 
     void onRemoveSendDestination(
@@ -1107,52 +1017,7 @@ public final class DriverConductor implements Agent
     void onAddNetworkSubscription(
         final String channel, final int streamId, final long registrationId, final long clientId)
     {
-        executeAsyncClientTask(
-            registrationId,
-            () -> UdpChannel.parse(channel, nameResolver, false),
-            (asyncResult) ->
-            {
-                final UdpChannel udpChannel = asyncResult.get();
-                final ControlMode controlMode = udpChannel.controlMode();
-
-                validateExperimentalFeatures(ctx.enableExperimentalFeatures(), udpChannel);
-                validateControlForSubscription(udpChannel);
-                validateTimestampConfiguration(udpChannel);
-
-                final SubscriptionParams params =
-                    SubscriptionParams.getSubscriptionParams(udpChannel.channelUri(), ctx, 0);
-                checkForClashingSubscription(params, udpChannel, streamId);
-
-                final ReceiveChannelEndpoint channelEndpoint = getOrCreateReceiveChannelEndpoint(
-                    params, udpChannel, registrationId);
-
-                if (ChannelEndpointStatus.CLOSING == channelEndpoint.status())
-                {
-                    clientProxy.onError(
-                        registrationId,
-                        ErrorCode.RESOURCE_TEMPORARILY_UNAVAILABLE,
-                        "ReceiveChannelEndpoint found in CLOSING state, please retry"
-                    );
-                    return;
-                }
-
-                final NetworkSubscriptionLink subscription = new NetworkSubscriptionLink(
-                    registrationId, channelEndpoint, streamId, channel, getOrAddClient(clientId), params);
-
-                subscriptionLinks.add(subscription);
-
-                if (ControlMode.RESPONSE == controlMode)
-                {
-                    channelEndpoint.incResponseRefToStream(subscription.streamId);
-                }
-                else
-                {
-                    addNetworkSubscriptionToReceiver(subscription);
-                }
-
-                clientProxy.onSubscriptionReady(registrationId, channelEndpoint.statusIndicatorCounter().id());
-                linkMatchingImages(subscription);
-            });
+        scheduleClientCommand(new AddNetworkSubscriptionCommand(channel, streamId, registrationId, clientId));
     }
 
     private void addNetworkSubscriptionToReceiver(final NetworkSubscriptionLink subscription)
@@ -1203,36 +1068,7 @@ public final class DriverConductor implements Agent
 
     void onAddSpySubscription(final String channel, final int streamId, final long registrationId, final long clientId)
     {
-        executeAsyncClientTask(
-            registrationId,
-            () -> UdpChannel.parse(channel, nameResolver, false),
-            (asyncResult) ->
-            {
-                final UdpChannel udpChannel = asyncResult.get();
-                final SubscriptionParams params =
-                    SubscriptionParams.getSubscriptionParams(udpChannel.channelUri(), ctx, 0);
-                final SpySubscriptionLink subscriptionLink = new SpySubscriptionLink(
-                    registrationId, udpChannel, streamId, getOrAddClient(clientId), params);
-
-                subscriptionLinks.add(subscriptionLink);
-                clientProxy.onSubscriptionReady(registrationId, ChannelEndpointStatus.NO_ID_ALLOCATED);
-
-                for (int i = 0, size = networkPublications.size(); i < size; i++)
-                {
-                    final NetworkPublication publication = networkPublications.get(i);
-                    if (subscriptionLink.matches(publication) && publication.isAcceptingSubscriptions())
-                    {
-                        clientProxy.onAvailableImage(
-                            publication.registrationId(),
-                            streamId,
-                            publication.sessionId(),
-                            registrationId,
-                            linkSpy(publication, subscriptionLink).id(),
-                            publication.rawLog().fileName(),
-                            IPC_CHANNEL);
-                    }
-                }
-            });
+        scheduleClientCommand(new AddSpySubscriptionCommand(channel, streamId, registrationId, clientId));
     }
 
     void onRemoveSubscription(final long registrationId, final long correlationId)
@@ -1418,96 +1254,13 @@ public final class DriverConductor implements Agent
 
     void onAddRcvSpyDestination(final long registrationId, final String destinationChannel, final long correlationId)
     {
-        executeAsyncClientTask(
-            correlationId,
-            () -> UdpChannel.parse(destinationChannel, nameResolver, false),
-            (asyncResult) ->
-            {
-                final UdpChannel udpChannel = asyncResult.get();
-                final SubscriptionParams params =
-                    SubscriptionParams.getSubscriptionParams(udpChannel.channelUri(), ctx, 0);
-                final SubscriptionLink mdsSubscriptionLink = findMdsSubscriptionLink(subscriptionLinks, registrationId);
-
-                if (null == mdsSubscriptionLink)
-                {
-                    throw new ControlProtocolException(
-                        UNKNOWN_SUBSCRIPTION, "unknown MDS subscription: " + registrationId);
-                }
-
-                final SpySubscriptionLink subscriptionLink = new SpySubscriptionLink(
-                    registrationId,
-                    udpChannel,
-                    mdsSubscriptionLink.streamId(),
-                    mdsSubscriptionLink.aeronClient(),
-                    params);
-
-                subscriptionLinks.add(subscriptionLink);
-                clientProxy.operationSucceeded(correlationId);
-
-                for (int i = 0, size = networkPublications.size(); i < size; i++)
-                {
-                    final NetworkPublication publication = networkPublications.get(i);
-                    if (subscriptionLink.matches(publication) && publication.isAcceptingSubscriptions())
-                    {
-                        clientProxy.onAvailableImage(
-                            publication.registrationId(),
-                            mdsSubscriptionLink.streamId(),
-                            publication.sessionId(),
-                            registrationId,
-                            linkSpy(publication, subscriptionLink).id(),
-                            publication.rawLog().fileName(),
-                            IPC_CHANNEL);
-                    }
-                }
-            });
+        scheduleClientCommand(new AddRcvSpyDestinationCommand(registrationId, destinationChannel, correlationId));
     }
 
     void onAddRcvNetworkDestination(
         final long registrationId, final String destinationChannel, final long correlationId)
     {
-        executeAsyncClientTask(
-            correlationId,
-            () -> UdpChannel.parse(destinationChannel, nameResolver, true),
-            (asyncResult) ->
-            {
-                final UdpChannel udpChannel = asyncResult.get();
-                validateDestinationUri(udpChannel.channelUri(), destinationChannel);
-
-                final SubscriptionLink mdsSubscriptionLink = findMdsSubscriptionLink(subscriptionLinks, registrationId);
-
-                if (null == mdsSubscriptionLink)
-                {
-                    throw new ControlProtocolException(
-                        UNKNOWN_SUBSCRIPTION, "unknown MDS subscription: " + registrationId);
-                }
-
-                final ReceiveChannelEndpoint receiveChannelEndpoint = mdsSubscriptionLink.channelEndpoint();
-
-                AtomicCounter localSocketAddressIndicator = null;
-                ReceiveDestinationTransport transport = null;
-
-                try
-                {
-                    localSocketAddressIndicator = ReceiveLocalSocketAddress.allocate(
-                        tempBuffer,
-                        countersManager,
-                        registrationId,
-                        receiveChannelEndpoint.statusIndicatorCounter().id());
-
-                    transport = new ReceiveDestinationTransport(
-                        udpChannel, ctx, localSocketAddressIndicator, receiveChannelEndpoint);
-
-                    transport.openChannel(null);
-                }
-                catch (final Exception ex)
-                {
-                    CloseHelper.closeAll(localSocketAddressIndicator, transport);
-                    throw ex;
-                }
-
-                receiverProxy.addDestination(receiveChannelEndpoint, transport);
-                clientProxy.operationSucceeded(correlationId);
-            });
+        scheduleClientCommand(new AddRcvNetworkDestinationCommand(registrationId, destinationChannel, correlationId));
     }
 
     void onRemoveRcvDestination(final long registrationId, final String destinationChannel, final long correlationId)
@@ -1542,34 +1295,8 @@ public final class DriverConductor implements Agent
     void onRemoveRcvNetworkDestination(
         final long registrationId, final String destinationChannel, final long correlationId)
     {
-        ReceiveChannelEndpoint receiveChannelEndpoint = null;
-
-        for (int i = 0, size = subscriptionLinks.size(); i < size; i++)
-        {
-            final SubscriptionLink subscriptionLink = subscriptionLinks.get(i);
-            if (registrationId == subscriptionLink.registrationId())
-            {
-                receiveChannelEndpoint = subscriptionLink.channelEndpoint();
-                break;
-            }
-        }
-
-        if (null == receiveChannelEndpoint)
-        {
-            throw new ControlProtocolException(UNKNOWN_SUBSCRIPTION, "unknown subscription: " + registrationId);
-        }
-
-        receiveChannelEndpoint.validateAllowsDestinationControl();
-
-        final ReceiveChannelEndpoint endpoint = receiveChannelEndpoint;
-        executeAsyncClientTask(
-            correlationId,
-            () -> UdpChannel.parse(destinationChannel, nameResolver, true),
-            (asyncResult) ->
-            {
-                receiverProxy.removeDestination(endpoint, asyncResult.get());
-                clientProxy.operationSucceeded(correlationId);
-            });
+        scheduleClientCommand(new RemoveRcvNetworkDestinationCommand(
+            registrationId, destinationChannel, correlationId));
     }
 
     void closeReceiveDestination(final ReceiveDestinationTransport destinationTransport)
@@ -1744,63 +1471,14 @@ public final class DriverConductor implements Agent
         return subscriberPositions;
     }
 
-    private <T> void executeAsyncClientTask(
-        final long correlationId,
-        final Supplier<T> asyncTask,
-        final Consumer<Supplier<T>> command)
+    private void scheduleClientCommand(final ClientCommand cmd)
     {
-        if (asyncExecutorProxy.notConcurrent())
+        if (null != clientCommand)
         {
-            command.accept(asyncTask);
+            throw new IllegalStateException("Command already in progress");
         }
-        else
-        {
-            asyncClientCommandInFlight = true;
-            asyncExecutorProxy.offer(() ->
-            {
-                final AsyncResult<T> asyncResult = AsyncResult.of(asyncTask);
-                addToCommandQueue(() ->
-                {
-                    try
-                    {
-                        command.accept(asyncResult);
-                    }
-                    catch (final Exception ex)
-                    {
-                        clientCommandAdapter.onError(correlationId, ex);
-                    }
-                    finally
-                    {
-                        asyncClientCommandInFlight = false;
-                    }
-                });
-            });
-        }
-    }
 
-    private <T> void executeAsyncTask(final Supplier<T> supplier, final Consumer<Supplier<T>> command)
-    {
-        if (asyncExecutorProxy.notConcurrent())
-        {
-            command.accept(supplier);
-        }
-        else
-        {
-            asyncExecutorProxy.offer(() ->
-            {
-                final AsyncResult<T> asyncResult = AsyncResult.of(supplier);
-                addToCommandQueue(() -> command.accept(asyncResult));
-            });
-        }
-    }
-
-    private void addToCommandQueue(final Runnable cmd)
-    {
-        if (!driverCmdQueue.offer(cmd))
-        {
-            // unreachable for ManyToOneConcurrentLinkedQueue
-            throw new IllegalStateException(driverCmdQueue.getClass().getSimpleName() + ".offer failed!");
-        }
+        clientCommand = cmd;
     }
 
     private static NetworkPublication findPublication(
@@ -2935,6 +2613,36 @@ public final class DriverConductor implements Agent
         return workCount;
     }
 
+    private int processClientCommands()
+    {
+        int workCount = 0;
+
+        if (null == clientCommand)
+        {
+            workCount += clientCommandAdapter.receive();
+        }
+
+        if (null != clientCommand)
+        {
+            ++workCount;
+
+            try
+            {
+                if (clientCommand.execute())
+                {
+                    clientCommand = null;
+                }
+            }
+            catch (final Exception ex)
+            {
+                clientCommandAdapter.onError(clientCommand.correlationId, ex);
+                clientCommand = null;
+            }
+        }
+
+        return workCount;
+    }
+
     private int drainCommandQueue()
     {
         int workCount = 0;
@@ -2952,6 +2660,23 @@ public final class DriverConductor implements Agent
             }
         }
         return workCount;
+    }
+
+    private <T> AsyncResult<T> executeAsync(final Supplier<T> supplier)
+    {
+        final AsyncResult<T> result = new AsyncResult<>();
+        asyncExecutorProxy.offer(() ->
+        {
+            try
+            {
+                result.value = supplier.get();
+            }
+            catch (final Throwable t)
+            {
+                result.error = t;
+            }
+        });
+        return result;
     }
 
     private static void validateChannelBufferLength(
@@ -3107,30 +2832,718 @@ public final class DriverConductor implements Agent
             receiverGroupConsideration == FORCE_TRUE;
     }
 
-    private interface AsyncResult<T> extends Supplier<T>
+    private static final class AsyncResult<T>
     {
-        T get();
+        private volatile T value;
+        private volatile Throwable error;
 
-        static <T> AsyncResult<T> of(final Supplier<T> supplier)
+        T get()
         {
-            try
+            if (null != error)
             {
-                final T value = supplier.get();
-                return () -> value;
+                LangUtil.rethrowUnchecked(error);
             }
-            catch (final Throwable t)
-            {
-                return () ->
-                {
-                    LangUtil.rethrowUnchecked(t);
-                    return null;
-                };
-            }
+
+            return value;
         }
+
     }
 
     private void recordError(final Exception ex)
     {
         ctx.countedErrorHandler().onError(ex);
+    }
+
+    private abstract static class ClientCommand
+    {
+        final long correlationId;
+
+        private ClientCommand(final long correlationId)
+        {
+            this.correlationId = correlationId;
+        }
+
+        abstract boolean execute();
+    }
+
+    private final class AddNetworkPublicationCommand extends ClientCommand
+    {
+        private final String channel;
+        private final int streamId;
+        private final long clientId;
+        private final boolean isExclusive;
+        private AsyncResult<UdpChannel> asyncResult;
+        private State state = State.INIT;
+        private PublicationParams params;
+        private SendChannelEndpoint channelEndpoint;
+        private UdpChannel udpChannel;
+
+        private AddNetworkPublicationCommand(
+            final String channel,
+            final int streamId,
+            final long correlationId,
+            final long clientId,
+            final boolean isExclusive)
+        {
+            super(correlationId);
+            this.channel = channel;
+            this.streamId = streamId;
+            this.clientId = clientId;
+            this.isExclusive = isExclusive;
+        }
+
+        boolean execute()
+        {
+            if (State.INIT == state)
+            {
+                asyncResult = executeAsync(() -> UdpChannel.parse(channel, nameResolver, false));
+                state = State.AWAITING_CHANNEL_PARSE;
+            }
+            if (State.AWAITING_CHANNEL_PARSE == state)
+            {
+                awaitingChannelParse();
+            }
+            if (State.VALIDATING == state)
+            {
+                validating();
+            }
+            if (State.RESOLVING_ENDPOINT == state)
+            {
+                resolvingEndpoint();
+            }
+            if (State.CREATING_LINKS == state)
+            {
+                creatingLinks();
+            }
+
+            return State.DONE == state;
+        }
+
+        private void awaitingChannelParse()
+        {
+            if (null != (udpChannel = asyncResult.get()))
+            {
+                state = State.VALIDATING;
+            }
+        }
+
+        private void validating()
+        {
+            final ChannelUri channelUri = udpChannel.channelUri();
+            params = getPublicationParams(channelUri, ctx, DriverConductor.this, streamId, udpChannel.canonicalForm());
+            validateExperimentalFeatures(ctx.enableExperimentalFeatures(), udpChannel);
+            validateEndpointForPublication(udpChannel);
+            validateControlForPublication(udpChannel);
+            validateResponseSubscription(params);
+
+            state = State.RESOLVING_ENDPOINT;
+        }
+
+        private void resolvingEndpoint()
+        {
+            channelEndpoint = getOrCreateSendChannelEndpoint(params, udpChannel, correlationId);
+
+            if (channelEndpoint.isActive())
+            {
+                state = State.CREATING_LINKS;
+            }
+        }
+
+        private void creatingLinks()
+        {
+            NetworkPublication publication = null;
+            if (!isExclusive)
+            {
+                publication =
+                    findPublication(networkPublications, streamId, channelEndpoint, params.responseCorrelationId);
+            }
+
+            final PublicationImage responsePublicationImage = findResponsePublicationImage(params);
+
+            boolean isNewPublication = false;
+            if (null == publication)
+            {
+                checkForSessionClash(params.sessionId, streamId, udpChannel.canonicalForm(), channel);
+                publication = newNetworkPublication(
+                    correlationId, clientId, streamId, channel, udpChannel, channelEndpoint, params, isExclusive);
+                isNewPublication = true;
+            }
+            else
+            {
+                confirmMatch(
+                    udpChannel.channelUri(),
+                    params,
+                    publication.rawLog(),
+                    publication.sessionId(),
+                    publication.channel(),
+                    publication.initialTermId(),
+                    publication.startingTermId(),
+                    publication.startingTermOffset());
+
+                validateSpiesSimulateConnection(
+                    params, publication.spiesSimulateConnection(), channel, publication.channel());
+            }
+
+            publicationLinks.add(new PublicationLink(correlationId, getOrAddClient(clientId), publication));
+
+            clientProxy.onPublicationReady(
+                correlationId,
+                publication.registrationId(),
+                streamId,
+                publication.sessionId(),
+                publication.rawLog().fileName(),
+                publication.publisherLimitId(),
+                channelEndpoint.statusIndicatorCounterId(),
+                isExclusive);
+
+            if (isNewPublication)
+            {
+                linkSpies(subscriptionLinks, publication);
+            }
+
+            if (null != responsePublicationImage)
+            {
+                responsePublicationImage.responseSessionId(publication.sessionId());
+            }
+
+            state = State.DONE;
+        }
+
+        private enum State
+        {
+            INIT,
+            AWAITING_CHANNEL_PARSE,
+            VALIDATING,
+            RESOLVING_ENDPOINT,
+            CREATING_LINKS,
+            DONE
+        }
+    }
+
+    private final class AddNetworkSubscriptionCommand extends ClientCommand
+    {
+        private final String channel;
+        private final int streamId;
+        private final long registrationId;
+        private final long clientId;
+        private AsyncResult<UdpChannel> asyncResult;
+        private State state = State.INIT;
+        private SubscriptionParams params;
+        private ReceiveChannelEndpoint channelEndpoint;
+        private UdpChannel udpChannel;
+
+        private AddNetworkSubscriptionCommand(
+            final String channel,
+            final int streamId,
+            final long registrationId,
+            final long clientId)
+        {
+            super(registrationId);
+            this.channel = channel;
+            this.streamId = streamId;
+            this.registrationId = registrationId;
+            this.clientId = clientId;
+        }
+
+        boolean execute()
+        {
+            if (State.INIT == state)
+            {
+                asyncResult = executeAsync(() -> UdpChannel.parse(channel, nameResolver, false));
+                state = State.AWAITING_CHANNEL_PARSE;
+            }
+            if (State.AWAITING_CHANNEL_PARSE == state)
+            {
+                awaitingChannelParse();
+            }
+            if (State.VALIDATING == state)
+            {
+                validating();
+            }
+            if (State.RESOLVING_ENDPOINT == state)
+            {
+                resolvingEndpoint();
+            }
+            if (State.CREATING_LINKS == state)
+            {
+                creatingLinks();
+            }
+
+            return State.DONE == state;
+        }
+
+        private void awaitingChannelParse()
+        {
+            if (null != (udpChannel = asyncResult.get()))
+            {
+                state = State.VALIDATING;
+            }
+        }
+
+        private void validating()
+        {
+            validateExperimentalFeatures(ctx.enableExperimentalFeatures(), udpChannel);
+            validateControlForSubscription(udpChannel);
+            validateTimestampConfiguration(udpChannel);
+
+            params = SubscriptionParams.getSubscriptionParams(udpChannel.channelUri(), ctx, 0);
+            checkForClashingSubscription(params, udpChannel, streamId);
+
+            state = State.RESOLVING_ENDPOINT;
+        }
+
+        private void resolvingEndpoint()
+        {
+            channelEndpoint = getOrCreateReceiveChannelEndpoint(params, udpChannel, registrationId);
+
+            if (ChannelEndpointStatus.ACTIVE == channelEndpoint.status())
+            {
+                state = State.CREATING_LINKS;
+            }
+        }
+
+        private void creatingLinks()
+        {
+            final NetworkSubscriptionLink subscription = new NetworkSubscriptionLink(
+                registrationId, channelEndpoint, streamId, channel, getOrAddClient(clientId), params);
+
+            subscriptionLinks.add(subscription);
+
+            final ControlMode controlMode = udpChannel.controlMode();
+            if (ControlMode.RESPONSE == controlMode)
+            {
+                channelEndpoint.incResponseRefToStream(subscription.streamId);
+            }
+            else
+            {
+                addNetworkSubscriptionToReceiver(subscription);
+            }
+
+            clientProxy.onSubscriptionReady(registrationId, channelEndpoint.statusIndicatorCounter().id());
+            linkMatchingImages(subscription);
+
+            state = State.DONE;
+        }
+
+        private enum State
+        {
+            INIT,
+            AWAITING_CHANNEL_PARSE,
+            VALIDATING,
+            RESOLVING_ENDPOINT,
+            CREATING_LINKS,
+            DONE
+        }
+    }
+
+    private final class AddSpySubscriptionCommand extends ClientCommand
+    {
+        private final int streamId;
+        private final long registrationId;
+        private final long clientId;
+        private final AsyncResult<UdpChannel> asyncResult;
+
+        private AddSpySubscriptionCommand(
+            final String channel,
+            final int streamId,
+            final long registrationId,
+            final long clientId)
+        {
+            super(registrationId);
+            this.streamId = streamId;
+            this.registrationId = registrationId;
+            this.clientId = clientId;
+            asyncResult = executeAsync(() -> UdpChannel.parse(channel, nameResolver, false));
+        }
+
+        boolean execute()
+        {
+            final UdpChannel udpChannel;
+            if (null == (udpChannel = asyncResult.get()))
+            {
+                return false;
+            }
+
+            final SubscriptionParams params =
+                SubscriptionParams.getSubscriptionParams(udpChannel.channelUri(), ctx, 0);
+            final SpySubscriptionLink subscriptionLink = new SpySubscriptionLink(
+                registrationId, udpChannel, streamId, getOrAddClient(clientId), params);
+
+            subscriptionLinks.add(subscriptionLink);
+            clientProxy.onSubscriptionReady(registrationId, ChannelEndpointStatus.NO_ID_ALLOCATED);
+
+            for (int i = 0, size = networkPublications.size(); i < size; i++)
+            {
+                final NetworkPublication publication = networkPublications.get(i);
+                if (subscriptionLink.matches(publication) && publication.isAcceptingSubscriptions())
+                {
+                    clientProxy.onAvailableImage(
+                        publication.registrationId(),
+                        streamId,
+                        publication.sessionId(),
+                        registrationId,
+                        linkSpy(publication, subscriptionLink).id(),
+                        publication.rawLog().fileName(),
+                        IPC_CHANNEL);
+                }
+            }
+
+            return true;
+        }
+    }
+
+    private final class AddRcvSpyDestinationCommand extends ClientCommand
+    {
+        private final long registrationId;
+        private final AsyncResult<UdpChannel> asyncResult;
+
+        private AddRcvSpyDestinationCommand(
+            final long registrationId,
+            final String destinationChannel,
+            final long correlationId)
+        {
+            super(correlationId);
+            this.registrationId = registrationId;
+            asyncResult = executeAsync(() -> UdpChannel.parse(destinationChannel, nameResolver, false));
+        }
+
+        boolean execute()
+        {
+            final UdpChannel udpChannel;
+            if (null == (udpChannel = asyncResult.get()))
+            {
+                return false;
+            }
+
+            final SubscriptionParams params =
+                SubscriptionParams.getSubscriptionParams(udpChannel.channelUri(), ctx, 0);
+            final SubscriptionLink mdsSubscriptionLink = findMdsSubscriptionLink(subscriptionLinks, registrationId);
+
+            if (null == mdsSubscriptionLink)
+            {
+                throw new ControlProtocolException(
+                    UNKNOWN_SUBSCRIPTION, "unknown MDS subscription: " + registrationId);
+            }
+
+            final SpySubscriptionLink subscriptionLink = new SpySubscriptionLink(
+                registrationId,
+                udpChannel,
+                mdsSubscriptionLink.streamId(),
+                mdsSubscriptionLink.aeronClient(),
+                params);
+
+            subscriptionLinks.add(subscriptionLink);
+            clientProxy.operationSucceeded(correlationId);
+
+            for (int i = 0, size = networkPublications.size(); i < size; i++)
+            {
+                final NetworkPublication publication = networkPublications.get(i);
+                if (subscriptionLink.matches(publication) && publication.isAcceptingSubscriptions())
+                {
+                    clientProxy.onAvailableImage(
+                        publication.registrationId(),
+                        mdsSubscriptionLink.streamId(),
+                        publication.sessionId(),
+                        registrationId,
+                        linkSpy(publication, subscriptionLink).id(),
+                        publication.rawLog().fileName(),
+                        IPC_CHANNEL);
+                }
+            }
+
+            return true;
+        }
+    }
+
+    private final class AddRcvNetworkDestinationCommand extends ClientCommand
+    {
+        private final long registrationId;
+        private final String destinationChannel;
+        private AsyncResult<UdpChannel> asyncResult;
+        private State state = State.INIT;
+        private ReceiveChannelEndpoint receiveChannelEndpoint;
+        private UdpChannel udpChannel;
+
+        private AddRcvNetworkDestinationCommand(
+            final long registrationId,
+            final String destinationChannel,
+            final long correlationId)
+        {
+            super(correlationId);
+            this.registrationId = registrationId;
+            this.destinationChannel = destinationChannel;
+        }
+
+        boolean execute()
+        {
+            if (State.INIT == state)
+            {
+                asyncResult = executeAsync(() -> UdpChannel.parse(destinationChannel, nameResolver, true));
+                state = State.AWAITING_CHANNEL_PARSE;
+            }
+            if (State.AWAITING_CHANNEL_PARSE == state)
+            {
+                if (null != (udpChannel = asyncResult.get()))
+                {
+                    state = State.CREATE_TRANSPORT;
+                }
+            }
+            if (State.CREATE_TRANSPORT == state)
+            {
+                createTransport();
+            }
+
+            return State.DONE == state;
+        }
+
+        private void createTransport()
+        {
+            validateDestinationUri(udpChannel.channelUri(), destinationChannel);
+
+            final SubscriptionLink mdsSubscriptionLink = findMdsSubscriptionLink(subscriptionLinks, registrationId);
+
+            if (null == mdsSubscriptionLink)
+            {
+                throw new ControlProtocolException(
+                    UNKNOWN_SUBSCRIPTION, "unknown MDS subscription: " + registrationId);
+            }
+
+            receiveChannelEndpoint = mdsSubscriptionLink.channelEndpoint();
+
+            AtomicCounter localSocketAddressIndicator = null;
+            ReceiveDestinationTransport transport = null;
+
+            try
+            {
+                localSocketAddressIndicator = ReceiveLocalSocketAddress.allocate(
+                    tempBuffer,
+                    countersManager,
+                    registrationId,
+                    receiveChannelEndpoint.statusIndicatorCounter().id());
+
+                transport = new ReceiveDestinationTransport(
+                    udpChannel, ctx, localSocketAddressIndicator, receiveChannelEndpoint);
+
+                transport.openChannel(null);
+                transport.indicateActive();
+            }
+            catch (final Exception ex)
+            {
+                CloseHelper.closeAll(localSocketAddressIndicator, transport);
+                throw ex;
+            }
+
+            receiverProxy.addDestination(receiveChannelEndpoint, transport);
+            clientProxy.operationSucceeded(correlationId);
+
+            state = State.DONE;
+        }
+
+        private enum State
+        {
+            INIT,
+            AWAITING_CHANNEL_PARSE,
+            CREATE_TRANSPORT,
+            DONE
+        }
+    }
+
+    private final class RemoveRcvNetworkDestinationCommand extends ClientCommand
+    {
+        private final long registrationId;
+        private final String destinationChannel;
+        private AsyncResult<UdpChannel> asyncResult;
+        private State state = State.INIT;
+        private UdpChannel udpChannel;
+        private ReceiveChannelEndpoint receiveChannelEndpoint;
+
+        private RemoveRcvNetworkDestinationCommand(
+            final long registrationId,
+            final String destinationChannel,
+            final long correlationId)
+        {
+            super(correlationId);
+            this.registrationId = registrationId;
+            this.destinationChannel = destinationChannel;
+        }
+
+        boolean execute()
+        {
+            if (State.INIT == state)
+            {
+                init();
+            }
+            if (State.AWAITING_CHANNEL_PARSE == state)
+            {
+                awaitingChannelParse();
+            }
+            if (State.REMOVING == state)
+            {
+                removing();
+            }
+
+            return State.DONE == state;
+        }
+
+        private void init()
+        {
+            for (int i = 0, size = subscriptionLinks.size(); i < size; i++)
+            {
+                final SubscriptionLink subscriptionLink = subscriptionLinks.get(i);
+                if (registrationId == subscriptionLink.registrationId())
+                {
+                    receiveChannelEndpoint = subscriptionLink.channelEndpoint();
+                    break;
+                }
+            }
+
+            if (null == receiveChannelEndpoint)
+            {
+                throw new ControlProtocolException(UNKNOWN_SUBSCRIPTION, "unknown subscription: " + registrationId);
+            }
+
+            receiveChannelEndpoint.validateAllowsDestinationControl();
+
+            asyncResult = executeAsync(() -> UdpChannel.parse(destinationChannel, nameResolver, true));
+
+            state = State.AWAITING_CHANNEL_PARSE;
+        }
+
+        private void awaitingChannelParse()
+        {
+            if (null != (udpChannel = asyncResult.get()))
+            {
+                state = State.REMOVING;
+            }
+        }
+
+        private void removing()
+        {
+            receiverProxy.removeDestination(receiveChannelEndpoint, udpChannel);
+            clientProxy.operationSucceeded(correlationId);
+
+            state = State.DONE;
+        }
+
+        enum State
+        {
+            INIT,
+            AWAITING_CHANNEL_PARSE,
+            REMOVING,
+            DONE
+        }
+    }
+
+    private final class AddSendDestinationCommand extends ClientCommand
+    {
+        private final long registrationId;
+        private final String destinationChannel;
+        private State state = State.INIT;
+        private ChannelUri channelUri;
+        private SendChannelEndpoint sendChannelEndpoint;
+        private AsyncResult<InetSocketAddress> asyncResult;
+
+        private AddSendDestinationCommand(
+            final long registrationId, final String destinationChannel, final long correlationId)
+        {
+            super(correlationId);
+            this.registrationId = registrationId;
+            this.destinationChannel = destinationChannel;
+        }
+
+        boolean execute()
+        {
+            if (State.INIT == state)
+            {
+                init();
+            }
+
+            if (State.AWAITING_DESTINATION_ADDRESS == state)
+            {
+                final InetSocketAddress address = asyncResult.get();
+                if (null != address)
+                {
+                    senderProxy.addDestination(sendChannelEndpoint, channelUri, address, correlationId);
+                    clientProxy.operationSucceeded(correlationId);
+                    state = State.DONE;
+                }
+            }
+
+            return State.DONE == state;
+        }
+
+        private void init()
+        {
+            channelUri = parseUri(destinationChannel);
+            validateDestinationUri(channelUri, destinationChannel);
+            validateSendDestinationUri(channelUri, destinationChannel);
+
+            sendChannelEndpoint = findExistingManualSendChannelEndpoint(registrationId);
+
+            asyncResult = executeAsync(() -> UdpChannel.destinationAddress(channelUri, nameResolver));
+            state = State.AWAITING_DESTINATION_ADDRESS;
+        }
+
+        enum State
+        {
+            INIT,
+            AWAITING_DESTINATION_ADDRESS,
+            DONE
+        }
+    }
+
+    private final class RemoveSendDestinationCommand extends ClientCommand
+    {
+        private final long registrationId;
+        private final String destinationChannel;
+        private State state = State.INIT;
+        private ChannelUri channelUri;
+        private SendChannelEndpoint sendChannelEndpoint;
+        private AsyncResult<InetSocketAddress> asyncResult;
+
+        private RemoveSendDestinationCommand(
+            final long registrationId, final String destinationChannel, final long correlationId)
+        {
+            super(correlationId);
+            this.registrationId = registrationId;
+            this.destinationChannel = destinationChannel;
+        }
+
+        boolean execute()
+        {
+            if (State.INIT == state)
+            {
+                init();
+            }
+
+            if (State.AWAITING_DESTINATION_ADDRESS == state)
+            {
+                final InetSocketAddress address = asyncResult.get();
+                if (null != address)
+                {
+                    senderProxy.removeDestination(sendChannelEndpoint, channelUri, address);
+                    clientProxy.operationSucceeded(correlationId);
+                    state = State.DONE;
+                }
+            }
+
+            return State.DONE == state;
+        }
+
+        private void init()
+        {
+            channelUri = parseUri(destinationChannel);
+            sendChannelEndpoint = findExistingManualSendChannelEndpoint(registrationId);
+
+            asyncResult = executeAsync(() -> UdpChannel.destinationAddress(channelUri, nameResolver));
+            state = State.AWAITING_DESTINATION_ADDRESS;
+        }
+
+        enum State
+        {
+            INIT,
+            AWAITING_DESTINATION_ADDRESS,
+            DONE
+        }
     }
 }

--- a/aeron-driver/src/main/java/io/aeron/driver/media/ReceiveChannelEndpoint.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/ReceiveChannelEndpoint.java
@@ -264,7 +264,7 @@ public class ReceiveChannelEndpoint extends ReceiveChannelEndpointRhsPadding
      */
     public void indicateActive()
     {
-        final long currentStatus = statusIndicator.get();
+        final long currentStatus = statusIndicator.getPlain();
         if (currentStatus != ChannelEndpointStatus.INITIALIZING)
         {
             throw new AeronException("channel cannot be registered unless INITIALIZING: status=" +
@@ -459,6 +459,7 @@ public class ReceiveChannelEndpoint extends ReceiveChannelEndpointRhsPadding
             refCountByStreamIdAndSessionIdMap.isEmpty() &&
             responseRefCountByStreamIdMap.isEmpty() &&
             !statusIndicator.isClosed() &&
+            statusIndicator.get() != ChannelEndpointStatus.CLOSING &&
             imageRefCount <= 0;
     }
 
@@ -1119,6 +1120,7 @@ public class ReceiveChannelEndpoint extends ReceiveChannelEndpointRhsPadding
             ", udpChannel=" + udpChannel +
             ", connectAddress=" + connectAddress +
             ", multiRcvDestination=" + multiRcvDestination +
+            ", statusIndicator=" + statusIndicator.getPlain() +
             '}';
     }
 }

--- a/aeron-driver/src/main/java/io/aeron/driver/media/ReceiveDestinationTransport.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/ReceiveDestinationTransport.java
@@ -23,6 +23,8 @@ import org.agrona.concurrent.status.AtomicCounter;
 
 import java.net.InetSocketAddress;
 
+import static io.aeron.status.ChannelEndpointStatus.status;
+
 abstract class ReceiveDestinationTransportLhsPadding extends UdpChannelTransport
 {
     byte p000, p001, p002, p003, p004, p005, p006, p007, p008, p009, p010, p011, p012, p013, p014, p015;
@@ -91,6 +93,7 @@ public final class ReceiveDestinationTransport extends ReceiveDestinationTranspo
 {
     private InetSocketAddress currentControlAddress;
     private final AtomicCounter localSocketAddressIndicator;
+    private final ReceiveChannelEndpoint receiveChannelEndpoint;
 
     /**
      * Construct transport for a receiving destination.
@@ -118,6 +121,7 @@ public final class ReceiveDestinationTransport extends ReceiveDestinationTranspo
         this.timeOfLastActivityNs = context.receiverCachedNanoClock().nanoTime();
         this.currentControlAddress = udpChannel.hasExplicitControl() ? udpChannel.localControl() : null;
         this.localSocketAddressIndicator = localSocketAddressIndicator;
+        this.receiveChannelEndpoint = receiveChannelEndpoint;
     }
 
     /**
@@ -128,6 +132,19 @@ public final class ReceiveDestinationTransport extends ReceiveDestinationTranspo
     public void openChannel(final AtomicCounter statusIndicator)
     {
         openDatagramChannel(statusIndicator);
+    }
+
+    /**
+     * Indicate that the transport is active after successfully opening it.
+     */
+    public void indicateActive()
+    {
+        final long currentStatus = localSocketAddressIndicator.getPlain();
+        if (currentStatus != ChannelEndpointStatus.INITIALIZING)
+        {
+            throw new IllegalStateException(
+                "channel cannot be registered unless INITIALIZING: status=" + status(currentStatus));
+        }
 
         LocalSocketAddressStatus.updateBindAddress(
             localSocketAddressIndicator, bindAddressAndPort(), context.countersMetaDataBuffer());
@@ -220,7 +237,8 @@ public final class ReceiveDestinationTransport extends ReceiveDestinationTranspo
     {
         return "ReceiveDestinationTransport{" +
             "currentControlAddress=" + currentControlAddress +
-            ", localSocketAddressIndicator=" + localSocketAddressIndicator +
+            ", localSocketAddress=" + localSocketAddressIndicator.label() +
+            ", statusIndicator=" + localSocketAddressIndicator.getPlain() +
             '}';
     }
 }

--- a/aeron-driver/src/main/java/io/aeron/driver/media/SendChannelEndpoint.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/SendChannelEndpoint.java
@@ -192,7 +192,7 @@ public class SendChannelEndpoint extends UdpChannelTransport
      */
     public void indicateActive()
     {
-        final long currentStatus = statusIndicator.get();
+        final long currentStatus = statusIndicator.getPlain();
         if (currentStatus != ChannelEndpointStatus.INITIALIZING)
         {
             throw new IllegalStateException(
@@ -201,6 +201,24 @@ public class SendChannelEndpoint extends UdpChannelTransport
 
         statusIndicator.appendToLabel(bindAddressAndPort());
         statusIndicator.setRelease(ChannelEndpointStatus.ACTIVE);
+    }
+
+    /**
+     * Indicate that the channel is closing and should not be used for new publications.
+     */
+    public void indicateClosing()
+    {
+        statusIndicator.setRelease(ChannelEndpointStatus.CLOSING);
+    }
+
+    /**
+     * Returns whether the channel is active and can be used for new publications.
+     *
+     * @return whether the channel is active and can be used for new publications.
+     */
+    public boolean isActive()
+    {
+        return !statusIndicator.isClosed() && statusIndicator.getAcquire() == ChannelEndpointStatus.ACTIVE;
     }
 
     /**
@@ -221,7 +239,9 @@ public class SendChannelEndpoint extends UdpChannelTransport
      */
     public boolean shouldBeClosed()
     {
-        return 0 == refCount && !statusIndicator.isClosed();
+        return 0 == refCount &&
+            !statusIndicator.isClosed() &&
+            statusIndicator.get() != ChannelEndpointStatus.CLOSING;
     }
 
     /**

--- a/aeron-driver/src/test/java/io/aeron/driver/DriverConductorTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/DriverConductorTest.java
@@ -41,13 +41,13 @@ import org.agrona.concurrent.CachedEpochClock;
 import org.agrona.concurrent.CachedNanoClock;
 import org.agrona.concurrent.CountedErrorHandler;
 import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
+import org.agrona.concurrent.OneToOneConcurrentArrayQueue;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.ringbuffer.ManyToOneRingBuffer;
 import org.agrona.concurrent.ringbuffer.RingBuffer;
 import org.agrona.concurrent.status.AtomicCounter;
 import org.agrona.concurrent.status.CountersManager;
 import org.agrona.concurrent.status.CountersReader;
-import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -107,8 +107,8 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.startsWith;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyLong;
@@ -120,7 +120,6 @@ import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -164,12 +163,16 @@ class DriverConductorTest
     private final ClientProxy mockClientProxy = mock(ClientProxy.class);
 
     private final CountedErrorHandler mockErrorHandler = mock(CountedErrorHandler.class);
+    private final AtomicCounter mockErrorCounter = mock(AtomicCounter.class);
 
     private final SenderProxy senderProxy = mock(SenderProxy.class);
     private final ReceiverProxy receiverProxy = mock(ReceiverProxy.class);
-    private final AsyncExecutorProxy asyncExecutorProxy = mock(AsyncExecutorProxy.class);
-    private final AgentInvoker asyncExecutorInvoker = mock(AgentInvoker.class);
     private final NameResolverAgent nameResolver = DefaultNameResolver.INSTANCE;
+    private final OneToOneConcurrentArrayQueue<Runnable> asyncTaskQueue = new OneToOneConcurrentArrayQueue<>(1024);
+    private final AsyncExecutorProxy asyncExecutorProxy =
+        spy(new AsyncExecutorProxy(asyncTaskQueue, mockErrorCounter, true));
+    private final AgentInvoker asyncExecutorInvoker =
+        new AgentInvoker(mockErrorHandler, mockErrorCounter, new AsyncExecutor(nameResolver, asyncTaskQueue));
     private final DriverConductorProxy mockDriverConductorProxy = mock(DriverConductorProxy.class);
     private ReceiveChannelEndpoint receiveChannelEndpoint = null;
 
@@ -253,10 +256,8 @@ class DriverConductorTest
             .countersMetaDataBuffer((UnsafeBuffer)spyCountersManager.metaDataBuffer())
             .countersValuesBuffer((UnsafeBuffer)spyCountersManager.valuesBuffer());
 
-        when(asyncExecutorProxy.notConcurrent()).thenReturn(true);
-
         driverProxy = new DriverProxy(toDriverCommands, toDriverCommands.nextCorrelationId());
-        driverConductor = new DriverConductor(ctx, asyncExecutorInvoker, nameResolver);
+        driverConductor = new DriverConductor(ctx.clone(), asyncExecutorInvoker, nameResolver);
         driverConductor.onStart();
 
         doAnswer(closeChannelEndpointAnswer).when(receiverProxy).closeReceiveChannelEndpoint(any());
@@ -275,36 +276,39 @@ class DriverConductorTest
     @Test
     void shouldCallAgentInvokerStart()
     {
-        reset(asyncExecutorInvoker);
+        final AgentInvoker invoker = mock(AgentInvoker.class);
+        final DriverConductor conductor = new DriverConductor(ctx.clone(), invoker, nameResolver);
 
-        driverConductor.onStart();
+        conductor.onStart();
 
-        verify(asyncExecutorInvoker).start();
-        verifyNoMoreInteractions(asyncExecutorInvoker);
+        verify(invoker).start();
+        verifyNoMoreInteractions(invoker);
     }
 
     @Test
     void shouldInvokeAgentInvoker()
     {
-        reset(asyncExecutorInvoker);
+        final AgentInvoker invoker = mock(AgentInvoker.class);
+        final DriverConductor conductor = new DriverConductor(ctx.clone(), invoker, nameResolver);
 
-        driverConductor.doWork();
-        driverConductor.doWork();
-        driverConductor.doWork();
+        conductor.doWork();
+        conductor.doWork();
+        conductor.doWork();
 
-        verify(asyncExecutorInvoker, times(3)).invoke();
-        verifyNoMoreInteractions(asyncExecutorInvoker);
+        verify(invoker, times(3)).invoke();
+        verifyNoMoreInteractions(invoker);
     }
 
     @Test
     void shouldNotCloseAgentInvoker()
     {
-        reset(asyncExecutorInvoker);
+        final AgentInvoker invoker = mock(AgentInvoker.class);
+        final MediaDriver.Context context = ctx.clone().cncByteBuffer((MappedByteBuffer)ByteBuffer.allocateDirect(1));
+        final DriverConductor conductor = new DriverConductor(context, invoker, nameResolver);
 
-        driverConductor.onClose();
-        driverConductor = null;
+        conductor.onClose();
 
-        verifyNoInteractions(asyncExecutorInvoker);
+        verifyNoInteractions(invoker);
     }
 
     @Test
@@ -355,7 +359,7 @@ class DriverConductorTest
             "URI must have explicit control, endpoint, or be manual control-mode when original:";
 
         driverProxy.addPublication("aeron:udp?tags=1001", STREAM_ID_1);
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         verify(mockErrorHandler).onError(argThat(
             (ex) ->
@@ -371,7 +375,7 @@ class DriverConductorTest
     {
         driverProxy.addPublication(CHANNEL_4000, STREAM_ID_1);
 
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         verify(senderProxy).registerSendChannelEndpoint(any());
         final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
@@ -401,7 +405,7 @@ class DriverConductorTest
 
         driverProxy.addExclusivePublication(CHANNEL_4000 + params, STREAM_ID_1);
 
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         verify(senderProxy).registerSendChannelEndpoint(any());
         final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
@@ -434,7 +438,7 @@ class DriverConductorTest
 
         driverProxy.addExclusivePublication(CHANNEL_IPC + params, STREAM_ID_1);
 
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final ArgumentCaptor<Long> captor = ArgumentCaptor.forClass(Long.class);
         verify(mockClientProxy).onPublicationReady(
@@ -455,7 +459,7 @@ class DriverConductorTest
     {
         final long id = driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
 
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final ArgumentCaptor<ReceiveChannelEndpoint> captor = ArgumentCaptor.forClass(ReceiveChannelEndpoint.class);
         verify(receiverProxy).registerReceiveChannelEndpoint(captor.capture());
@@ -471,8 +475,8 @@ class DriverConductorTest
         final long id = driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
         driverProxy.removeSubscription(id);
 
-        driverConductor.doWork();
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
+        doWorkUntilOneClientCommandIsExecuted();
 
         verify(receiverProxy).registerReceiveChannelEndpoint(any());
         verify(receiverProxy).closeReceiveChannelEndpoint(any());
@@ -484,8 +488,8 @@ class DriverConductorTest
         final long id1 = driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
         driverProxy.removeSubscription(id1);
 
-        driverConductor.doWork();
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
+        doWorkUntilOneClientCommandIsExecuted();
 
         verify(receiverProxy).registerReceiveChannelEndpoint(any());
         final ArgumentCaptor<ReceiveChannelEndpoint> captor = ArgumentCaptor.forClass(ReceiveChannelEndpoint.class);
@@ -493,19 +497,13 @@ class DriverConductorTest
 
         final long id2 = driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
 
-        driverConductor.doWork();
-        driverConductor.doWork();
-
-        verify(mockClientProxy, times(1)).onError(id2, ErrorCode.RESOURCE_TEMPORARILY_UNAVAILABLE,
-            "ReceiveChannelEndpoint found in CLOSING state, please retry");
+        doWorkUntilOneClientCommandIsExecuted();
 
         driverConductor.receiveChannelEndpointClosed(captor.getValue());
 
-        final long id3 = driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
+        doWorkUntilOneClientCommandIsExecuted();
 
-        driverConductor.doWork();
-
-        verify(mockClientProxy, times(1)).onSubscriptionReady(eq(id3), anyInt());
+        verify(mockClientProxy, times(1)).onSubscriptionReady(eq(id2), anyInt());
     }
 
     @Test
@@ -583,8 +581,8 @@ class DriverConductorTest
         driverProxy.removeSubscription(id1);
         driverProxy.removeSubscription(id2);
 
-        driverConductor.doWork();
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
+        doWorkUntilOneClientCommandIsExecuted();
 
         assertEquals(1, receiveChannelEndpoint.distinctSubscriptionCount());
     }
@@ -614,14 +612,14 @@ class DriverConductorTest
         driverProxy.removeSubscription(id2);
         driverProxy.removeSubscription(id3);
 
-        driverConductor.doWork();
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
+        doWorkUntilOneClientCommandIsExecuted();
 
         assertEquals(1, receiveChannelEndpoint.distinctSubscriptionCount());
 
         driverProxy.removeSubscription(id1);
 
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         verify(receiverProxy).closeReceiveChannelEndpoint(receiveChannelEndpoint);
     }
@@ -632,8 +630,8 @@ class DriverConductorTest
         final long id = driverProxy.addPublication(CHANNEL_4000, STREAM_ID_1);
         driverProxy.removePublication(id + 1, false);
 
-        driverConductor.doWork();
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final InOrder inOrder = inOrder(senderProxy, mockClientProxy);
 
@@ -653,7 +651,7 @@ class DriverConductorTest
         final String mtuParam = "|" + CommonContext.MTU_LENGTH_PARAM_NAME + "=" + mtuLength;
         driverProxy.addPublication(CHANNEL_4000 + mtuParam, STREAM_ID_1);
 
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final ArgumentCaptor<NetworkPublication> argumentCaptor = ArgumentCaptor.forClass(NetworkPublication.class);
         verify(senderProxy).newNetworkPublication(argumentCaptor.capture());
@@ -667,8 +665,8 @@ class DriverConductorTest
         final long id1 = driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
         driverProxy.removeSubscription(id1 + 100);
 
-        driverConductor.doWork();
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final InOrder inOrder = inOrder(receiverProxy, mockClientProxy);
 
@@ -680,13 +678,19 @@ class DriverConductorTest
         verify(mockErrorHandler).onError(any(Throwable.class));
     }
 
+    private void doWorkUntilOneClientCommandIsExecuted()
+    {
+        driverConductor.doWork();
+        driverConductor.doWork();
+    }
+
     @Test
     void shouldErrorOnAddSubscriptionWithInvalidChannel()
     {
         driverProxy.addSubscription(INVALID_URI, STREAM_ID_1);
 
-        driverConductor.doWork();
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
+        doWorkUntilOneClientCommandIsExecuted();
 
         verify(senderProxy, never()).newNetworkPublication(any());
 
@@ -701,7 +705,7 @@ class DriverConductorTest
     {
         driverProxy.addPublication(CHANNEL_4000, STREAM_ID_1);
 
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
         verify(senderProxy, times(1)).newNetworkPublication(captor.capture());
@@ -719,7 +723,7 @@ class DriverConductorTest
     {
         driverProxy.addPublication(CHANNEL_4000, STREAM_ID_1);
 
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
         verify(senderProxy, times(1)).newNetworkPublication(captor.capture());
@@ -745,7 +749,7 @@ class DriverConductorTest
     {
         driverProxy.addPublication(CHANNEL_4000, STREAM_ID_1);
 
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
         verify(senderProxy, times(1)).newNetworkPublication(captor.capture());
@@ -789,7 +793,7 @@ class DriverConductorTest
             Matchers.anyOf(is(NetworkPublication.State.LINGER), is(NetworkPublication.State.DONE)));
 
         nanoClock.advance(DEFAULT_TIMER_INTERVAL_NS + PUBLICATION_LINGER_TIMEOUT_NS);
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
         assertEquals(NetworkPublication.State.DONE, publication.state());
 
         verify(senderProxy).removeNetworkPublication(eq(publication));
@@ -801,7 +805,7 @@ class DriverConductorTest
     {
         driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
 
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final ArgumentCaptor<ReceiveChannelEndpoint> captor = ArgumentCaptor.forClass(ReceiveChannelEndpoint.class);
         verify(receiverProxy).registerReceiveChannelEndpoint(captor.capture());
@@ -822,7 +826,7 @@ class DriverConductorTest
     {
         driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
 
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final ArgumentCaptor<ReceiveChannelEndpoint> captor = ArgumentCaptor.forClass(ReceiveChannelEndpoint.class);
         verify(receiverProxy).registerReceiveChannelEndpoint(captor.capture());
@@ -854,7 +858,7 @@ class DriverConductorTest
 
         driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
 
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final ArgumentCaptor<ReceiveChannelEndpoint> captor1 = ArgumentCaptor.forClass(ReceiveChannelEndpoint.class);
         verify(receiverProxy).registerReceiveChannelEndpoint(captor1.capture());
@@ -882,7 +886,7 @@ class DriverConductorTest
 
         driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
 
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final ArgumentCaptor<ReceiveChannelEndpoint> captor = ArgumentCaptor.forClass(ReceiveChannelEndpoint.class);
         verify(receiverProxy).registerReceiveChannelEndpoint(captor.capture());
@@ -904,7 +908,7 @@ class DriverConductorTest
 
         final long subId = driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
 
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final ArgumentCaptor<ReceiveChannelEndpoint> captor1 = ArgumentCaptor.forClass(ReceiveChannelEndpoint.class);
         verify(receiverProxy).registerReceiveChannelEndpoint(captor1.capture());
@@ -935,7 +939,7 @@ class DriverConductorTest
 
         final long subId1 = driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
 
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final ArgumentCaptor<ReceiveChannelEndpoint> captor1 = ArgumentCaptor.forClass(ReceiveChannelEndpoint.class);
         verify(receiverProxy).registerReceiveChannelEndpoint(captor1.capture());
@@ -954,7 +958,7 @@ class DriverConductorTest
 
         final long subId2 = driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
 
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         publicationImage.deactivate();
 
@@ -982,7 +986,7 @@ class DriverConductorTest
 
         final long subOneId = driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
 
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final ArgumentCaptor<ReceiveChannelEndpoint> captor1 = ArgumentCaptor.forClass(ReceiveChannelEndpoint.class);
         verify(receiverProxy).registerReceiveChannelEndpoint(captor1.capture());
@@ -1009,7 +1013,7 @@ class DriverConductorTest
 
         final long subTwoId = driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
 
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final InOrder inOrder = inOrder(mockClientProxy);
         inOrder.verify(mockClientProxy, times(1)).onSubscriptionReady(eq(subOneId), anyInt());
@@ -1032,7 +1036,7 @@ class DriverConductorTest
     {
         final long id = driverProxy.addPublication(CHANNEL_IPC, STREAM_ID_1);
 
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         assertNotNull(driverConductor.getSharedIpcPublication(STREAM_ID_1, Aeron.NULL_VALUE));
         verify(mockClientProxy).onPublicationReady(
@@ -1045,8 +1049,8 @@ class DriverConductorTest
         final long idPub = driverProxy.addPublication(CHANNEL_IPC, STREAM_ID_1);
         final long idSub = driverProxy.addSubscription(CHANNEL_IPC, STREAM_ID_1);
 
-        driverConductor.doWork();
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final IpcPublication ipcPublication = driverConductor.getSharedIpcPublication(STREAM_ID_1, Aeron.NULL_VALUE);
         assertNotNull(ipcPublication);
@@ -1065,17 +1069,17 @@ class DriverConductorTest
     {
         final long idSub = driverProxy.addSubscription(CHANNEL_IPC, STREAM_ID_1);
         final long idPubOne = driverProxy.addPublication(CHANNEL_IPC, STREAM_ID_1);
-        driverConductor.doWork();
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final IpcPublication ipcPublicationOne = driverConductor.getSharedIpcPublication(STREAM_ID_1, Aeron.NULL_VALUE);
         assertNotNull(ipcPublicationOne);
 
         final long idPubOneRemove = driverProxy.removePublication(idPubOne, false);
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final long idPubTwo = driverProxy.addPublication(CHANNEL_IPC, STREAM_ID_1);
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final IpcPublication ipcPublicationTwo = driverConductor.getSharedIpcPublication(STREAM_ID_1, Aeron.NULL_VALUE);
         assertNotNull(ipcPublicationTwo);
@@ -1101,8 +1105,8 @@ class DriverConductorTest
         final long idSub = driverProxy.addSubscription(CHANNEL_IPC, STREAM_ID_1);
         final long idPub = driverProxy.addPublication(CHANNEL_IPC, STREAM_ID_1);
 
-        driverConductor.doWork();
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final IpcPublication ipcPublication = driverConductor.getSharedIpcPublication(STREAM_ID_1, Aeron.NULL_VALUE);
         assertNotNull(ipcPublication);
@@ -1147,7 +1151,7 @@ class DriverConductorTest
         final long idAdd2 = driverProxy.addPublication(CHANNEL_IPC, STREAM_ID_1);
         driverProxy.removePublication(idAdd1, false);
 
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         IpcPublication ipcPublication = driverConductor.getSharedIpcPublication(STREAM_ID_1, Aeron.NULL_VALUE);
         assertNotNull(ipcPublication);
@@ -1167,9 +1171,9 @@ class DriverConductorTest
         final long idAdd2 = driverProxy.addPublication(CHANNEL_IPC, STREAM_ID_1);
         driverProxy.removeSubscription(idAdd1);
 
-        driverConductor.doWork();
-        driverConductor.doWork();
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
+        doWorkUntilOneClientCommandIsExecuted();
+        doWorkUntilOneClientCommandIsExecuted();
 
         IpcPublication ipcPublication = driverConductor.getSharedIpcPublication(STREAM_ID_1, Aeron.NULL_VALUE);
         assertNotNull(ipcPublication);
@@ -1187,7 +1191,7 @@ class DriverConductorTest
     {
         driverProxy.addPublication(CHANNEL_IPC, STREAM_ID_1);
 
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         IpcPublication ipcPublication = driverConductor.getSharedIpcPublication(STREAM_ID_1, Aeron.NULL_VALUE);
         assertNotNull(ipcPublication);
@@ -1203,7 +1207,7 @@ class DriverConductorTest
     {
         driverProxy.addPublication(CHANNEL_IPC, STREAM_ID_1);
 
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         IpcPublication ipcPublication = driverConductor.getSharedIpcPublication(STREAM_ID_1, Aeron.NULL_VALUE);
         assertNotNull(ipcPublication);
@@ -1224,7 +1228,7 @@ class DriverConductorTest
     {
         final long id = driverProxy.addSubscription(spyForChannel(CHANNEL_4000), STREAM_ID_1);
 
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         verify(receiverProxy, never()).registerReceiveChannelEndpoint(any());
         verify(receiverProxy, never()).addSubscription(any(), eq(STREAM_ID_1));
@@ -1237,8 +1241,8 @@ class DriverConductorTest
         driverProxy.addPublication(CHANNEL_4000, STREAM_ID_1);
         final long idSpy = driverProxy.addSubscription(spyForChannel(CHANNEL_4000), STREAM_ID_1);
 
-        driverConductor.doWork();
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
         verify(senderProxy, times(1)).newNetworkPublication(captor.capture());
@@ -1259,8 +1263,8 @@ class DriverConductorTest
         final long idSpy = driverProxy.addSubscription(spyForChannel(CHANNEL_4000), STREAM_ID_1);
         driverProxy.addPublication(CHANNEL_4000, STREAM_ID_1);
 
-        driverConductor.doWork();
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
         verify(senderProxy, times(1)).newNetworkPublication(captor.capture());
@@ -1303,8 +1307,8 @@ class DriverConductorTest
         driverProxy.addPublication(CHANNEL_4000, STREAM_ID_1);
         driverProxy.addSubscription(spyForChannel(CHANNEL_4000), STREAM_ID_1);
 
-        driverConductor.doWork();
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
         verify(senderProxy, times(1)).newNetworkPublication(captor.capture());
@@ -1323,8 +1327,8 @@ class DriverConductorTest
         driverProxy.addPublication(CHANNEL_4000, STREAM_ID_1);
         driverProxy.addSubscription(spyForChannel(CHANNEL_4000), STREAM_ID_1);
 
-        driverConductor.doWork();
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
         verify(senderProxy, times(1)).newNetworkPublication(captor.capture());
@@ -1351,7 +1355,7 @@ class DriverConductorTest
         driverProxy.addPublication(CHANNEL_4000, STREAM_ID_1);
         final long subId = spyDriverProxy.addSubscription(spyForChannel(CHANNEL_4000), STREAM_ID_1);
 
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
         verify(senderProxy, times(1)).newNetworkPublication(captor.capture());
@@ -1402,10 +1406,10 @@ class DriverConductorTest
     void shouldErrorWhenConflictingUnreliableSubscriptionAdded()
     {
         driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final long id2 = driverProxy.addSubscription(CHANNEL_4000 + "|reliable=false", STREAM_ID_1);
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         verify(mockClientProxy).onError(eq(id2), any(ErrorCode.class), anyString());
     }
@@ -1414,10 +1418,10 @@ class DriverConductorTest
     void shouldErrorWhenConflictingUnreliableSessionSpecificSubscriptionAdded()
     {
         driverProxy.addSubscription(CHANNEL_4000 + "|session-id=1024", STREAM_ID_1);
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final long id2 = driverProxy.addSubscription(CHANNEL_4000 + "|session-id=1024|reliable=false", STREAM_ID_1);
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         verify(mockClientProxy).onError(eq(id2), any(ErrorCode.class), anyString());
     }
@@ -1426,10 +1430,10 @@ class DriverConductorTest
     void shouldNotErrorWhenConflictingUnreliableSessionSpecificSubscriptionAddedToDifferentSessions()
     {
         final long id1 = driverProxy.addSubscription(CHANNEL_4000 + "|session-id=1024|reliable=true", STREAM_ID_1);
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final long id2 = driverProxy.addSubscription(CHANNEL_4000 + "|session-id=1025|reliable=false", STREAM_ID_1);
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         verify(mockClientProxy).onSubscriptionReady(eq(id1), anyInt());
         verify(mockClientProxy).onSubscriptionReady(eq(id2), anyInt());
@@ -1439,13 +1443,13 @@ class DriverConductorTest
     void shouldNotErrorWhenConflictingUnreliableSessionSpecificSubscriptionAddedToDifferentSessionsVsWildcard()
     {
         final long id1 = driverProxy.addSubscription(CHANNEL_4000 + "|session-id=1024|reliable=false", STREAM_ID_1);
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final long id2 = driverProxy.addSubscription(CHANNEL_4000 + "|reliable=true", STREAM_ID_1);
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final long id3 = driverProxy.addSubscription(CHANNEL_4000 + "|session-id=1025|reliable=false", STREAM_ID_1);
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         verify(mockClientProxy).onSubscriptionReady(eq(id1), anyInt());
         verify(mockClientProxy).onSubscriptionReady(eq(id2), anyInt());
@@ -1456,10 +1460,10 @@ class DriverConductorTest
     void shouldErrorWhenConflictingDefaultReliableSubscriptionAdded()
     {
         driverProxy.addSubscription(CHANNEL_4000 + "|reliable=false", STREAM_ID_1);
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final long id2 = driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         verify(mockClientProxy).onError(eq(id2), any(ErrorCode.class), anyString());
     }
@@ -1468,10 +1472,10 @@ class DriverConductorTest
     void shouldErrorWhenConflictingReliableSubscriptionAdded()
     {
         driverProxy.addSubscription(CHANNEL_4000 + "|reliable=false", STREAM_ID_1);
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final long id2 = driverProxy.addSubscription(CHANNEL_4000 + "|reliable=true", STREAM_ID_1);
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         verify(mockClientProxy).onError(eq(id2), any(ErrorCode.class), anyString());
     }
@@ -1488,7 +1492,7 @@ class DriverConductorTest
             COUNTER_LABEL_OFFSET,
             COUNTER_LABEL_LENGTH);
 
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         verify(mockClientProxy).onCounterReady(eq(registrationId), anyInt());
         verify(spyCountersManager).newCounter(
@@ -1513,10 +1517,10 @@ class DriverConductorTest
             COUNTER_LABEL_OFFSET,
             COUNTER_LABEL_LENGTH);
 
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final long removeCorrelationId = driverProxy.removeCounter(registrationId);
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final ArgumentCaptor<Integer> captor = ArgumentCaptor.forClass(Integer.class);
 
@@ -1539,7 +1543,7 @@ class DriverConductorTest
             COUNTER_LABEL_OFFSET,
             COUNTER_LABEL_LENGTH);
 
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final ArgumentCaptor<Integer> captor = ArgumentCaptor.forClass(Integer.class);
 
@@ -1562,7 +1566,7 @@ class DriverConductorTest
             COUNTER_LABEL_OFFSET,
             COUNTER_LABEL_LENGTH);
 
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final ArgumentCaptor<Integer> captor = ArgumentCaptor.forClass(Integer.class);
 
@@ -1590,10 +1594,10 @@ class DriverConductorTest
             COUNTER_LABEL_OFFSET,
             COUNTER_LABEL_LENGTH);
 
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final long removeCorrelationId = driverProxy.removeCounter(registrationId);
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final ArgumentCaptor<Integer> captor = ArgumentCaptor.forClass(Integer.class);
 
@@ -1612,7 +1616,7 @@ class DriverConductorTest
         final String sessionIdParam = "|" + CommonContext.SESSION_ID_PARAM_NAME + "=" + sessionId;
         driverProxy.addPublication(CHANNEL_4000 + sessionIdParam, STREAM_ID_1);
 
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final ArgumentCaptor<NetworkPublication> argumentCaptor = ArgumentCaptor.forClass(NetworkPublication.class);
         verify(senderProxy).newNetworkPublication(argumentCaptor.capture());
@@ -1627,7 +1631,7 @@ class DriverConductorTest
         final String sessionIdParam = "|" + CommonContext.SESSION_ID_PARAM_NAME + "=" + sessionId;
         driverProxy.addExclusivePublication(CHANNEL_4000 + sessionIdParam, STREAM_ID_1);
 
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final ArgumentCaptor<NetworkPublication> argumentCaptor = ArgumentCaptor.forClass(NetworkPublication.class);
         verify(senderProxy).newNetworkPublication(argumentCaptor.capture());
@@ -1639,7 +1643,7 @@ class DriverConductorTest
     void shouldAddPublicationWithSameSessionId()
     {
         driverProxy.addPublication(CHANNEL_4000, STREAM_ID_1);
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final ArgumentCaptor<NetworkPublication> argumentCaptor = ArgumentCaptor.forClass(NetworkPublication.class);
         verify(senderProxy).newNetworkPublication(argumentCaptor.capture());
@@ -1647,7 +1651,7 @@ class DriverConductorTest
         final int sessionId = argumentCaptor.getValue().sessionId();
         final String sessionIdParam = "|" + CommonContext.SESSION_ID_PARAM_NAME + "=" + sessionId;
         driverProxy.addPublication(CHANNEL_4000 + sessionIdParam, STREAM_ID_1);
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         verify(mockClientProxy, times(2)).onPublicationReady(
             anyLong(), anyLong(), eq(STREAM_ID_1), eq(sessionId), anyString(), anyInt(), anyInt(), eq(false));
@@ -1657,7 +1661,7 @@ class DriverConductorTest
     void shouldAddExclusivePublicationWithSameSessionId()
     {
         driverProxy.addPublication(CHANNEL_4000, STREAM_ID_1);
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final ArgumentCaptor<NetworkPublication> argumentCaptor = ArgumentCaptor.forClass(NetworkPublication.class);
         verify(senderProxy).newNetworkPublication(argumentCaptor.capture());
@@ -1665,7 +1669,7 @@ class DriverConductorTest
         final int sessionId = argumentCaptor.getValue().sessionId();
         final String sessionIdParam = "|" + CommonContext.SESSION_ID_PARAM_NAME + "=" + (sessionId + 1);
         driverProxy.addExclusivePublication(CHANNEL_4000 + sessionIdParam, STREAM_ID_1);
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         verify(mockClientProxy).onPublicationReady(
             anyLong(), anyLong(), eq(STREAM_ID_1), eq(sessionId), anyString(), anyInt(), anyInt(), eq(false));
@@ -1677,7 +1681,7 @@ class DriverConductorTest
     void shouldErrorOnAddPublicationWithNonEqualSessionId()
     {
         driverProxy.addPublication(CHANNEL_4000, STREAM_ID_1);
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final ArgumentCaptor<NetworkPublication> argumentCaptor = ArgumentCaptor.forClass(NetworkPublication.class);
         verify(senderProxy).newNetworkPublication(argumentCaptor.capture());
@@ -1685,7 +1689,7 @@ class DriverConductorTest
         final String sessionIdParam =
             "|" + CommonContext.SESSION_ID_PARAM_NAME + "=" + (argumentCaptor.getValue().sessionId() + 1);
         final long correlationId = driverProxy.addPublication(CHANNEL_4000 + sessionIdParam, STREAM_ID_1);
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         verify(mockClientProxy).onError(eq(correlationId), eq(GENERIC_ERROR), anyString());
         verify(mockErrorHandler).onError(any(Throwable.class));
@@ -1695,7 +1699,7 @@ class DriverConductorTest
     void shouldErrorOnAddPublicationWithClashingSessionId()
     {
         driverProxy.addPublication(CHANNEL_4000, STREAM_ID_1);
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final ArgumentCaptor<NetworkPublication> argumentCaptor = ArgumentCaptor.forClass(NetworkPublication.class);
         verify(senderProxy).newNetworkPublication(argumentCaptor.capture());
@@ -1703,7 +1707,7 @@ class DriverConductorTest
         final String sessionIdParam =
             "|" + CommonContext.SESSION_ID_PARAM_NAME + "=" + argumentCaptor.getValue().sessionId();
         final long correlationId = driverProxy.addExclusivePublication(CHANNEL_4000 + sessionIdParam, STREAM_ID_1);
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         verify(mockClientProxy).onError(eq(correlationId), eq(INVALID_CHANNEL), anyString());
         verify(mockErrorHandler).onError(any(Throwable.class));
@@ -1719,8 +1723,8 @@ class DriverConductorTest
         driverProxy.addPublication(channelIpcAndSessionId, STREAM_ID_1);
         driverProxy.addSubscription(channelIpcAndSessionId, STREAM_ID_1);
 
-        driverConductor.doWork();
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final IpcPublication ipcPublication = driverConductor.getSharedIpcPublication(STREAM_ID_1, Aeron.NULL_VALUE);
         assertNotNull(ipcPublication);
@@ -1740,8 +1744,8 @@ class DriverConductorTest
         driverProxy.addSubscription(channelIpcAndSessionId, STREAM_ID_1);
         driverProxy.addPublication(channelIpcAndSessionId, STREAM_ID_1);
 
-        driverConductor.doWork();
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final IpcPublication ipcPublication = driverConductor.getSharedIpcPublication(STREAM_ID_1, Aeron.NULL_VALUE);
         assertNotNull(ipcPublication);
@@ -1762,7 +1766,7 @@ class DriverConductorTest
         driverProxy.addPublication(CHANNEL_IPC + sessionIdPubParam, STREAM_ID_1);
         driverProxy.addSubscription(CHANNEL_IPC + sessionIdSubParam, STREAM_ID_1);
 
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final IpcPublication ipcPublication = driverConductor.getSharedIpcPublication(STREAM_ID_1, Aeron.NULL_VALUE);
         assertNotNull(ipcPublication);
@@ -1782,8 +1786,8 @@ class DriverConductorTest
         driverProxy.addSubscription(CHANNEL_IPC + sessionIdSubParam, STREAM_ID_1);
         driverProxy.addPublication(CHANNEL_IPC + sessionIdPubParam, STREAM_ID_1);
 
-        driverConductor.doWork();
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final IpcPublication ipcPublication = driverConductor.getSharedIpcPublication(STREAM_ID_1, Aeron.NULL_VALUE);
         assertNotNull(ipcPublication);
@@ -1800,8 +1804,8 @@ class DriverConductorTest
         driverProxy.addPublication(CHANNEL_4000 + sessionIdParam, STREAM_ID_1);
         driverProxy.addSubscription(spyForChannel(CHANNEL_4000 + sessionIdParam), STREAM_ID_1);
 
-        driverConductor.doWork();
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
         verify(senderProxy, times(1)).newNetworkPublication(captor.capture());
@@ -1824,7 +1828,7 @@ class DriverConductorTest
         driverProxy.addPublication(CHANNEL_4000 + sessionIdPubParam, STREAM_ID_1);
         driverProxy.addSubscription(spyForChannel(CHANNEL_4000 + sessionIdSubParam), STREAM_ID_1);
 
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
         verify(senderProxy, times(1)).newNetworkPublication(captor.capture());
@@ -1842,9 +1846,9 @@ class DriverConductorTest
         final int sessionId = -4097;
         final String sessionIdParam = "|" + CommonContext.SESSION_ID_PARAM_NAME + "=" + sessionId;
         driverProxy.addSubscription(spyForChannel(CHANNEL_4000 + sessionIdParam), STREAM_ID_1);
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
         driverProxy.addPublication(CHANNEL_4000 + sessionIdParam, STREAM_ID_1);
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
         verify(senderProxy, times(1)).newNetworkPublication(captor.capture());
@@ -1867,8 +1871,8 @@ class DriverConductorTest
         driverProxy.addSubscription(spyForChannel(CHANNEL_4000 + sessionIdSubParam), STREAM_ID_1);
         driverProxy.addPublication(CHANNEL_4000 + sessionIdPubParam, STREAM_ID_1);
 
-        driverConductor.doWork();
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
         verify(senderProxy, times(1)).newNetworkPublication(captor.capture());
@@ -1886,7 +1890,7 @@ class DriverConductorTest
         final long id1 = driverProxy.addPublication(CHANNEL_4000_TAG_ID_1, STREAM_ID_1);
         final long id2 = driverProxy.addPublication(CHANNEL_TAG_ID_1, STREAM_ID_1);
 
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
         verify(mockErrorHandler, never()).onError(any());
 
         verify(senderProxy).registerSendChannelEndpoint(any());
@@ -1907,8 +1911,8 @@ class DriverConductorTest
         final long id1 = driverProxy.addPublication(CHANNEL_4000_TAG_ID_1, STREAM_ID_1);
         final long id2 = driverProxy.addPublication(CHANNEL_TAG_ID_1, STREAM_ID_2);
 
-        driverConductor.doWork();
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
+        doWorkUntilOneClientCommandIsExecuted();
         verify(mockErrorHandler, never()).onError(any());
 
         verify(senderProxy).registerSendChannelEndpoint(any());
@@ -1929,8 +1933,8 @@ class DriverConductorTest
         final long id1 = driverProxy.addSubscription(CHANNEL_4000_TAG_ID_1, STREAM_ID_1);
         final long id2 = driverProxy.addSubscription(CHANNEL_TAG_ID_1, STREAM_ID_1);
 
-        driverConductor.doWork();
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
+        doWorkUntilOneClientCommandIsExecuted();
         verify(mockErrorHandler, never()).onError(any());
 
         verify(receiverProxy).registerReceiveChannelEndpoint(any());
@@ -1938,8 +1942,8 @@ class DriverConductorTest
         driverProxy.removeSubscription(id1);
         driverProxy.removeSubscription(id2);
 
-        driverConductor.doWork();
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
+        doWorkUntilOneClientCommandIsExecuted();
 
         verify(receiverProxy).closeReceiveChannelEndpoint(any());
     }
@@ -1950,16 +1954,16 @@ class DriverConductorTest
         final long id1 = driverProxy.addSubscription(CHANNEL_SUB_CONTROL_MODE_MANUAL, STREAM_ID_1);
         final long id2 = driverProxy.addSubscription(CHANNEL_SUB_CONTROL_MODE_MANUAL, STREAM_ID_1);
 
-        driverConductor.doWork();
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
+        doWorkUntilOneClientCommandIsExecuted();
 
         verify(receiverProxy, times(2)).registerReceiveChannelEndpoint(any());
 
         driverProxy.removeSubscription(id1);
         driverProxy.removeSubscription(id2);
 
-        driverConductor.doWork();
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
+        doWorkUntilOneClientCommandIsExecuted();
 
         verify(receiverProxy, times(2)).closeReceiveChannelEndpoint(any());
 
@@ -1972,8 +1976,8 @@ class DriverConductorTest
         driverProxy.addPublication(CHANNEL_4000_TAG_ID_1, STREAM_ID_1);
         final long idSpy = driverProxy.addSubscription(spyForChannel(CHANNEL_TAG_ID_1), STREAM_ID_1);
 
-        driverConductor.doWork();
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
         verify(senderProxy, times(1)).newNetworkPublication(captor.capture());
@@ -1994,8 +1998,8 @@ class DriverConductorTest
         final long idSpy = driverProxy.addSubscription(spyForChannel(CHANNEL_TAG_ID_1), STREAM_ID_1);
         driverProxy.addPublication(CHANNEL_4000_TAG_ID_1, STREAM_ID_1);
 
-        driverConductor.doWork();
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
+        doWorkUntilOneClientCommandIsExecuted();
 
         final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
         verify(senderProxy, times(1)).newNetworkPublication(captor.capture());
@@ -2016,17 +2020,17 @@ class DriverConductorTest
         final AtomicCounter maxCycleTime = spySystemCounters.get(CONDUCTOR_MAX_CYCLE_TIME);
         final AtomicCounter thresholdExceeded = spySystemCounters.get(CONDUCTOR_CYCLE_TIME_THRESHOLD_EXCEEDED);
 
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
         nanoClock.advance(MILLISECONDS.toNanos(750));
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
         nanoClock.advance(MILLISECONDS.toNanos(1000));
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
         nanoClock.advance(MILLISECONDS.toNanos(500));
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
         nanoClock.advance(MILLISECONDS.toNanos(600));
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
         nanoClock.advance(MILLISECONDS.toNanos(601));
-        driverConductor.doWork();
+        doWorkUntilOneClientCommandIsExecuted();
 
         assertEquals(SECONDS.toNanos(1), maxCycleTime.get());
         assertEquals(3, thresholdExceeded.get());
@@ -2035,47 +2039,56 @@ class DriverConductorTest
     @Test
     void shouldThrowExceptionWhenSendDestinationHasControlModeResponseSet()
     {
-        final Exception exception = assertThrowsExactly(InvalidChannelException.class,
-            () -> driverConductor.onAddSendDestination(13, "aeron:udp?control-mode=response", 19)
-        );
+        driverConductor.onAddSendDestination(13, "aeron:udp?control-mode=response", 19);
 
-        assertThat(exception.getMessage(), containsString(MDC_CONTROL_MODE_PARAM_NAME));
-        assertThat(exception.getMessage(), containsString(CONTROL_MODE_RESPONSE));
+        doWorkUntilOneClientCommandIsExecuted();
+
+        verify(mockClientProxy).onError(
+            eq(19L),
+            eq(INVALID_CHANNEL),
+            startsWith("ERROR - destinations may not specify " +
+                MDC_CONTROL_MODE_PARAM_NAME + "=" + CONTROL_MODE_RESPONSE)
+        );
     }
 
     @Test
     void shouldThrowExceptionWhenSendDestinationHasResponseCorrelationIdSet()
     {
-        final Exception exception = assertThrowsExactly(InvalidChannelException.class,
-            () -> driverConductor.onAddSendDestination(4, "aeron:udp?response-correlation-id=1234", 8)
-        );
+        driverConductor.onAddSendDestination(4, "aeron:udp?response-correlation-id=1234", 8);
 
-        assertThat(exception.getMessage(), containsString(RESPONSE_CORRELATION_ID_PARAM_NAME));
+
+        doWorkUntilOneClientCommandIsExecuted();
+
+        verify(mockClientProxy).onError(
+            eq(8L),
+            eq(INVALID_CHANNEL),
+            startsWith("ERROR - destinations must not contain the key: " + RESPONSE_CORRELATION_ID_PARAM_NAME)
+        );
     }
 
     @Test
     void shouldThrowExceptionWhenRcvDestinationHasControlModeResponseSet()
     {
-        final Exception exception = assertThrowsExactly(InvalidChannelException.class,
-            () -> driverConductor.onAddRcvDestination(5, "aeron:udp?control-mode=response", 7)
+        driverConductor.onAddRcvDestination(5, "aeron:udp?control-mode=response", 7);
+        doWorkUntilOneClientCommandIsExecuted();
+        verify(mockClientProxy).onError(
+            eq(7L),
+            eq(INVALID_CHANNEL),
+            startsWith("ERROR - destinations may not specify " +
+                MDC_CONTROL_MODE_PARAM_NAME + "=" + CONTROL_MODE_RESPONSE)
         );
-
-        assertEquals(
-            "ERROR - destinations may not specify " + MDC_CONTROL_MODE_PARAM_NAME + "=" + CONTROL_MODE_RESPONSE,
-            exception.getMessage());
     }
 
     @Test
     void shouldThrowExceptionWhenRcvDestinationHasResponseCorrelationIdSet()
     {
-        final Exception exception = assertThrowsExactly(InvalidChannelException.class,
-            () -> driverConductor.onAddRcvDestination(
-            42, "aeron:udp?endpoint=localhost:8080|response-correlation-id=1234", 1)
+        driverConductor.onAddRcvDestination(42, "aeron:udp?endpoint=localhost:8080|response-correlation-id=1234", 1L);
+        doWorkUntilOneClientCommandIsExecuted();
+        verify(mockClientProxy).onError(
+            eq(1L),
+            eq(INVALID_CHANNEL),
+            startsWith("ERROR - destinations must not contain the key: response-correlation-id")
         );
-
-        assertThat(
-            exception.getMessage(),
-            CoreMatchers.startsWith("ERROR - destinations must not contain the key: response-correlation-id"));
     }
 
     @Test
@@ -2102,7 +2115,7 @@ class DriverConductorTest
             nanoClock.advance(TimeUnit.MILLISECONDS.toNanos(millisecondsToAdvance));
             epochClock.advance(millisecondsToAdvance);
             timeConsumer.accept(nanoClock.nanoTime());
-            driverConductor.doWork();
+            doWorkUntilOneClientCommandIsExecuted();
         }
     }
 

--- a/aeron-system-tests/src/test/java/io/aeron/driver/SocketLifecycleTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/driver/SocketLifecycleTest.java
@@ -18,9 +18,10 @@ package io.aeron.driver;
 import io.aeron.Aeron;
 import io.aeron.AeronCounters;
 import io.aeron.CommonContext;
-import io.aeron.ErrorCode;
+import io.aeron.Publication;
 import io.aeron.Subscription;
-import io.aeron.exceptions.RegistrationException;
+import io.aeron.status.ChannelEndpointStatus;
+import io.aeron.status.LocalSocketAddressStatus;
 import io.aeron.test.EventLogExtension;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
@@ -33,14 +34,37 @@ import org.agrona.concurrent.status.CountersReader;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.FieldSource;
 
+import java.util.List;
+import java.util.Random;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.oneOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @ExtendWith({ EventLogExtension.class, InterruptingTestCallback.class })
 class SocketLifecycleTest
 {
     private static final int TEST_ITERATION_COUNT = 10;
+    private static final int EXAMPLE_TEST_ITERATION_COUNT = 100;
+    private static final int PROPERTY_TEST_ITERATION_COUNT = 1000;
+    private static final String PUBLISHER_MDC_URI = "aeron:udp?control-mode=dynamic|control=localhost:5001";
+    private static final String PUBLISHER_UNICAST_URI = "aeron:udp?control=localhost:5000|endpoint=localhost:10000";
+    private static final String SUBSCRIBER_UNICAST_URI = "aeron:udp?endpoint=localhost:10000";
+    private static final String IPC_URI = "aeron:ipc";
+    private static final List<String> PUBLISHER_URIS = List.of(
+        PUBLISHER_UNICAST_URI,
+        PUBLISHER_MDC_URI,
+        IPC_URI
+    );
+    private static final List<String> SUBSCRIBER_URIS = List.of(
+        SUBSCRIBER_UNICAST_URI,
+        IPC_URI
+    );
+    private static final int STREAM_ID = 1000;
 
     @RegisterExtension
     final SystemTestWatcher systemTestWatcher = new SystemTestWatcher();
@@ -49,7 +73,7 @@ class SocketLifecycleTest
     @InterruptAfter(10)
     void supportsClosingOpeningSubscriptionWithSameChannelUri0()
     {
-        try (TestMediaDriver driver = launchDriver();
+        try (TestMediaDriver driver = launchDriver(ThreadingMode.DEDICATED);
             Aeron aeron = Aeron.connect(new Aeron.Context().aeronDirectoryName(driver.aeronDirectoryName())))
         {
             final CountersReader countersReader = aeron.countersReader();
@@ -77,8 +101,7 @@ class SocketLifecycleTest
     @InterruptAfter(10)
     void supportsClosingOpeningSubscriptionWithSameChannelUri1()
     {
-        int unavailableCount = 0;
-        try (TestMediaDriver driver = launchDriver();
+        try (TestMediaDriver driver = launchDriver(ThreadingMode.DEDICATED);
             Aeron aeron = Aeron.connect(new Aeron.Context().aeronDirectoryName(driver.aeronDirectoryName())))
         {
             for (int i = 0; i < TEST_ITERATION_COUNT; i++)
@@ -86,32 +109,148 @@ class SocketLifecycleTest
                 Subscription subscription = null;
                 while (null == subscription)
                 {
-                    try
-                    {
-                        subscription = aeron.addSubscription("aeron:udp?endpoint=localhost:10000", 1000);
-                    }
-                    catch (final RegistrationException exception)
-                    {
-                        if (ErrorCode.RESOURCE_TEMPORARILY_UNAVAILABLE == exception.errorCode())
-                        {
-                            ++unavailableCount;
-                            Tests.yield();
-                        }
-                        else
-                        {
-                            throw exception;
-                        }
-                    }
+                    subscription = aeron.addSubscription("aeron:udp?endpoint=localhost:10000", 1000);
                 }
                 subscription.close();
             }
 
-            assumeTrue(unavailableCount > 0, "Expected at least one RESOURCE_TEMPORARILY_UNAVAILABLE exception");
             assertEquals(0, errorCount(aeron));
         }
     }
 
-    private TestMediaDriver launchDriver()
+    @ParameterizedTest
+    @FieldSource("SUBSCRIBER_URIS")
+    void supportsClosingAndImmediatelyOpeningSubscriptionWithSameChannel(final String channelUri)
+    {
+        try (TestMediaDriver driver = launchDriver(ThreadingMode.DEDICATED);
+            Aeron aeron = Aeron.connect(new Aeron.Context().aeronDirectoryName(driver.aeronDirectoryName())))
+        {
+            for (int i = 0; i < EXAMPLE_TEST_ITERATION_COUNT; i++)
+            {
+                final Subscription subscription = aeron.addSubscription(channelUri, STREAM_ID);
+                assertThat(
+                    subscription.channelStatus(),
+                    oneOf(ChannelEndpointStatus.INITIALIZING, ChannelEndpointStatus.ACTIVE)
+                );
+                subscription.close();
+            }
+
+            assertEquals(0, errorCount(aeron));
+        }
+    }
+
+    @ParameterizedTest
+    @FieldSource("PUBLISHER_URIS")
+    @InterruptAfter(10)
+    void supportsClosingAndImmediatelyOpeningPublicationWithSameChannel(final String channelUri)
+    {
+        try (TestMediaDriver driver = launchDriver(ThreadingMode.DEDICATED);
+            Aeron aeron = Aeron.connect(new Aeron.Context().aeronDirectoryName(driver.aeronDirectoryName())))
+        {
+            for (int i = 0; i < EXAMPLE_TEST_ITERATION_COUNT; i++)
+            {
+                final Publication publication = aeron.addPublication(channelUri, STREAM_ID);
+                assertThat(
+                    publication.channelStatus(),
+                    oneOf(ChannelEndpointStatus.INITIALIZING, ChannelEndpointStatus.ACTIVE)
+                );
+                publication.close();
+            }
+
+            assertEquals(0, errorCount(aeron));
+        }
+    }
+
+    @ParameterizedTest
+    @FieldSource("PUBLISHER_URIS")
+    void supportsClosingAndImmediatelyOpeningExclusivePublicationWithSameChannel(final String channelUri)
+    {
+        try (TestMediaDriver driver = launchDriver(ThreadingMode.DEDICATED);
+            Aeron aeron = Aeron.connect(new Aeron.Context().aeronDirectoryName(driver.aeronDirectoryName())))
+        {
+            for (int i = 0; i < EXAMPLE_TEST_ITERATION_COUNT; i++)
+            {
+                final long registrationId = aeron.asyncAddExclusivePublication(channelUri, STREAM_ID);
+                aeron.asyncRemovePublication(registrationId);
+            }
+
+            assertEquals(0, errorCount(aeron));
+        }
+    }
+
+    @Test
+    @InterruptAfter(10)
+    void noInterferenceBetweenMdsSubscriptionsSharingSameMulticastDestination()
+    {
+        try (TestMediaDriver driver = launchDriver(ThreadingMode.DEDICATED);
+            Aeron aeron = Aeron.connect(new Aeron.Context().aeronDirectoryName(driver.aeronDirectoryName()));
+        )
+        {
+            final Subscription subscription1 = aeron.addSubscription("aeron:udp?control-mode=manual", STREAM_ID);
+            final Subscription subscription2 = aeron.addSubscription("aeron:udp?control-mode=manual", STREAM_ID);
+
+            final String multicastChannel = "aeron:udp?endpoint=239.192.12.87:20123|interface=127.0.0.1";
+            subscription1.asyncAddDestination(multicastChannel);
+            subscription2.asyncAddDestination(multicastChannel);
+
+            final CountersReader countersReader = aeron.countersReader();
+
+            int counterId1 = CountersReader.NULL_COUNTER_ID;
+            int counterId2 = CountersReader.NULL_COUNTER_ID;
+
+            while (counterId1 == CountersReader.NULL_COUNTER_ID || counterId2 == CountersReader.NULL_COUNTER_ID)
+            {
+                counterId1 = countersReader.findByTypeIdAndRegistrationId(
+                    LocalSocketAddressStatus.LOCAL_SOCKET_ADDRESS_STATUS_TYPE_ID,
+                    subscription1.registrationId()
+                );
+
+                counterId2 = countersReader.findByTypeIdAndRegistrationId(
+                    LocalSocketAddressStatus.LOCAL_SOCKET_ADDRESS_STATUS_TYPE_ID,
+                    subscription2.registrationId()
+                );
+
+                Tests.yield();
+            }
+
+            subscription1.removeDestination(multicastChannel);
+
+            final int finalCounterId1 = counterId1;
+            Tests.await(() -> countersReader.getCounterState(finalCounterId1) == CountersReader.RECORD_RECLAIMED);
+            assertEquals(ChannelEndpointStatus.ACTIVE, countersReader.getCounterValue(counterId2));
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ThreadingMode.class, mode = EnumSource.Mode.EXCLUDE, names = "INVOKER")
+    void randomlyAttemptToReuseSockets(final ThreadingMode threadingMode)
+    {
+        try (TestMediaDriver driver = launchDriver(threadingMode);
+            Aeron aeron1 = Aeron.connect(new Aeron.Context().aeronDirectoryName(driver.aeronDirectoryName()));
+            Aeron aeron2 = Aeron.connect(new Aeron.Context().aeronDirectoryName(driver.aeronDirectoryName()));
+            Aeron aeron3 = Aeron.connect(new Aeron.Context().aeronDirectoryName(driver.aeronDirectoryName()));
+            Aeron aeron4 = Aeron.connect(new Aeron.Context().aeronDirectoryName(driver.aeronDirectoryName()));
+            Aeron aeron5 = Aeron.connect(new Aeron.Context().aeronDirectoryName(driver.aeronDirectoryName())))
+        {
+
+            final AeronClientState[] state = {
+                new AeronClientState(aeron1),
+                new AeronClientState(aeron2),
+                new AeronClientState(aeron3),
+                new AeronClientState(aeron4),
+                new AeronClientState(aeron5)
+            };
+
+            final Random random = new Random();
+
+            for (int i = 0; i < PROPERTY_TEST_ITERATION_COUNT; i++)
+            {
+                state[i % state.length].performOperation(random);
+            }
+        }
+    }
+
+    private TestMediaDriver launchDriver(final ThreadingMode threadingMode)
     {
         TestMediaDriver.notSupportedOnCMediaDriver("C Media Driver requires more work");
 
@@ -120,7 +259,7 @@ class SocketLifecycleTest
         final MediaDriver.Context driverCtx = new MediaDriver.Context()
             .aeronDirectoryName(aeronDirectoryName)
             .termBufferSparseFile(true)
-            .threadingMode(ThreadingMode.DEDICATED)
+            .threadingMode(threadingMode)
             .dirDeleteOnStart(true)
             .conductorIdleStrategy(new NoOpIdleStrategy())
             .receiverIdleStrategy(new SleepingMillisIdleStrategy(2))
@@ -140,5 +279,55 @@ class SocketLifecycleTest
             AeronCounters.DRIVER_SYSTEM_COUNTER_TYPE_ID,
             AeronCounters.SYSTEM_COUNTER_ID_ERRORS);
         return countersReader.getCounterValue(counterId);
+    }
+
+    private static final class AeronClientState
+    {
+        private final Aeron aeron;
+        private Subscription subscription;
+        private Publication publication;
+
+        AeronClientState(final Aeron aeron)
+        {
+            this.aeron = aeron;
+        }
+
+        public void performOperation(final Random random)
+        {
+            final boolean isPublicationOp = random.nextBoolean();
+            if (isPublicationOp)
+            {
+                if (null != publication)
+                {
+                    publication.close();
+                    publication = null;
+                }
+                else
+                {
+                    final String uri = PUBLISHER_URIS.get(random.nextInt(PUBLISHER_URIS.size()));
+                    final boolean isExclusive = random.nextBoolean();
+                    if (isExclusive)
+                    {
+                        publication = aeron.addExclusivePublication(uri, STREAM_ID);
+                    }
+                    else
+                    {
+                        publication = aeron.addPublication(uri, STREAM_ID);
+                    }
+                }
+            }
+            else
+            {
+                if (null != subscription)
+                {
+                    subscription.close();
+                    subscription = null;
+                }
+                else
+                {
+                    subscription = aeron.addSubscription(SUBSCRIBER_UNICAST_URI, STREAM_ID);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
We have introduced the concept of a `ClientCommand` to the `DriverConductor` to allow commands to be written as state machines and execute asynchronously. The conductor only executes one `ClientCommand` at a time. Therefore, it does not poll the command queue from clients while a command is in progress, as this may create new commands, and when it does poll it limits the poll to a single message (as before). The logic around asynchronously parsing UDP channels has been folded into these state machines.

Since only one command is executed at a time. Dependencies between certain actions are now explicit. For example, a sequence of commands `RemoveSubscription` -> `AddSubscription` now works as expected without any errors.