### PR TITLE
fix(c): ignore missing properties files in aeron_properties_file_load

### DIFF
--- a/aeron-client/src/main/c/util/aeron_properties_util.c
+++ b/aeron-client/src/main/c/util/aeron_properties_util.c
@@ -202,6 +202,11 @@ int aeron_properties_parse_file(const char *filename, aeron_properties_file_hand
     FILE *fpin = fopen(filename, "r");
     if (NULL == fpin)
     {
+        if (ENOENT == errno)
+        {
+            return 0;
+        }
+
         AERON_SET_ERR(errno, "could not open properties file: %s", filename);
         return -1;
     }

--- a/aeron-driver/src/test/c/aeron_properties_test.cpp
+++ b/aeron-driver/src/test/c/aeron_properties_test.cpp
@@ -171,6 +171,11 @@ TEST_F(DriverConfigurationTest, shouldParseContinuationWithBlankLine)
     EXPECT_EQ(m_value, "propertyValue");
 }
 
+TEST_F(DriverConfigurationTest, shouldIgnoreMissingPropertiesFile)
+{
+    EXPECT_EQ(aeron_properties_file_load("/tmp/aeron-nonexistent-properties-file.properties"), 0);
+}
+
 TEST_F(DriverConfigurationTest, DISABLED_shouldHttpRetrieve)
 {
     aeron_http_response_t *response = nullptr;


### PR DESCRIPTION
## Summary

The C media driver failed to start when a properties file path did not exist, while the Java driver silently skips missing files via `SystemUtil.loadPropertiesFiles`. This aligns C with Java by treating `ENOENT` from `fopen` as a no-op in `aeron_properties_parse_file`.

Other open failures (permissions, etc.) still return an error.

## Test plan

- [x] Built `properties_test` target
- [x] `./binaries/properties_test --gtest_filter=DriverConfigurationTest.shouldIgnoreMissingPropertiesFile`

Fixes #1124

Made with [Cursor](https://cursor.com)