### PR TITLE
Detect possible tail loss in ClusterNetworkTopologyTest

### DIFF
--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterNetworkTopologyTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterNetworkTopologyTest.java
@@ -36,6 +36,7 @@ import io.aeron.test.launcher.FileResolveUtil;
 import io.aeron.test.launcher.RemoteLaunchClient;
 import org.agrona.IoUtil;
 import org.agrona.MutableDirectBuffer;
+import org.agrona.collections.MutableLong;
 import org.agrona.collections.MutableReference;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.BeforeEach;
@@ -69,6 +70,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.*;
@@ -298,9 +300,16 @@ class ClusterNetworkTopologyTest
                     },
                     SECONDS.toNanos(5));
 
+                final MutableLong nextKeepAliveNs = new MutableLong(System.nanoTime() + MILLISECONDS.toNanos(100));
                 Tests.await(
                     () ->
                     {
+                        final long nowNs = System.nanoTime();
+                        if (nowNs >= nextKeepAliveNs.get())
+                        {
+                            aeronCluster.sendKeepAlive();
+                            nextKeepAliveNs.set(nowNs + MILLISECONDS.toNanos(100));
+                        }
                         aeronCluster.pollEgress();
                         pollSelector(selector);
                         return message.equals(egressResponse.get());

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterNetworkTopologyTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterNetworkTopologyTest.java
@@ -83,6 +83,8 @@ class ClusterNetworkTopologyTest
     private static final int REMOTE_LAUNCH_PORT = 11112;
     private static final long STARTUP_CANVASS_TIMEOUT_S =
         NANOSECONDS.toSeconds(2 * ConsensusModule.Configuration.leaderHeartbeatTimeoutNs());
+    private static final long CLIENT_LIVENESS_TIMEOUT_S = 30;
+    private static final long PUBLICATION_UNBLOCK_TIMEOUT_S = 60;
     private static final List<String> HOSTNAMES = Arrays.asList("10.42.0.10", "10.42.0.11", "10.42.0.12");
     private static final List<String> INTERNAL_HOSTNAMES = Arrays.asList("10.42.1.10", "10.42.1.11", "10.42.1.12");
 
@@ -483,6 +485,8 @@ class ClusterNetworkTopologyTest
         command.add("-Daeron.event.log.filename=" + new File(clusterDir, "event.log").getAbsolutePath());
         command.add("-Daeron.driver.resolver.name=node" + nodeId);
         command.add("-Daeron.cluster.startup.canvass.timeout=" + STARTUP_CANVASS_TIMEOUT_S + "s");
+        command.add("-Daeron.client.liveness.timeout=" + CLIENT_LIVENESS_TIMEOUT_S + "s");
+        command.add("-Daeron.publication.unblock.timeout=" + PUBLICATION_UNBLOCK_TIMEOUT_S + "s");
 
         if (null != ingressChannel)
         {


### PR DESCRIPTION
There's an extremely rare environment flake where ClusterNetworkTopologyTest can hang waiting for an echo response that is never going to come and then time out because the echo message was lost. This adds periodic keepalive messages so the tail loss is detected & repaired, hopefully reducing a tiny source of flakiness.