### PR TITLE
[Java] Lower Windows TestCluster startup-canvass timeout to fit @InterruptAfter budgets

### DIFF
--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
@@ -124,10 +124,7 @@ import static io.aeron.archive.client.AeronArchive.NULL_POSITION;
 import static io.aeron.cluster.ConsensusModule.Configuration.ELECTION_STATUS_INTERVAL_DEFAULT_NS;
 import static io.aeron.cluster.ConsensusModule.Configuration.ELECTION_TIMEOUT_DEFAULT_NS;
 import static io.aeron.cluster.ConsensusModule.Configuration.LEADER_HEARTBEAT_INTERVAL_DEFAULT_NS;
-import static io.aeron.cluster.ConsensusModule.Configuration.LEADER_HEARTBEAT_TIMEOUT_DEFAULT_NS;
 import static io.aeron.cluster.ConsensusModule.Configuration.SERVICE_ID;
-import static io.aeron.cluster.ConsensusModule.Configuration.STARTUP_CANVASS_TIMEOUT_DEFAULT_NS;
-import static io.aeron.cluster.ConsensusModule.Configuration.TERMINATION_TIMEOUT_DEFAULT_NS;
 import static io.aeron.cluster.service.Cluster.Role.FOLLOWER;
 import static io.aeron.test.cluster.ClusterTests.LARGE_MSG;
 import static io.aeron.test.cluster.ClusterTests.PAUSE;
@@ -161,12 +158,17 @@ public final class TestCluster implements AutoCloseable
     {
         if (SystemUtil.isWindows())
         {
-            LEADER_HEARTBEAT_TIMEOUT_NS = LEADER_HEARTBEAT_TIMEOUT_DEFAULT_NS;
+            // Windows CI runners are slower, so use larger timeouts than other platforms for liveness
+            // headroom; but keep them well below the per-test @InterruptAfter budgets. In particular the
+            // startup canvass timeout must be small enough that a node restarting with only a bare quorum
+            // present (so it can never be a unanimous candidate and must wait out the canvass deadline before
+            // nominating) still elects within the test budget.
+            LEADER_HEARTBEAT_TIMEOUT_NS = TimeUnit.SECONDS.toNanos(4);
             LEADER_HEARTBEAT_INTERVAL_NS = LEADER_HEARTBEAT_INTERVAL_DEFAULT_NS;
             ELECTION_TIMEOUT_NS = ELECTION_TIMEOUT_DEFAULT_NS;
             ELECTION_STATUS_INTERVAL_NS = ELECTION_STATUS_INTERVAL_DEFAULT_NS;
-            STARTUP_CANVASS_TIMEOUT_NS = STARTUP_CANVASS_TIMEOUT_DEFAULT_NS;
-            TERMINATION_TIMEOUT_NS = TERMINATION_TIMEOUT_DEFAULT_NS;
+            STARTUP_CANVASS_TIMEOUT_NS = LEADER_HEARTBEAT_TIMEOUT_NS * 3;
+            TERMINATION_TIMEOUT_NS = LEADER_HEARTBEAT_TIMEOUT_NS;
         }
         else
         {


### PR DESCRIPTION
## Problem

Setting the Windows cluster-test timeouts to the production defaults (in the OS-specific timeout block of `TestCluster`) gives a **60s startup-canvass timeout**, but the per-test `@InterruptAfter` budgets (typically 30–40s) are sized for a much smaller value.

A test that restarts a node while only a *bare quorum* is present can never form a **unanimous** candidate (one member is intentionally down for the scenario), so the restarting node must wait out the full startup-canvass deadline before it can nominate itself (`Election.canvass()` only leaves `CANVASS` on `isUnanimousCandidate` or `deadline && isQuorumCandidate`). On Windows that 60s deadline exceeds the test budget, so such tests **deterministically** hang to `@InterruptAfter` and fail on Windows across all JDKs.

`shouldRecoverWhenLeaderHasAppendedMoreThanFollower` (`@InterruptAfter(40)`) is the clearest example: after the restart the two surviving members exchange `CANVASS_POSITION` fine (~10/s, both directions), the old leader is immediately a quorum candidate, but it sits idle in `CANVASS` waiting for the 60s deadline and is killed at 40s.

## Fix

Keep the Windows timeouts larger than other platforms for slow-runner liveness headroom, but bring them comfortably below the test budgets:

| | startup-canvass | heartbeat | termination |
|---|---|---|---|
| Windows (before) | 60s | 10s | 10s |
| **Windows (after)** | **12s** | **4s** | **4s** |
| Linux/macOS | 10s | 2s | 2s |

(The `ConsensusModule` validation requires `startupCanvass / heartbeat >= 2`.)

## Validation

Ran the full `io.aeron.cluster.ClusterTest` class on `windows-latest` across JDK 17, 21 and 25 — all green with this change (the affected tests previously failed deterministically).