### PR TITLE
test: cover aeron cluster context defaults

### DIFF
--- a/aeron-cluster/src/test/java/io/aeron/cluster/client/AeronClusterContextTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/client/AeronClusterContextTest.java
@@ -19,6 +19,7 @@ import io.aeron.Aeron;
 import io.aeron.RethrowingErrorHandler;
 import io.aeron.exceptions.ConfigurationException;
 import io.aeron.test.Tests;
+import org.agrona.concurrent.AgentInvoker;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -26,8 +27,10 @@ import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class AeronClusterContextTest
@@ -122,5 +125,40 @@ class AeronClusterContextTest
         assertEquals(
             "ERROR - AeronCluster.Context.clientName length must be <= " + Aeron.Configuration.MAX_CLIENT_NAME_LENGTH,
             exception.getMessage());
+    }
+
+    @Test
+    void clonePreservesConfiguredContextValues()
+    {
+        final AgentInvoker agentInvoker = mock(AgentInvoker.class);
+
+        context
+            .messageTimeoutNs(42)
+            .newLeaderTimeoutNs(43)
+            .aeronDirectoryName("custom-dir")
+            .agentInvoker(agentInvoker);
+
+        final AeronCluster.Context clone = context.clone();
+
+        assertEquals(42, clone.messageTimeoutNs());
+        assertEquals(43, clone.newLeaderTimeoutNs());
+        assertEquals("custom-dir", clone.aeronDirectoryName());
+        assertSame(agentInvoker, clone.agentInvoker());
+    }
+
+    @Test
+    void runAgentInvokersInvokesConductorAndConfiguredInvoker()
+    {
+        final AgentInvoker conductorAgentInvoker = mock(AgentInvoker.class);
+        final AgentInvoker agentInvoker = mock(AgentInvoker.class);
+        when(aeron.conductorAgentInvoker()).thenReturn(conductorAgentInvoker);
+        when(conductorAgentInvoker.invoke()).thenReturn(1);
+        when(agentInvoker.invoke()).thenReturn(2);
+
+        context.agentInvoker(agentInvoker);
+
+        assertEquals(3, context.runAgentInvokers());
+        verify(conductorAgentInvoker).invoke();
+        verify(agentInvoker).invoke();
     }
 }


### PR DESCRIPTION
Hi,

I added two small tests around context state that is easy to regress but was not directly covered before. They check that cloned contexts preserve configured values and that `runAgentInvokers()` invokes both the Aeron conductor invoker and the configured context invoker.

Impact on coverage:

* Covers `AeronCluster.Context` cloning, timeout/directory/invoker state, and combined agent-invoker execution, including [AeronCluster.java:1439-1444](https://github.com/amirdeljouyi/aeron/blob/3a4c7c5fc19f0d4c18c79fc49eb715fb9d9e64d7/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java#L1439-L1444) and [AeronCluster.java:2073-2089](https://github.com/amirdeljouyi/aeron/blob/3a4c7c5fc19f0d4c18c79fc49eb715fb9d9e64d7/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java#L2073-L2089).
* Line coverage for `AeronCluster` increases by around 3%.

Why:

I hope you find these tests useful. 😄 Please let me know if you have any questions or concerns.

Thanks,
Amir