### PR TITLE
[Test] Bump driver/message timeouts for flaky topology and archive system tests

### DIFF
--- a/aeron-samples/src/test/java/io/aeron/cluster/ConsensusModuleSnapshotPendingServiceMessagesPatchTest.java
+++ b/aeron-samples/src/test/java/io/aeron/cluster/ConsensusModuleSnapshotPendingServiceMessagesPatchTest.java
@@ -132,7 +132,7 @@ class ConsensusModuleSnapshotPendingServiceMessagesPatchTest
 
     @Test
     @SlowTest
-    @InterruptAfter(60)
+    @InterruptAfter(90)
     void executeIsANoOpIfTheSnapshotIsValid()
     {
         final IntFunction<TestNode.TestService[]> servicesSupplier =
@@ -145,6 +145,12 @@ class ConsensusModuleSnapshotPendingServiceMessagesPatchTest
             .withStaticNodes(3)
             .withTimerServiceSupplier(new PriorityHeapTimerServiceSupplier())
             .withServiceSupplier(servicesSupplier)
+            // The default 1s leader heartbeat timeout is too aggressive for this throughput-heavy test on slow
+            // CI runners: draining the backlog of pending service messages can starve the leader conductor long
+            // enough to trip a spurious re-election, which stalls egress and trips @InterruptAfter. Use the more
+            // tolerant timeouts from ClusterNetworkPartitionTest (election = heartbeat / 2).
+            .withLeaderHeartbeatTimeoutNs(TimeUnit.SECONDS.toNanos(10))
+            .withElectionTimeoutNs(TimeUnit.SECONDS.toNanos(5))
             .start();
         systemTestWatcher.cluster(cluster);
         final int serviceCount = cluster.node(0).services().length;
@@ -242,7 +248,7 @@ class ConsensusModuleSnapshotPendingServiceMessagesPatchTest
         "$compute, 200000, 1, 199999, NextServiceSessionId",
         "7777, 9999, 1000000000000000, 1223372036854775, MaxClusterSessionId" })
     @SlowTest
-    @InterruptAfter(60)
+    @InterruptAfter(90)
     @SuppressWarnings("MethodLength")
     void executeShouldPatchTheStateOfTheLeaderSnapshot(
         final String baseLogServiceSessionId,
@@ -261,6 +267,12 @@ class ConsensusModuleSnapshotPendingServiceMessagesPatchTest
             .withStaticNodes(3)
             .withTimerServiceSupplier(new PriorityHeapTimerServiceSupplier())
             .withServiceSupplier(servicesSupplier)
+            // The default 1s leader heartbeat timeout is too aggressive for this throughput-heavy test on slow
+            // CI runners: draining the backlog of pending service messages can starve the leader conductor long
+            // enough to trip a spurious re-election, which stalls egress and trips @InterruptAfter. Use the more
+            // tolerant timeouts from ClusterNetworkPartitionTest (election = heartbeat / 2).
+            .withLeaderHeartbeatTimeoutNs(TimeUnit.SECONDS.toNanos(10))
+            .withElectionTimeoutNs(TimeUnit.SECONDS.toNanos(5))
             .start();
         systemTestWatcher.cluster(cluster);
         final int serviceCount = cluster.node(0).services().length;

--- a/aeron-samples/src/test/java/io/aeron/cluster/ConsensusModuleSnapshotPendingServiceMessagesPatchTest.java
+++ b/aeron-samples/src/test/java/io/aeron/cluster/ConsensusModuleSnapshotPendingServiceMessagesPatchTest.java
@@ -148,8 +148,10 @@ class ConsensusModuleSnapshotPendingServiceMessagesPatchTest
             // The default 1s leader heartbeat timeout is too aggressive for this throughput-heavy test on slow
             // CI runners: draining the backlog of pending service messages can starve the leader conductor long
             // enough to trip a spurious re-election, which stalls egress and trips @InterruptAfter. Use the more
-            // tolerant timeouts from ClusterNetworkPartitionTest (election = heartbeat / 2).
+            // tolerant timeouts from ClusterNetworkPartitionTest (startup canvass = heartbeat * 2, which the
+            // ConsensusModule requires, and election = heartbeat / 2).
             .withLeaderHeartbeatTimeoutNs(TimeUnit.SECONDS.toNanos(10))
+            .withStartupCanvassTimeoutNs(TimeUnit.SECONDS.toNanos(20))
             .withElectionTimeoutNs(TimeUnit.SECONDS.toNanos(5))
             .start();
         systemTestWatcher.cluster(cluster);
@@ -270,8 +272,10 @@ class ConsensusModuleSnapshotPendingServiceMessagesPatchTest
             // The default 1s leader heartbeat timeout is too aggressive for this throughput-heavy test on slow
             // CI runners: draining the backlog of pending service messages can starve the leader conductor long
             // enough to trip a spurious re-election, which stalls egress and trips @InterruptAfter. Use the more
-            // tolerant timeouts from ClusterNetworkPartitionTest (election = heartbeat / 2).
+            // tolerant timeouts from ClusterNetworkPartitionTest (startup canvass = heartbeat * 2, which the
+            // ConsensusModule requires, and election = heartbeat / 2).
             .withLeaderHeartbeatTimeoutNs(TimeUnit.SECONDS.toNanos(10))
+            .withStartupCanvassTimeoutNs(TimeUnit.SECONDS.toNanos(20))
             .withElectionTimeoutNs(TimeUnit.SECONDS.toNanos(5))
             .start();
         systemTestWatcher.cluster(cluster);

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveListRecordingsTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveListRecordingsTest.java
@@ -15,6 +15,7 @@
  */
 package io.aeron.archive;
 
+import io.aeron.Aeron;
 import io.aeron.ChannelUri;
 import io.aeron.CommonContext;
 import io.aeron.archive.client.AeronArchive;
@@ -42,6 +43,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import java.io.File;
 
 import static io.aeron.archive.ArchiveSystemTests.recordData;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -55,8 +57,14 @@ public class ArchiveListRecordingsTest
     final SystemTestWatcher systemTestWatcher = new SystemTestWatcher()
         .ignoreErrorsMatching(s -> s.contains("response publication is closed"));
 
+    // The default 10s client liveness (driver) timeout is too aggressive under sanitizers, where the driver
+    // conductor can be starved long enough to miss a keepalive. Used only by this test's clients - it is NOT a
+    // suite-wide override (that would break tests which rely on the default to bound a failure path).
+    private static final long DRIVER_TIMEOUT_S = 30;
+
     private TestMediaDriver driver;
     private Archive archive;
+    private Aeron aeron;
 
     @BeforeEach
     void setUp()
@@ -81,15 +89,24 @@ public class ArchiveListRecordingsTest
         driver = TestMediaDriver.launch(driverCtx, systemTestWatcher);
         systemTestWatcher.dataCollector().add(driverCtx.aeronDirectory());
 
-        archive = Archive.launch(archiveContext);
+        // Share a single conductor-invoker client (driven by the Archive conductor, as in ConsensusModule) so the
+        // Archive - and the test clients connected to it - tolerate a sanitizer-starved driver. ownsAeronClient is
+        // false on the Archive, so this client is closed explicitly in tearDown.
+        aeron = Aeron.connect(new Aeron.Context()
+            .aeronDirectoryName(driverCtx.aeronDirectoryName())
+            .useConductorAgentInvoker(true)
+            .driverTimeoutMs(SECONDS.toMillis(DRIVER_TIMEOUT_S)));
+
+        archive = Archive.launch(archiveContext
+            .aeron(aeron)
+            .ownsAeronClient(false));
         systemTestWatcher.dataCollector().add(archiveContext.archiveDir());
     }
 
     @AfterEach
     void tearDown()
     {
-        CloseHelper.quietCloseAll(archive);
-        CloseHelper.quietCloseAll(driver);
+        CloseHelper.quietCloseAll(archive, aeron, driver);
     }
 
     @Test
