### PR TITLE
Pool cluster node threads by type in tests (gated)

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceContainer.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceContainer.java
@@ -44,6 +44,7 @@ import org.agrona.SemanticVersion;
 import org.agrona.Strings;
 import org.agrona.SystemUtil;
 import org.agrona.concurrent.Agent;
+import org.agrona.concurrent.AgentInvoker;
 import org.agrona.concurrent.AgentRunner;
 import org.agrona.concurrent.CountedErrorHandler;
 import org.agrona.concurrent.EpochClock;
@@ -107,6 +108,7 @@ public final class ClusteredServiceContainer implements AutoCloseable
 
     private final Context ctx;
     private final AgentRunner serviceAgentRunner;
+    private final AgentInvoker serviceAgentInvoker;
 
     private ClusteredServiceContainer(final Context ctx)
     {
@@ -129,7 +131,16 @@ public final class ClusteredServiceContainer implements AutoCloseable
         }
 
         final ClusteredServiceAgent agent = new ClusteredServiceAgent(ctx);
-        serviceAgentRunner = new AgentRunner(ctx.idleStrategy(), ctx.errorHandler(), ctx.errorCounter(), agent);
+        if (ctx.useAgentInvoker())
+        {
+            serviceAgentInvoker = new AgentInvoker(ctx.errorHandler(), ctx.errorCounter(), agent);
+            serviceAgentRunner = null;
+        }
+        else
+        {
+            serviceAgentRunner = new AgentRunner(ctx.idleStrategy(), ctx.errorHandler(), ctx.errorCounter(), agent);
+            serviceAgentInvoker = null;
+        }
     }
 
     /**
@@ -151,9 +162,26 @@ public final class ClusteredServiceContainer implements AutoCloseable
     public static ClusteredServiceContainer launch(final Context ctx)
     {
         final ClusteredServiceContainer clusteredServiceContainer = new ClusteredServiceContainer(ctx);
-        AgentRunner.startOnThread(clusteredServiceContainer.serviceAgentRunner, ctx.threadFactory());
+        if (null != clusteredServiceContainer.serviceAgentRunner)
+        {
+            AgentRunner.startOnThread(clusteredServiceContainer.serviceAgentRunner, ctx.threadFactory());
+        }
+        else
+        {
+            clusteredServiceContainer.serviceAgentInvoker.start();
+        }
 
         return clusteredServiceContainer;
+    }
+
+    /**
+     * Get the {@link AgentInvoker} for the clustered service if it is running in invoker mode, otherwise null.
+     *
+     * @return the {@link AgentInvoker} for the clustered service, or null if running on its own thread.
+     */
+    public AgentInvoker serviceAgentInvoker()
+    {
+        return serviceAgentInvoker;
     }
 
     /**
@@ -172,6 +200,7 @@ public final class ClusteredServiceContainer implements AutoCloseable
     public void close()
     {
         CloseHelper.close(serviceAgentRunner);
+        CloseHelper.close(serviceAgentInvoker);
     }
 
     /**
@@ -781,6 +810,7 @@ public final class ClusteredServiceContainer implements AutoCloseable
         private SnapshotDurationTracker snapshotDurationTracker;
         private VersionValidator appVersionValidator;
         private boolean ownsAeronClient;
+        private boolean useAgentInvoker = false;
 
         private ClusteredService clusteredService;
         private Runnable terminationHook;
@@ -930,6 +960,7 @@ public final class ClusteredServiceContainer implements AutoCloseable
                         .errorHandler(errorHandler)
                         .subscriberErrorHandler(RethrowingErrorHandler.INSTANCE)
                         .awaitingIdleStrategy(YieldingIdleStrategy.INSTANCE)
+                        .useConductorAgentInvoker(useAgentInvoker)
                         .epochClock(epochClock)
                         .clientName(serviceName));
 
@@ -1632,6 +1663,30 @@ public final class ClusteredServiceContainer implements AutoCloseable
         {
             this.ownsAeronClient = ownsAeronClient;
             return this;
+        }
+
+        /**
+         * Should an {@link AgentInvoker} be used for running the {@link ClusteredServiceContainer} rather than
+         * run it on a thread with an {@link AgentRunner}. When enabled the owned {@link Aeron} client (if created)
+         * uses a conductor agent invoker, and {@link #serviceAgentInvoker()} must be driven by the caller.
+         *
+         * @param useAgentInvoker use an {@link AgentInvoker} for running the {@link ClusteredServiceContainer}?
+         * @return this for a fluent API.
+         */
+        public Context useAgentInvoker(final boolean useAgentInvoker)
+        {
+            this.useAgentInvoker = useAgentInvoker;
+            return this;
+        }
+
+        /**
+         * Should an {@link AgentInvoker} be used for running the {@link ClusteredServiceContainer}?
+         *
+         * @return true if the {@link ClusteredServiceContainer} will be run with an {@link AgentInvoker}.
+         */
+        public boolean useAgentInvoker()
+        {
+            return useAgentInvoker;
         }
 
         /**

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/NodeAgentPools.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/NodeAgentPools.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2014-2025 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.test.cluster;
+
+import org.agrona.CloseHelper;
+import org.agrona.ErrorHandler;
+import org.agrona.concurrent.Agent;
+import org.agrona.concurrent.AgentInvoker;
+import org.agrona.concurrent.AgentRunner;
+import org.agrona.concurrent.YieldingIdleStrategy;
+
+import java.util.Arrays;
+
+/**
+ * Pools cluster-node component agents by TYPE across all nodes onto a small fixed number of
+ * cooperative threads (one for every node's driver, one for every archive, one for every consensus module,
+ * one for every clustered service), so an oversubscribed CI runner is not asked to schedule ~4 threads per
+ * node.
+ * <p>
+ * Components that block on one another always live on DIFFERENT pools, so the blocking handshake is serviced
+ * cross-thread and never deadlocks: a client connects to the driver (driver pool); a consensus module /
+ * service connects to its archive (archive pool); and a consensus module blocks on its service during
+ * election ({@code awaitServicesReady}) and recovery (the {@code ServiceAck} handshake), so the consensus
+ * module and service occupy separate pools. Archive-to-archive replication is asynchronous, so all archives
+ * may safely share one thread.
+ */
+final class NodeAgentPools implements AutoCloseable
+{
+    private final InvokerPool driverPool = new InvokerPool("test-driver-pool");
+    private final InvokerPool archivePool = new InvokerPool("test-archive-pool");
+    private final InvokerPool consensusModulePool = new InvokerPool("test-consensus-module-pool");
+    private final InvokerPool servicePool = new InvokerPool("test-service-pool");
+    private final AgentRunner driverRunner;
+    private final AgentRunner archiveRunner;
+    private final AgentRunner consensusModuleRunner;
+    private final AgentRunner serviceRunner;
+
+    NodeAgentPools(final ErrorHandler errorHandler)
+    {
+        driverRunner = new AgentRunner(new YieldingIdleStrategy(), errorHandler, null, driverPool);
+        archiveRunner = new AgentRunner(new YieldingIdleStrategy(), errorHandler, null, archivePool);
+        consensusModuleRunner = new AgentRunner(new YieldingIdleStrategy(), errorHandler, null, consensusModulePool);
+        serviceRunner = new AgentRunner(new YieldingIdleStrategy(), errorHandler, null, servicePool);
+        AgentRunner.startOnThread(driverRunner);
+        AgentRunner.startOnThread(archiveRunner);
+        AgentRunner.startOnThread(consensusModuleRunner);
+        AgentRunner.startOnThread(serviceRunner);
+    }
+
+    void registerDriver(final AgentInvoker invoker)
+    {
+        driverPool.add(invoker);
+    }
+
+    void registerArchive(final AgentInvoker invoker)
+    {
+        archivePool.add(invoker);
+    }
+
+    void registerConsensusModule(final AgentInvoker invoker)
+    {
+        consensusModulePool.add(invoker);
+    }
+
+    void registerService(final AgentInvoker invoker)
+    {
+        servicePool.add(invoker);
+    }
+
+    void deregister(final AgentInvoker invoker)
+    {
+        if (null == invoker)
+        {
+            return;
+        }
+
+        driverPool.remove(invoker);
+        archivePool.remove(invoker);
+        consensusModulePool.remove(invoker);
+        servicePool.remove(invoker);
+    }
+
+    public void close()
+    {
+        CloseHelper.closeAll(driverRunner, archiveRunner, consensusModuleRunner, serviceRunner);
+    }
+
+    private static final class InvokerPool implements Agent
+    {
+        private final String roleName;
+        private volatile AgentInvoker[] invokers = new AgentInvoker[0];
+
+        InvokerPool(final String roleName)
+        {
+            this.roleName = roleName;
+        }
+
+        synchronized void add(final AgentInvoker invoker)
+        {
+            final AgentInvoker[] current = invokers;
+            final AgentInvoker[] next = Arrays.copyOf(current, current.length + 1);
+            next[current.length] = invoker;
+            invokers = next;
+        }
+
+        synchronized void remove(final AgentInvoker invoker)
+        {
+            final AgentInvoker[] current = invokers;
+            int index = -1;
+            for (int i = 0; i < current.length; i++)
+            {
+                if (current[i] == invoker)
+                {
+                    index = i;
+                    break;
+                }
+            }
+
+            if (index < 0)
+            {
+                return;
+            }
+
+            final AgentInvoker[] next = new AgentInvoker[current.length - 1];
+            System.arraycopy(current, 0, next, 0, index);
+            System.arraycopy(current, index + 1, next, index, current.length - index - 1);
+            invokers = next;
+        }
+
+        // Synchronized on the same monitor as add/remove so that once remove() returns, the pool thread
+        // cannot be mid-invocation of the removed invoker; the caller may then close it safely.
+        public synchronized int doWork()
+        {
+            final AgentInvoker[] current = invokers;
+            int workCount = 0;
+            for (final AgentInvoker invoker : current)
+            {
+                workCount += invoker.invoke();
+            }
+
+            return workCount;
+        }
+
+        public String roleName()
+        {
+            return roleName;
+        }
+    }
+}

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
@@ -141,6 +141,13 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 public final class TestCluster implements AutoCloseable
 {
+    // When -Daeron.test.cluster.pooled.node.threads=true, all nodes' components run in invoker
+    // mode pooled by type onto three shared threads (drivers / archives / consensus modules + services)
+    // rather than ~4 threads per node.
+    // Defaults to false so the standard multi-threaded path used by every other test is unaffected.
+    static final boolean POOLED_NODE_THREADS =
+        Boolean.getBoolean("aeron.test.cluster.pooled.node.threads");
+
     static final int TERM_LENGTH = 64 * 1024;
     static final int SEGMENT_FILE_LENGTH = 128 * 1024;
     static final long CATALOG_CAPACITY = 128 * 1024;
@@ -198,6 +205,7 @@ public final class TestCluster implements AutoCloseable
     private ControlledEgressListener controlledEgressListener;
 
     private final TestNode[] nodes;
+    private final NodeAgentPools nodeAgentPools;
     private final String clusterMembers;
     private final String clusterMemberEndpoints;
     private final String[] senderWildcardPortRanges;
@@ -266,6 +274,7 @@ public final class TestCluster implements AutoCloseable
         this.serviceSupplier = requireNonNull(serviceSupplier);
 
         this.nodes = new TestNode[memberCount + 1];
+        this.nodeAgentPools = POOLED_NODE_THREADS ? new NodeAgentPools(Throwable::printStackTrace) : null;
         this.backupNodeIndex = memberCount;
         this.useResponseChannels = useResponseChannels;
         this.clusterMembers = clusterMembers(clusterId, 0, memberCount, memberCount, this.useResponseChannels);
@@ -403,6 +412,11 @@ public final class TestCluster implements AutoCloseable
         }
     }
 
