### PR TITLE
Add PowerPC 64-bit (ppc64le) support to C and C++ clients

### DIFF
--- a/aeron-client/src/main/c/concurrent/aeron_atomic.h
+++ b/aeron-client/src/main/c/concurrent/aeron_atomic.h
@@ -58,7 +58,7 @@ while (false)
 
 #endif
 
-#if !defined(AERON_CPU_X64) && !defined(AERON_CPU_ARM)
+#if !defined(AERON_CPU_X64) && !defined(AERON_CPU_ARM) && !defined(AERON_CPU_PPC64)
     #error Unsupported CPU type!
 #endif
 
@@ -66,6 +66,8 @@ while (false)
     #if defined(AERON_CPU_X64)
         #include "concurrent/aeron_atomic64_gcc_x86_64.h"
     #elif defined(AERON_CPU_ARM)
+        #include "concurrent/aeron_atomic64_c11.h"
+    #elif defined(AERON_CPU_PPC64)
         #include "concurrent/aeron_atomic64_c11.h"
     #endif
 #elif defined(AERON_COMPILER_MSVC)

--- a/aeron-client/src/main/c/concurrent/aeron_thread.c
+++ b/aeron-client/src/main/c/concurrent/aeron_thread.c
@@ -627,7 +627,7 @@ int aeron_cond_signal(aeron_cond_t *cv)
 
 void proc_yield(void)
 {
-#if !defined(AERON_CPU_ARM)
+#if !defined(AERON_CPU_ARM) && !defined(AERON_CPU_PPC64)
     __asm__ __volatile__("pause\n": : : "memory");
 #endif
 }

--- a/aeron-client/src/main/c/util/aeron_platform.h
+++ b/aeron-client/src/main/c/util/aeron_platform.h
@@ -51,6 +51,13 @@
 #endif
 #endif
 
+#if defined(__powerpc64__)
+#define AERON_CPU_PPC64 1
+#if defined(__STDC_NO_ATOMICS__)
+#error C11 atomics are required to compile for powerpc64!
+#endif
+#endif
+
 #if defined(__cplusplus)
 #define _Static_assert static_assert
 #endif

--- a/aeron-client/src/main/cpp_wrapper/concurrent/Atomic64.h
+++ b/aeron-client/src/main/cpp_wrapper/concurrent/Atomic64.h
@@ -22,6 +22,8 @@
     #include "concurrent/atomic/Atomic64_gcc_x86_64.h"
 #elif defined(AERON_COMPILER_GCC) && defined(AERON_CPU_ARM)
     #include "concurrent/atomic/Atomic64_gcc_cpp11.h"
+#elif defined(AERON_COMPILER_GCC) && defined(AERON_CPU_PPC64)
+    #include "concurrent/atomic/Atomic64_gcc_cpp11.h"
 #elif defined(AERON_COMPILER_MSVC) && defined(AERON_CPU_X64)
     #include "concurrent/atomic/Atomic64_msvc.h"
 #elif defined(AERON_COMPILER_MSVC) && defined(AERON_CPU_ARM)

--- a/aeron-client/src/main/cpp_wrapper/util/Platform.h
+++ b/aeron-client/src/main/cpp_wrapper/util/Platform.h
@@ -50,6 +50,10 @@
         #endif
     #endif
 
+    #if defined(__powerpc64__)
+        #define AERON_CPU_PPC64 1
+    #endif
+
 #else
     #error Unsupported compiler!
 #endif


### PR DESCRIPTION
Detect __powerpc64__ as AERON_CPU_PPC64 in both the C and C++ (cpp_wrapper)
clients and route atomic operations to the portable C11/C++11 implementations
already used for AArch64. Skip the x86 'pause' instruction in proc_yield() on
PowerPC, matching the existing AArch64 handling.

Built and tested on FreeBSD/powerpc64le.

Signed-off-by: Piotr Kubaj <pkubaj@FreeBSD.org>
