### PR TITLE
[C++] Give PersistentSubscriptionWrapperTest dedicated archive control ports

### DIFF
--- a/aeron-system-tests/src/test/cpp_wrapper/PersistentSubscriptionWrapperTest.cpp
+++ b/aeron-system-tests/src/test/cpp_wrapper/PersistentSubscriptionWrapperTest.cpp
@@ -43,7 +43,11 @@ static const std::string UNICAST_CHANNEL = "aeron:udp?endpoint=localhost:2000";
 static const std::int32_t STREAM_ID = 1000;
 static const std::int32_t REPLAY_STREAM_ID = -5;
 static const std::int32_t ONE_KB = 992;
-static const std::string CONTROL_REQUEST_CHANNEL = "aeron:udp?endpoint=localhost:8010";
+// Use control ports dedicated to this test binary. Sharing the common 8010/8011 with the archive system
+// tests (aeron_archive_test / archiveTestW) means that if one of those tests is killed by the CTest timeout
+// it can leave an orphaned media driver holding the port, causing this test to fail to bind with
+// "Address already in use" and masking the real culprit.
+static const std::string CONTROL_REQUEST_CHANNEL = "aeron:udp?endpoint=localhost:8200";
 static const std::string CONTROL_RESPONSE_CHANNEL = "aeron:udp?endpoint=localhost:0";
 
 class PersistentSubscriptionWrapperTestBase
@@ -328,7 +332,7 @@ TEST_F(PersistentSubscriptionWrapperTest, shouldCycleThroughMultipleLiveReplayTr
         const std::string aeronDir2 = aeron::Context::defaultAeronPath() + "_2";
         const std::string archiveDir2 = std::string(ARCHIVE_DIR) + AERON_FILE_SEP + "driver2";
         TestArchive archive2(aeronDir2, archiveDir2, std::cout,
-            "aeron:udp?endpoint=localhost:8011", "aeron:udp?endpoint=localhost:0", 2);
+            "aeron:udp?endpoint=localhost:8201", "aeron:udp?endpoint=localhost:0", 2);
 
         aeron::Context aeronCtx2;
         aeronCtx2.aeronDir(aeronDir2);


### PR DESCRIPTION
## Problem

`PersistentSubscriptionWrapperTest` (CTest target `persistentSubscriptionTestW`) uses `localhost:8010` and `localhost:8011` for its archive control-request channels — the **same fixed ports** as the archive system tests `aeron_archive_test` and `archiveTestW`.

These test binaries run in the same CTest sequence. If one of the archive tests is killed by the **CTest timeout** (for example a replication scenario hanging on Windows MSVC, where `AeronCArchiveTest.shouldRecordReplicateThenReplay` has been observed to hang to the 300s timeout), the kill can leave an **orphaned `ArchivingMediaDriver` still holding the port**. The next test to run, `persistentSubscriptionTestW`, then fails immediately:

```
RegistrationException: ERROR - channel error - Address already in use: bind
  (sun.nio.ch.Net.bind0): aeron:udp?endpoint=localhost:8010, errorCodeValue=11
  ... at io.aeron.archive.Archive.launch ... ArchivingMediaDriver.main
```

So a single hang produces a **second, misleading failure** in an unrelated test, masking the real culprit.

## Change

Move this test's two archive control-request channels to **dedicated ports `8200` / `8201`** that no other test binary uses. Same transport and configuration — only the port numbers change — so a neighbouring test's timeout can no longer cascade into this one. The control-response channels already use ephemeral `localhost:0`.

This is a test-isolation fix only; it does not change what the test exercises.