### PR TITLE
Fixed accidental send channel endpoint map removal

### DIFF
--- a/aeron-driver/src/main/c/aeron_driver_conductor.c
+++ b/aeron-driver/src/main/c/aeron_driver_conductor.c
@@ -1574,10 +1574,19 @@ bool aeron_send_channel_endpoint_entry_has_reached_end_of_life(
 void aeron_send_channel_endpoint_entry_delete(
     aeron_driver_conductor_t *conductor, aeron_send_channel_endpoint_entry_t *entry)
 {
-    aeron_str_to_ptr_hash_map_remove(
+    // Only remove the map entry if it still refers to this endpoint. A new endpoint
+    // with the same canonical form may have already been created by the time we get
+    // here, in which case we don't want to remove that new endpoint's map entry.
+    if (entry->endpoint == aeron_str_to_ptr_hash_map_get(
         &conductor->send_channel_endpoint_by_channel_map,
         entry->endpoint->conductor_fields.udp_channel->canonical_form,
-        entry->endpoint->conductor_fields.udp_channel->canonical_length);
+        entry->endpoint->conductor_fields.udp_channel->canonical_length))
+    {
+        aeron_str_to_ptr_hash_map_remove(
+            &conductor->send_channel_endpoint_by_channel_map,
+            entry->endpoint->conductor_fields.udp_channel->canonical_form,
+            entry->endpoint->conductor_fields.udp_channel->canonical_length);
+    }
 
     aeron_send_channel_endpoint_delete(&conductor->counters_manager, entry->endpoint);
 }

--- a/aeron-driver/src/test/c/aeron_driver_conductor_network_test.cpp
+++ b/aeron-driver/src/test/c/aeron_driver_conductor_network_test.cpp
@@ -489,6 +489,92 @@ TEST_F(DriverConductorNetworkTest, shouldUseExistingChannelEndpointOnAddPublicat
     EXPECT_EQ(aeron_driver_conductor_num_send_channel_endpoints(&m_conductor.m_conductor), 0u);
 }
 
+TEST_F(DriverConductorNetworkTest, shouldNotEvictRecreatedSendChannelEndpointWhenPriorEndpointDeferredDeleteRuns)
+{
+    int64_t client_id = nextCorrelationId();
+    int64_t pub_id_1 = nextCorrelationId();
+
+    // Create the initial send channel endpoint for the channel.
+    ASSERT_EQ(addPublication(client_id, pub_id_1, CHANNEL_1, STREAM_ID_1, false), 0);
+    doWorkUntilDone();
+    ASSERT_EQ(aeron_driver_conductor_num_send_channel_endpoints(&m_conductor.m_conductor), 1u);
+
+    aeron_send_channel_endpoint_t *endpoint_a = aeron_driver_conductor_find_send_channel_endpoint(
+        &m_conductor.m_conductor, CHANNEL_1);
+    ASSERT_NE(endpoint_a, nullptr);
+
+    char canonical[1024];
+    size_t canonical_length = endpoint_a->conductor_fields.udp_channel->canonical_length;
+    ASSERT_LT(canonical_length, sizeof(canonical));
+    memcpy(canonical, endpoint_a->conductor_fields.udp_channel->canonical_form, canonical_length);
+
+    aeron_str_to_ptr_hash_map_t *endpoint_map =
+        &m_conductor.m_conductor.send_channel_endpoint_by_channel_map;
+
+    // Begin teardown of the endpoint by removing its only publication.
+    int64_t remove_id = nextCorrelationId();
+    ASSERT_EQ(removePublication(client_id, remove_id, pub_id_1), 0);
+    doWork();
+
+    // Advance past the publication linger (one timer cycle per iteration) until the publication is freed,
+    // which drops the endpoint reference count to zero and transitions it to CLOSING.
+    int guard = 0;
+    while (0u != aeron_driver_conductor_num_network_publications(&m_conductor.m_conductor) && guard++ < 1000)
+    {
+        test_increment_nano_time((int64_t)m_context.m_context->publication_linger_timeout_ns + 1);
+        clientKeepalive(client_id);
+        doWork();
+    }
+
+    // Complete the conductor->sender->conductor release round-trip with plain doWork() calls. doWork() does
+    // not advance the test clock, so the managed-resource sweep does not run: this leaves the endpoint removed
+    // from the lookup map (by on_release_resource) but still present in the endpoint array awaiting its
+    // deferred delete.
+    guard = 0;
+    while (nullptr != aeron_str_to_ptr_hash_map_get(endpoint_map, canonical, canonical_length) &&
+        guard++ < 1000)
+    {
+        doWork();
+    }
+
+    // Window reached: prior endpoint is out of the lookup map but still in the array.
+    ASSERT_EQ(nullptr, aeron_str_to_ptr_hash_map_get(endpoint_map, canonical, canonical_length));
+    ASSERT_EQ(aeron_driver_conductor_num_send_channel_endpoints(&m_conductor.m_conductor), 1u);
+
+    // Recreate an endpoint for the same channel. It is mapped under the same canonical form as the prior,
+    // not-yet-deleted endpoint.
+    int64_t pub_id_2 = nextCorrelationId();
+    ASSERT_EQ(addPublication(client_id, pub_id_2, CHANNEL_1, STREAM_ID_1, false), 0);
+    doWorkUntilDone();
+
+    void *mapped_b = aeron_str_to_ptr_hash_map_get(endpoint_map, canonical, canonical_length);
+    ASSERT_NE(nullptr, mapped_b);
+    ASSERT_EQ(aeron_driver_conductor_num_send_channel_endpoints(&m_conductor.m_conductor), 2u);
+
+    // Fire managed-resource sweeps until the prior end-of-life endpoint is deferred-deleted. The deferred
+    // delete must not remove the map entry that now belongs to the recreated successor.
+    int sweep_guard = 0;
+    while (aeron_driver_conductor_num_send_channel_endpoints(&m_conductor.m_conductor) > 1u &&
+        sweep_guard++ < 1000)
+    {
+        test_increment_nano_time((int64_t)m_context.m_context->timer_interval_ns + 1);
+        clientKeepalive(client_id);
+        doWork();
+    }
+    ASSERT_EQ(aeron_driver_conductor_num_send_channel_endpoints(&m_conductor.m_conductor), 1u);
+
+    // Regression: a stale-handle deferred delete used to remove the map entry by canonical form
+    // unconditionally, evicting the live successor and leaving the lookup map and endpoint array inconsistent.
+    EXPECT_EQ(mapped_b, aeron_str_to_ptr_hash_map_get(endpoint_map, canonical, canonical_length));
+
+    // A subsequent publication on the same channel must reuse the mapped endpoint rather than create a
+    // duplicate (which, against a real media driver, collides on the bind with EADDRINUSE).
+    int64_t pub_id_3 = nextCorrelationId();
+    ASSERT_EQ(addPublication(client_id, pub_id_3, CHANNEL_1, STREAM_ID_1, false), 0);
+    doWorkUntilDone();
+    EXPECT_EQ(aeron_driver_conductor_num_send_channel_endpoints(&m_conductor.m_conductor), 1u);
+}
+
 TEST_F(DriverConductorNetworkTest, shouldUseExistingChannelEndpointOnAddPublicationWithSameTagIdDifferentStreamId)
 {
     int64_t client_id = nextCorrelationId();


### PR DESCRIPTION
Removing an endpoint from the map in `aeron_send_channel_endpoint_entry_delete` just removed it keyed off the canonical form of the endpoint without checking that the entry in the map really did refer to the endpoint supposedly being removed.  Which meant that if a _new_ endpoint had been added to the map in between the old endpoint's socket being closed and `aeron_send_channel_endpoint_entry_delete` being called for the old endpoint, then `aeron_send_channel_endpoint_entry_delete` would remove the map entry for what was now the _new_ endpoint.