### PR TITLE
Fixed accidentally-added "final" modifiers for several classes

### DIFF
--- a/aeron-agent/src/main/java/io/aeron/agent/ArchiveComponentLogger.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ArchiveComponentLogger.java
@@ -36,7 +36,7 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
  * Implementation of a component logger for archive log events.
  */
 @Versioned
-public final class ArchiveComponentLogger implements ComponentLogger
+public class ArchiveComponentLogger implements ComponentLogger
 {
     static final EnumSet<ArchiveEventCode> ENABLED_EVENTS = EnumSet.noneOf(ArchiveEventCode.class);
     private static final Object2ObjectHashMap<String, EnumSet<ArchiveEventCode>> SPECIAL_EVENTS =

--- a/aeron-client/src/main/java/io/aeron/Aeron.java
+++ b/aeron-client/src/main/java/io/aeron/Aeron.java
@@ -908,9 +908,12 @@ public final class Aeron implements AutoCloseable
     /**
      * Configuration options for the {@link Aeron} client.
      */
-    public static final class Configuration
+    public static class Configuration
     {
-        private Configuration()
+        /**
+         * Create an instance. All configuration options are provided via static members.
+         */
+        public Configuration()
         {
         }
 
@@ -1110,7 +1113,7 @@ public final class Aeron implements AutoCloseable
      * The context will be owned by {@link ClientConductor} after a successful
      * {@link Aeron#connect(Context)} and closed via {@link Aeron#close()}.
      */
-    public static final class Context extends CommonContext
+    public static class Context extends CommonContext
     {
         private long clientId;
         private String clientName = Configuration.clientName();

--- a/aeron-client/src/main/java/io/aeron/status/HeartbeatTimestamp.java
+++ b/aeron-client/src/main/java/io/aeron/status/HeartbeatTimestamp.java
@@ -30,9 +30,13 @@ import static org.agrona.concurrent.status.CountersReader.*;
 /**
  * Allocate a counter for tracking the last heartbeat of an entity with a given registration id.
  */
-public final class HeartbeatTimestamp
+public class HeartbeatTimestamp
 {
-    private HeartbeatTimestamp()
+    /**
+     * Create an instance. All functionality is provided via static methods; this constructor exists to
+     * allow subclassing for custom heartbeat counter types.
+     */
+    public HeartbeatTimestamp()
     {
     }
 

--- a/aeron-cluster/src/main/java/io/aeron/cluster/AppVersionValidator.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/AppVersionValidator.java
@@ -22,9 +22,13 @@ import org.agrona.SemanticVersion;
  * <p>
  * Default is to use {@link org.agrona.SemanticVersion} major version for checking compatibility.
  */
-public final class AppVersionValidator
+public class AppVersionValidator
 {
-    private AppVersionValidator()
+    /**
+     * Create a validator which uses {@link org.agrona.SemanticVersion} major version for checking compatibility.
+     * Subclasses may override {@link #isVersionCompatible(int, int)} to provide a custom policy.
+     */
+    public AppVersionValidator()
     {
     }
 

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackup.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackup.java
@@ -318,9 +318,12 @@ public final class ClusterBackup implements AutoCloseable
      * Configuration options for {@link ClusterBackup} with defaults and constants for system properties lookup.
      */
     @Config(existsInC = false)
-    public static final class Configuration
+    public static class Configuration
     {
-        private Configuration()
+        /**
+         * Create an instance. All configuration options are provided via static members.
+         */
+        public Configuration()
         {
         }
 

--- a/aeron-driver/src/main/java/io/aeron/driver/status/ClientHeartbeatTimestamp.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/status/ClientHeartbeatTimestamp.java
@@ -20,21 +20,23 @@ import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.status.AtomicCounter;
 import org.agrona.concurrent.status.CountersManager;
 
-import static io.aeron.status.HeartbeatTimestamp.HEARTBEAT_TYPE_ID;
-
 /**
  * Counter for tracking the timestamp of a last heartbeat from an Aeron client.
  *
  * @see HeartbeatTimestamp
  */
-public final class ClientHeartbeatTimestamp
+public class ClientHeartbeatTimestamp extends HeartbeatTimestamp
 {
     /**
      * Human-readable name for the counter.
      */
     public static final String NAME = "client-heartbeat";
 
-    private ClientHeartbeatTimestamp()
+    /**
+     * Create an instance. All functionality is provided via static methods; this constructor exists to
+     * allow subclassing for custom heartbeat counter types.
+     */
+    public ClientHeartbeatTimestamp()
     {
     }
 


### PR DESCRIPTION
Classes that are either required to be extended or might plausibly be usefully extended:

- io.aeron.cluster.AppVersionValidator
- io.aeron.Aeron.Context
- io.aeron.status.HeartbeatTimestamp
- io.aeron.agent.ArchiveComponentLogger
- io.aeron.Aeron.Configuration
- io.aeron.cluster.ClusterBackup.Configuration
- io.aeron.driver.status.ClientHeartbeatTimestamp

I've reverted those & made sure checkstyle / javadoc passes.

There were a lot of other classes (40+) marked `final` in 1.51.0 as well, but I did not revert those - the ones in the list above are the ones that I think someone might actually have a reason to be non-final.  My opinion is it's nice to make things final if you can, so we should leave the rest of the `final`s in until someone actually complains.