### PR TITLE
Retry asyncAddIngressPublication in addNewLeaderIngressPublication

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
@@ -757,15 +757,32 @@ public final class AeronCluster implements AutoCloseable
 
     private Publication addNewLeaderIngressPublication(final Context ctx, final String channel, final int streamId)
     {
-        final long registrationId = asyncAddIngressPublication(ctx, channel, streamId);
+        long registrationId = asyncAddIngressPublication(ctx, channel, streamId);
         final long deadlineNs = nanoClock.nanoTime() + ctx.messageTimeoutNs();
         do
         {
-            final Publication publication = getIngressPublication(ctx, registrationId);
-            if (null != publication)
+            if (NULL_VALUE == registrationId)
             {
-                return publication;
+                registrationId = asyncAddIngressPublication(ctx, channel, streamId);
             }
+
+            try
+            {
+                final Publication publication = getIngressPublication(ctx, registrationId);
+                if (null != publication)
+                {
+                    return publication;
+                }
+            }
+            catch (final RegistrationException ex)
+            {
+                registrationId = NULL_VALUE;
+                if (ErrorCode.RESOURCE_TEMPORARILY_UNAVAILABLE != ex.errorCode())
+                {
+                    throw ex;
+                }
+            }
+
             idleStrategy.idle(ctx.runAgentInvokers());
         }
         while (nanoClock.nanoTime() < deadlineNs);

--- a/aeron-cluster/src/test/java/io/aeron/cluster/client/AeronClusterTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/client/AeronClusterTest.java
@@ -16,6 +16,7 @@
 package io.aeron.cluster.client;
 
 import io.aeron.Aeron;
+import io.aeron.ErrorCode;
 import io.aeron.ExclusivePublication;
 import io.aeron.Image;
 import io.aeron.Publication;
@@ -23,6 +24,7 @@ import io.aeron.RethrowingErrorHandler;
 import io.aeron.Subscription;
 import io.aeron.cluster.codecs.MessageHeaderEncoder;
 import io.aeron.cluster.codecs.NewLeaderEventEncoder;
+import io.aeron.exceptions.RegistrationException;
 import io.aeron.logbuffer.BufferClaim;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.FrameDescriptor;
@@ -185,6 +187,28 @@ class AeronClusterTest
         nanoTime += 1;
 
         assertEquals(0, aeronCluster.pollEgress());
+        assertFalse(aeronCluster.isClosed());
+    }
+
+    @Test
+    void shouldRetryNewLeaderIngressPublicationWhenSendChannelEndpointIsClosing()
+    {
+        // When the ingress publication for a new leader is added, the send channel endpoint of the
+        // just-closed publication may still be closing, so the driver returns a retryable error. The client
+        // must retry rather than fail the leader change.
+        final long registrationId = ingressPublication.registrationId();
+        when(aeron.getExclusivePublication(registrationId))
+            .thenThrow(new RegistrationException(
+                registrationId,
+                ErrorCode.RESOURCE_TEMPORARILY_UNAVAILABLE.value(),
+                ErrorCode.RESOURCE_TEMPORARILY_UNAVAILABLE,
+                "send_channel_endpoint found in CLOSING state, please retry"))
+            .thenReturn(ingressPublication);
+
+        makeEgressSubscriptionDeliverNewLeaderEvent();
+
+        assertEquals(1, aeronCluster.pollEgress());
+        verify(egressListener).onNewLeader(CLUSTER_SESSION_ID, leadershipTermId, leaderMemberId, INGRESS_ENDPOINTS);
         assertFalse(aeronCluster.isClosed());
     }
 


### PR DESCRIPTION
We do a similar retry for other resource-temporarily-unavailable exceptions elsewhere; seems OK to do it here, too (and fix a source of test flakiness).