### PR TITLE
Added VersionValidator interface, made AppVersionValidator implement it

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
@@ -1667,7 +1667,7 @@ public final class ConsensusModule implements AutoCloseable
         private EgressPublisher egressPublisher;
         private DutyCycleTracker dutyCycleTracker;
         private SnapshotDurationTracker totalSnapshotDurationTracker;
-        private AppVersionValidator appVersionValidator;
+        private VersionValidator appVersionValidator;
         private boolean isLogMdc;
         private boolean useAgentInvoker = false;
         private ConsensusModuleStateExport bootstrapState = null;
@@ -2335,7 +2335,7 @@ public final class ConsensusModule implements AutoCloseable
          * @param appVersionValidator for user application.
          * @return this for fluent API.
          */
-        public Context appVersionValidator(final AppVersionValidator appVersionValidator)
+        public Context appVersionValidator(final VersionValidator appVersionValidator)
         {
             this.appVersionValidator = appVersionValidator;
             return this;
@@ -2346,9 +2346,9 @@ public final class ConsensusModule implements AutoCloseable
          * <p>
          * The default is to use {@link org.agrona.SemanticVersion} major version for checking compatibility.
          *
-         * @return AppVersionValidator in use.
+         * @return VersionValidator in use.
          */
-        public AppVersionValidator appVersionValidator()
+        public VersionValidator appVersionValidator()
         {
             return appVersionValidator;
         }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/VersionValidator.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/VersionValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 Real Logic Limited.
+ * Copyright 2026 Adaptive Financial Consulting Limited.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,25 +15,17 @@
  */
 package io.aeron.cluster;
 
-import org.agrona.SemanticVersion;
-
 /**
- * Default {@link VersionValidator} used for determining AppVersion compatibility, which uses
- * {@link org.agrona.SemanticVersion} major version for checking compatibility.
+ * Interface for determining AppVersion compatibility, so that a custom policy can be supplied via
+ * {@link ConsensusModule.Context#appVersionValidator(VersionValidator)} and
+ * {@link io.aeron.cluster.service.ClusteredServiceContainer.Context#appVersionValidator(VersionValidator)}.
  * <p>
- * A custom policy can be supplied by implementing {@link VersionValidator}.
+ * The default implementation is {@link AppVersionValidator#SEMANTIC_VERSIONING_VALIDATOR} which uses
+ * {@link org.agrona.SemanticVersion} major version for checking compatibility.
  */
-public final class AppVersionValidator implements VersionValidator
+@FunctionalInterface
+public interface VersionValidator
 {
-    private AppVersionValidator()
-    {
-    }
-
-    /**
-     * Singleton instance of {@link AppVersionValidator} version which can be used to avoid allocation.
-     */
-    public static final AppVersionValidator SEMANTIC_VERSIONING_VALIDATOR = new AppVersionValidator();
-
     /**
      * Check version compatibility between configured context appVersion and appVersion in
      * new leadership term or snapshot.
@@ -42,8 +34,5 @@ public final class AppVersionValidator implements VersionValidator
      * @param appVersionUnderTest to check against configured appVersion.
      * @return true for compatible or false for not compatible.
      */
-    public boolean isVersionCompatible(final int contextAppVersion, final int appVersionUnderTest)
-    {
-        return SemanticVersion.major(contextAppVersion) == SemanticVersion.major(appVersionUnderTest);
-    }
+    boolean isVersionCompatible(int contextAppVersion, int appVersionUnderTest);
 }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceContainer.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceContainer.java
@@ -22,6 +22,7 @@ import io.aeron.RethrowingErrorHandler;
 import io.aeron.Subscription;
 import io.aeron.archive.client.AeronArchive;
 import io.aeron.cluster.AppVersionValidator;
+import io.aeron.cluster.VersionValidator;
 import io.aeron.cluster.client.ClusterException;
 import io.aeron.cluster.codecs.mark.ClusterComponentType;
 import io.aeron.cluster.codecs.mark.MarkFileHeaderEncoder;
@@ -778,7 +779,7 @@ public final class ClusteredServiceContainer implements AutoCloseable
         private Aeron aeron;
         private DutyCycleTracker dutyCycleTracker;
         private SnapshotDurationTracker snapshotDurationTracker;
-        private AppVersionValidator appVersionValidator;
+        private VersionValidator appVersionValidator;
         private boolean ownsAeronClient;
 
         private ClusteredService clusteredService;
@@ -1097,7 +1098,7 @@ public final class ClusteredServiceContainer implements AutoCloseable
          * @param appVersionValidator for user application.
          * @return this for fluent API.
          */
-        public Context appVersionValidator(final AppVersionValidator appVersionValidator)
+        public Context appVersionValidator(final VersionValidator appVersionValidator)
         {
             this.appVersionValidator = appVersionValidator;
             return this;
@@ -1108,9 +1109,9 @@ public final class ClusteredServiceContainer implements AutoCloseable
          * <p>
          * The default is to use {@link org.agrona.SemanticVersion} major version for checking compatibility.
          *
-         * @return AppVersionValidator in use.
+         * @return VersionValidator in use.
          */
-        public AppVersionValidator appVersionValidator()
+        public VersionValidator appVersionValidator()
         {
             return appVersionValidator;
         }

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleAgentTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleAgentTest.java
@@ -668,7 +668,7 @@ class ConsensusModuleAgentTest
 
         controlToggle.set(NEUTRAL.code());
 
-        final AppVersionValidator appVersionValidator = mock(AppVersionValidator.class);
+        final VersionValidator appVersionValidator = mock(VersionValidator.class);
         when(appVersionValidator.isVersionCompatible(anyInt(), anyInt())).thenReturn(true);
         ctx.moduleStateCounter(stateCounter)
             .controlToggleCounter(controlToggle)


### PR DESCRIPTION
Per @vyazelenko 's request.

Users should now create a class that implements VersionValidator rather than subclassing AppVersionValidator.