+    NodeAgentPools nodeAgentPools()
+    {
+        return nodeAgentPools;
+    }
+
     public void close()
     {
         final boolean isInterrupted = Thread.interrupted();
@@ -414,7 +428,8 @@ public final class TestCluster implements AutoCloseable
                 client,
                 clientMediaDriver,
                 null != backupNode ? () -> backupNode.close() : null,
-                () -> CloseHelper.closeAll(Stream.of(nodes).filter(Objects::nonNull).collect(toList())));
+                () -> CloseHelper.closeAll(Stream.of(nodes).filter(Objects::nonNull).collect(toList())),
+                nodeAgentPools);
         }
         finally
         {
@@ -440,6 +455,7 @@ public final class TestCluster implements AutoCloseable
         final File markFileDir = null != markFileBaseDir ? new File(markFileBaseDir, "mark-" + index) : null;
         final TestNode.Context context = new TestNode.Context(
             serviceSupplier.apply(index), hostname(index, memberCount), nodeNameMappings());
+        context.nodeAgentPools = nodeAgentPools;
         context.extensionSupplier = extensionSupplier;
         context.errorCounterSupplier = errorCounterSupplier;
         context.snapshotCounterSupplier = snapshotCounterSupplier;
@@ -626,6 +642,7 @@ public final class TestCluster implements AutoCloseable
         final File markFileDir = null != markFileBaseDir ? new File(markFileBaseDir, "mark-" + backupNodeIndex) : null;
         final TestNode.Context context = new TestNode.Context(
             serviceSupplier.apply(backupNodeIndex), hostname(backupNodeIndex, memberCount), nodeNameMappings());
+        context.nodeAgentPools = nodeAgentPools;
 
         if (null == backupNode || !backupNode.isClosed())
         {

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/TestNode.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/TestNode.java
@@ -23,6 +23,7 @@ import io.aeron.FragmentAssembler;
 import io.aeron.Image;
 import io.aeron.RethrowingErrorHandler;
 import io.aeron.archive.Archive;
+import io.aeron.archive.ArchiveThreadingMode;
 import io.aeron.archive.ArchiveTool;
 import io.aeron.archive.client.AeronArchive;
 import io.aeron.archive.status.RecordingPos;
@@ -42,6 +43,7 @@ import io.aeron.cluster.service.ClusterCounters;
 import io.aeron.cluster.service.ClusterTerminationException;
 import io.aeron.cluster.service.ClusteredServiceContainer;
 import io.aeron.driver.MediaDriver;
+import io.aeron.driver.ThreadingMode;
 import io.aeron.exceptions.AeronException;
 import io.aeron.exceptions.TimeoutException;
 import io.aeron.logbuffer.BufferClaim;
@@ -53,7 +55,9 @@ import io.aeron.test.Tests;
 import io.aeron.test.driver.RedirectingNameResolver;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
+import org.agrona.IoUtil;
 import org.agrona.DirectBuffer;
+import org.agrona.LangUtil;
 import org.agrona.ExpandableArrayBuffer;
 import org.agrona.collections.Hashing;
 import org.agrona.collections.IntArrayList;
@@ -70,6 +74,7 @@ import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.Function;
 import java.util.function.IntPredicate;
@@ -114,16 +119,37 @@ public final class TestNode implements AutoCloseable
 
         try
         {
+            final NodeAgentPools pools = context.nodeAgentPools;
+            final boolean pooled = null != pools;
+
+            if (pooled)
+            {
+                context.mediaDriverContext.threadingMode(ThreadingMode.INVOKER);
+            }
+
             mediaDriver = TestMediaDriver.launch(
                 context.mediaDriverContext, TestCluster.clientDriverOutputConsumer(dataCollector));
 
             final String aeronDirectoryName = mediaDriver.context().aeronDirectoryName();
+
+            if (pooled)
+            {
+                // Driver onto the shared driver thread first, so subsequent client connects (which
+                // busy-wait on the driver heartbeat) are serviced cross-thread while this thread blocks.
+                pools.registerDriver(mediaDriver.sharedAgentInvoker());
+
+                context.archiveContext.threadingMode(ArchiveThreadingMode.INVOKER);
+            }
             archive = Archive.launch(context.archiveContext.aeronDirectoryName(aeronDirectoryName));
+            if (pooled)
+            {
+                pools.registerArchive(archive.invoker());
+            }
 
             services = context.services;
 
             Aeron consensusModuleAeronClient = null;
-            if (null != context.errorCounterSupplier || null != context.snapshotCounterSupplier)
+            if (pooled || null != context.errorCounterSupplier || null != context.snapshotCounterSupplier)
             {
                 consensusModuleAeronClient = Aeron.connect(new Aeron.Context()
                     .aeronDirectoryName(aeronDirectoryName)
@@ -139,6 +165,7 @@ public final class TestNode implements AutoCloseable
                 .serviceCount(services.length)
                 .aeron(consensusModuleAeronClient)
                 .aeronDirectoryName(aeronDirectoryName)
+                .useAgentInvoker(pooled)
                 .isIpcIngressAllowed(true)
                 .terminationHook(ClusterTests.terminationHook(
                     context.isTerminationExpected, context.hasMemberTerminated));
@@ -179,31 +206,85 @@ public final class TestNode implements AutoCloseable
 
             final AeronArchive.Context archiveContext = context.consensusModuleContext.archiveContext().clone();
 
-            consensusModule = ConsensusModule.launch(context.consensusModuleContext);
+            containers = new ClusteredServiceContainer[services.length];
+
+            if (pooled)
+            {
+                // The consensus module and the clustered service share the same cluster directory and both
+                // create it in their conclude() via the non-atomic IoUtil.ensureDirectoryExists. Because we
+                // launch them concurrently (below), pre-create it here on this single thread — performing the
+                // clean-start delete ourselves and clearing deleteDirOnStart so conclude does not race to
+                // delete/recreate it underneath the concurrent launches.
+                final File clusterDir = context.consensusModuleContext.clusterDir();
+                if (context.consensusModuleContext.deleteDirOnStart())
+                {
+                    IoUtil.delete(clusterDir, false);
+                    context.consensusModuleContext.deleteDirOnStart(false);
+                }
+                IoUtil.ensureDirectoryExists(clusterDir, "cluster");
+                if (null != context.consensusModuleContext.markFileDir())
+                {
+                    IoUtil.ensureDirectoryExists(context.consensusModuleContext.markFileDir(), "mark file");
+                }
+
+                // The consensus module's onStart blocks awaiting a ServiceAck while the clustered service's
+                // onStart awaits the consensus module, so the two must start CONCURRENTLY (as they do in the
+                // normal AgentRunner mode where ConsensusModule.launch returns immediately). In invoker mode
+                // launch runs onStart synchronously, so run it on a dedicated startup thread, registering it
+                // with the pool the moment its onStart completes so it is pumped while the services come up.
+                final AtomicReference<ConsensusModule> cmHolder = new AtomicReference<>();
+                final AtomicReference<Throwable> cmError = new AtomicReference<>();
+                final Thread cmStartup = new Thread(
+                    () ->
+                    {
+                        try
+                        {
+                            final ConsensusModule cm = ConsensusModule.launch(context.consensusModuleContext);
+                            cmHolder.set(cm);
+                            pools.registerConsensusModule(cm.conductorAgentInvoker());
+                        }
+                        catch (final Throwable t)
+                        {
+                            cmError.set(t);
+                        }
+                    },
+                    "test-cm-startup-" + context.consensusModuleContext.clusterMemberId());
+                cmStartup.start();
+
+                for (int i = 0; i < services.length; i++)
+                {
+                    containers[i] = launchServiceContainer(context, aeronDirectoryName, archiveContext, i, true);
+                    // Register immediately so the service is pumped (and keeps sending keepalives to the
+                    // driver) while we wait for the consensus module startup thread to finish below.
+                    pools.registerService(containers[i].serviceAgentInvoker());
+                }
+
+                try
+                {
+                    cmStartup.join();
+                }
+                catch (final InterruptedException ex)
+                {
+                    Thread.currentThread().interrupt();
+                    LangUtil.rethrowUnchecked(ex);
+                }
+                if (null != cmError.get())
+                {
+                    LangUtil.rethrowUnchecked(cmError.get());
+                }
+                consensusModule = cmHolder.get();
+            }
+            else
+            {
+                consensusModule = ConsensusModule.launch(context.consensusModuleContext);
+                for (int i = 0; i < services.length; i++)
+                {
+                    containers[i] = launchServiceContainer(context, aeronDirectoryName, archiveContext, i, false);
+                }
+            }
+
             final File baseDir = context.consensusModuleContext.clusterDir().getParentFile();
             dataCollector.addForCleanup(baseDir);
-
-            containers = new ClusteredServiceContainer[services.length];
-            for (int i = 0; i < services.length; i++)
-            {
-                final ClusteredServiceContainer.Context ctx = context.serviceContainerContext.clone();
-
-                final int clusterId = context.consensusModuleContext.clusterId();
-                final int memberId = context.consensusModuleContext.clusterMemberId();
-
-                ctx.aeronDirectoryName(aeronDirectoryName)
-                    .clusterId(clusterId)
-                    .archiveContext(archiveContext.clone())
-                    .terminationHook(ClusterTests.terminationHook(
-                        context.isTerminationExpected, context.hasServiceTerminated[i]))
-                    .clusterDir(context.consensusModuleContext.clusterDir())
-                    .markFileDir(context.consensusModuleContext.markFileDir())
-                    .clusteredService(services[i])
-                    .snapshotDurationThresholdNs(TimeUnit.MILLISECONDS.toNanos(100))
-                    .serviceName("clustered-service-" + clusterId + "-" + memberId + "-" + i)
-                    .serviceId(i);
-                containers[i] = ClusteredServiceContainer.launch(ctx);
-            }
 
             dataCollector.add(consensusModule.context().clusterDir().toPath());
             dataCollector.add(archive.context().archiveDir().toPath());
@@ -222,6 +303,47 @@ public final class TestNode implements AutoCloseable
 
             throw ex;
         }
+    }
+
+    private static ClusteredServiceContainer launchServiceContainer(
+        final Context context,
+        final String aeronDirectoryName,
+        final AeronArchive.Context archiveContext,
+        final int index,
+        final boolean pooled)
+    {
+        final ClusteredServiceContainer.Context ctx = context.serviceContainerContext.clone();
+
+        final int clusterId = context.consensusModuleContext.clusterId();
+        final int memberId = context.consensusModuleContext.clusterMemberId();
+
+        ctx.aeronDirectoryName(aeronDirectoryName)
+            .clusterId(clusterId)
+            .archiveContext(archiveContext.clone())
+            .terminationHook(ClusterTests.terminationHook(
+                context.isTerminationExpected, context.hasServiceTerminated[index]))
+            .clusterDir(context.consensusModuleContext.clusterDir())
+            .markFileDir(context.consensusModuleContext.markFileDir())
+            .clusteredService(context.services[index])
+            .snapshotDurationThresholdNs(TimeUnit.MILLISECONDS.toNanos(100))
+            .serviceName("clustered-service-" + clusterId + "-" + memberId + "-" + index)
+            .serviceId(index);
+
+        if (pooled)
+        {
+            // Service connects to the driver (driver pool) and archive (archive pool) cross-thread, so it
+            // needs no driver agent invoker of its own; its conductor is invoker driven by the client pool.
+            final Aeron serviceAeronClient = Aeron.connect(new Aeron.Context()
+                .aeronDirectoryName(aeronDirectoryName)
+                .subscriberErrorHandler(RethrowingErrorHandler.INSTANCE)
+                .useConductorAgentInvoker(true)
+                .awaitingIdleStrategy(YieldingIdleStrategy.INSTANCE)
+                .clientLock(NoOpLock.INSTANCE)
+                .clientName("test-service-client-" + clusterId + "-" + memberId + "-" + index));
+            ctx.aeron(serviceAeronClient).ownsAeronClient(true).useAgentInvoker(true);
+        }
+
+        return ClusteredServiceContainer.launch(ctx);
     }
 
     public void stopServiceContainers()
@@ -283,7 +405,47 @@ public final class TestNode implements AutoCloseable
         if (!isClosed)
         {
             isClosed = true;
-            CloseHelper.closeAll(consensusModule, () -> CloseHelper.closeAll(containers), archive, mediaDriver);
+            final NodeAgentPools pools = context.nodeAgentPools;
+            if (null != pools)
+            {
+                // Close in dependency order, keeping the driver and archive pumped while the consensus module
+                // and services close: their onClose performs blocking archive operations (e.g. stop log
+                // recording) that need the driver and archive to keep running to complete. Deregister each
+                // component from its pool immediately before closing it so the pool stops invoking it first.
+                if (null != consensusModule)
+                {
+                    pools.deregister(consensusModule.conductorAgentInvoker());
+                }
+                CloseHelper.close(consensusModule);
+
+                if (null != containers)
+                {
+                    for (final ClusteredServiceContainer container : containers)
+                    {
+                        if (null != container)
+                        {
+                            pools.deregister(container.serviceAgentInvoker());
+                        }
+                    }
+                    CloseHelper.closeAll(containers);
+                }
+
+                if (null != archive)
+                {
+                    pools.deregister(archive.invoker());
+                }
+                CloseHelper.close(archive);
+
+                if (null != mediaDriver)
+                {
+                    pools.deregister(mediaDriver.sharedAgentInvoker());
+                }
+                CloseHelper.close(mediaDriver);
+            }
+            else
+            {
+                CloseHelper.closeAll(consensusModule, () -> CloseHelper.closeAll(containers), archive, mediaDriver);
+            }
         }
     }
 
@@ -1342,6 +1504,11 @@ public final class TestNode implements AutoCloseable
         Supplier<ConsensusModuleExtension> extensionSupplier;
         Function<Aeron, Counter> errorCounterSupplier;
         Function<Aeron, Counter> snapshotCounterSupplier;
+        // When non-null, this node's driver, archive, consensus module and clustered service
+        // run in invoker mode and are driven by the shared type-pooled threads (all drivers on one thread,
+        // all archives on another, all consensus modules and services on a third) instead of ~4 threads of
+        // their own.
+        NodeAgentPools nodeAgentPools;
 
         Context(final TestService[] services, final String hostName, final String nodeMappings)
         {


### PR DESCRIPTION
Adds an opt-in test mode (`-Daeron.test.cluster.pooled.node.threads=true`, default off) that pools all cluster nodes' components **by type** onto a small fixed set of cooperative threads (drivers / archives / consensus modules / clustered services) instead of ~4 threads per node. This keeps heavily-oversubscribed CI runners (notably 4-vCPU Windows) from becoming the scheduling bottleneck, without inflating timeouts.

**Commits**
1. `ClusteredServiceContainer`: add `useAgentInvoker` + `serviceAgentInvoker()` (mirrors `ConsensusModule.Context.useAgentInvoker`).
2. `TestCluster`/`TestNode` + new `NodeAgentPools`: the gated pooling — mutually-blocking peers stay on separate pools; the consensus module launches concurrently with its service to complete the `ServiceAck`/`awaitServicesReady` startup handshake; shared cluster dirs are pre-created to avoid a concurrent-creation race; `close()` keeps the driver/archive pumped while the consensus module and service shut down.

The default multi-threaded path is unchanged. (Branch is based on `462cad0958`; can be rebased onto current master.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)