### PR TITLE
[Java] Handle RESOURCE_TEMPORARILY_UNAVAILABLE in SessionManager.

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusterSession.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusterSession.java
@@ -18,6 +18,7 @@ package io.aeron.cluster;
 import io.aeron.Aeron;
 import io.aeron.AeronCounters;
 import io.aeron.Counter;
+import io.aeron.ErrorCode;
 import io.aeron.Image;
 import io.aeron.Publication;
 import io.aeron.archive.client.AeronArchive;
@@ -245,8 +246,24 @@ final class ClusterSession implements ClusterClientSession
         {
             if (!aeron.isCommandActive(responsePublicationId))
             {
-                responsePublication = aeron.getPublication(responsePublicationId);
-                responsePublicationId = NULL_VALUE;
+                try
+                {
+                    responsePublication = aeron.getPublication(responsePublicationId);
+                    responsePublicationId = NULL_VALUE;
+                }
+                catch (final RegistrationException ex)
+                {
+                    if (ErrorCode.RESOURCE_TEMPORARILY_UNAVAILABLE == ex.errorCode())
+                    {
+                        responsePublicationId = aeron.asyncAddPublication(responseChannel, responseStreamId);
+                        return false;
+                    }
+                    else
+                    {
+                        responsePublicationId = NULL_VALUE;
+                        throw ex;
+                    }
+                }
 
                 counter = aeron.getCounter(counterRegistrationId);
                 counterRegistrationId = NULL_VALUE;


### PR DESCRIPTION
Previously, it was possible to encounter transient errors when
processing pending sessions and leave them unhandled, e.g.:

```
    Consensus Module file /dev/shm/aeron-runner-a43784f0-a4d0-475a-be74-8ca5ccf73dcf-0/consensus-module/cluster-mark.dat
    ***
    (ignored) 1 observations from 2026-06-30 23:09:02.844+0000 to 2026-06-30 23:09:02.844+0000 for:
     io.aeron.exceptions.RegistrationException: WARN - SendChannelEndpoint found in CLOSING state, please retry, errorCodeValue=10
    	at io.aeron.ClientConductor.resourceOrThrow(ClientConductor.java:2094)
    	at io.aeron.ClientConductor.getPublication(ClientConductor.java:621)
    	at io.aeron.Aeron.getPublication(Aeron.java:364)
    	at io.aeron.cluster.ClusterSession.isResponsePublicationConnected(ClusterSession.java:248)
    	at io.aeron.cluster.SessionManager.processPendingSessions(SessionManager.java:613)
    	at io.aeron.cluster.SessionManager.processPendingBackupSessions(SessionManager.java:574)
    	at io.aeron.cluster.ConsensusModuleAgent.slowTickWork(ConsensusModuleAgent.java:2373)
    	at io.aeron.cluster.ConsensusModuleAgent.doWork(ConsensusModuleAgent.java:402)
    	at org.agrona.concurrent.AgentRunner.doWork(AgentRunner.java:304)
    	at org.agrona.concurrent.AgentRunner.workLoop(AgentRunner.java:296)
    	at org.agrona.concurrent.AgentRunner.run(AgentRunner.java:162)
    	at java.base/java.lang.Thread.run(Thread.java:1474)
```

Now, it should retry creating the response publication.

Note the `return false` avoids transitioning the session into an
`INVALID` state.