@@ -176,11 +193,14 @@ public class ArchiveListRecordingsTest
     }
 
     @Test
-    @InterruptAfter(15)
+    @InterruptAfter(45)
     @SlowTest
     void shouldFailToUpdateChannelWhileARecordingListingIsRunning()
     {
-        try (AeronArchive aeronArchive = AeronArchive.connect(TestContexts.ipcAeronArchive()))
+        try (AeronArchive aeronArchive = AeronArchive.connect(TestContexts.ipcAeronArchive()
+            .aeron(aeron)
+            .ownsAeronClient(false)
+            .messageTimeoutNs(SECONDS.toNanos(DRIVER_TIMEOUT_S))))
         {
             final ArchiveSystemTests.RecordingResult result1 = recordData(
                 aeronArchive, 1, "alias=original");

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterNetworkTopologyTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterNetworkTopologyTest.java
@@ -86,6 +86,7 @@ class ClusterNetworkTopologyTest
     private static final long CLIENT_LIVENESS_TIMEOUT_S = 30;
     private static final long DRIVER_TIMEOUT_S = 30;
     private static final long PUBLICATION_UNBLOCK_TIMEOUT_S = 60;
+    private static final long MESSAGE_TIMEOUT_S = 20;
     private static final List<String> HOSTNAMES = Arrays.asList("10.42.0.10", "10.42.0.11", "10.42.0.12");
     private static final List<String> INTERNAL_HOSTNAMES = Arrays.asList("10.42.1.10", "10.42.1.11", "10.42.1.12");
 
@@ -301,7 +302,7 @@ class ClusterNetworkTopologyTest
                         pollSelector(selector);
                         return 0 < position;
                     },
-                    SECONDS.toNanos(5));
+                    SECONDS.toNanos(MESSAGE_TIMEOUT_S));
 
                 final MutableLong nextKeepAliveNs = new MutableLong(System.nanoTime() + MILLISECONDS.toNanos(100));
                 Tests.await(
@@ -317,7 +318,7 @@ class ClusterNetworkTopologyTest
                         pollSelector(selector);
                         return message.equals(egressResponse.get());
                     },
-                    SECONDS.toNanos(5));
+                    SECONDS.toNanos(MESSAGE_TIMEOUT_S));
             }
         }
     }
@@ -487,7 +488,7 @@ class ClusterNetworkTopologyTest
         command.add("-Daeron.driver.resolver.name=node" + nodeId);
         command.add("-Daeron.cluster.startup.canvass.timeout=" + STARTUP_CANVASS_TIMEOUT_S + "s");
         command.add("-Daeron.client.liveness.timeout=" + CLIENT_LIVENESS_TIMEOUT_S + "s");
-        command.add("-Daeron.driver.timeout=" + DRIVER_TIMEOUT_S + "s");
+        command.add("-Daeron.driver.timeout=" + SECONDS.toMillis(DRIVER_TIMEOUT_S));
         command.add("-Daeron.publication.unblock.timeout=" + PUBLICATION_UNBLOCK_TIMEOUT_S + "s");
 
         if (null != ingressChannel)


### PR DESCRIPTION
Even more timeout bumps where needed, where we appear to be on the hairy edge for slow tests running with ASAN.