### PR TITLE
Lowered publishing rate in shouldRecoverFromNetworkProblems test

### DIFF
--- a/aeron-system-tests/src/test/java/io/aeron/archive/client/PersistentSubscriptionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/client/PersistentSubscriptionTest.java
@@ -3183,7 +3183,7 @@ abstract class PersistentSubscriptionTest
             .recordingId(persistentPublication.recordingId())
             .liveChannel(subChannel);
 
-        final int ratePerSecond = 500;
+        final int ratePerSecond = 50;
         final long maxProcessingTime = 1_000_000_000 / ratePerSecond / 8;
 
         final Thread publisher = new Thread(


### PR DESCRIPTION
Even just 500 messages/sec. turned out to be too fast for some super-slow GH runners, so lowered the background publishing rate to 50 messages/sec. Shouldn't affect the test semantics.