### PR TITLE
[Driver/C] Do not log RESOURCE_TEMPORARILY_UNAVAILABLE

### DIFF
--- a/aeron-driver/src/main/c/aeron_driver_conductor.c
+++ b/aeron-driver/src/main/c/aeron_driver_conductor.c
@@ -2768,7 +2768,10 @@ void aeron_driver_conductor_on_error(
     }
 
 log_error:
-    aeron_driver_conductor_log_explicit_error(conductor, code, errmsg);
+    if (AERON_ERROR_CODE_RESOURCE_TEMPORARILY_UNAVAILABLE != code)
+    {
+        aeron_driver_conductor_log_explicit_error(conductor, code, errmsg);
+    }
 }
 
 void on_publication_ready(

--- a/aeron-driver/src/main/c/aeron_driver_conductor.h
+++ b/aeron-driver/src/main/c/aeron_driver_conductor.h
@@ -429,6 +429,9 @@ void aeron_driver_conductor_on_unavailable_counter(
 
 void aeron_driver_conductor_on_client_timeout(aeron_driver_conductor_t *conductor, int64_t correlation_id);
 
+void aeron_driver_conductor_on_error(
+    aeron_driver_conductor_t *conductor, int32_t errcode, const char *errmsg, int64_t correlation_id);
+
 void aeron_driver_conductor_on_static_counter(
     aeron_driver_conductor_t *conductor, int64_t correlation_id, int32_t counter_id);
 

--- a/aeron-driver/src/test/c/aeron_driver_conductor_network_test.cpp
+++ b/aeron-driver/src/test/c/aeron_driver_conductor_network_test.cpp
@@ -489,6 +489,35 @@ TEST_F(DriverConductorNetworkTest, shouldUseExistingChannelEndpointOnAddPublicat
     EXPECT_EQ(aeron_driver_conductor_num_send_channel_endpoints(&m_conductor.m_conductor), 0u);
 }
 
+TEST_F(DriverConductorNetworkTest, shouldNotLogRetryableResourceTemporarilyUnavailableToDistinctErrorLog)
+{
+    const int64_t correlation_id = nextCorrelationId();
+    const size_t observations_before =
+        aeron_distinct_error_log_num_observations(&m_conductor.m_conductor.error_log);
+
+    // RESOURCE_TEMPORARILY_UNAVAILABLE is a transient, retryable condition reported to the client (for example
+    // adding a publication while a send channel endpoint is still closing). It must not be recorded in the
+    // distinct error log, matching the Java driver which only sends it to the client.
+    aeron_driver_conductor_on_error(
+        &m_conductor.m_conductor,
+        -AERON_ERROR_CODE_RESOURCE_TEMPORARILY_UNAVAILABLE,
+        "send_channel_endpoint found in CLOSING state, please retry",
+        correlation_id);
+
+    EXPECT_EQ(observations_before,
+        aeron_distinct_error_log_num_observations(&m_conductor.m_conductor.error_log));
+
+    // A genuine (non-retryable) error must still be recorded in the distinct error log.
+    aeron_driver_conductor_on_error(
+        &m_conductor.m_conductor,
+        -AERON_ERROR_CODE_INVALID_CHANNEL,
+        "invalid channel",
+        correlation_id);
+
+    EXPECT_EQ(observations_before + 1,
+        aeron_distinct_error_log_num_observations(&m_conductor.m_conductor.error_log));
+}
+
 TEST_F(DriverConductorNetworkTest, shouldUseExistingChannelEndpointOnAddPublicationWithSameTagIdDifferentStreamId)
 {
     int64_t client_id = nextCorrelationId();


### PR DESCRIPTION
This matches the Java driver's behavior - it doesn't log transient errors in its error log, just responds to the client. Fixes one source of CI test intermittency.