### PR TITLE
[Cluster] Send a termination request to the ClusteredServiceContainer when the ConsensusModuleAgent is closed

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -282,6 +282,30 @@ final class ConsensusModuleAgent
     {
         if (!aeron.isClosed())
         {
+            final long logPosition = commitPosition.get();
+            serviceProxy.terminationPosition(logPosition, ctx.countedErrorHandler());
+
+//            try
+//            {
+//                idleStrategy.reset();
+//                while (!ServiceAck.hasReached(logPosition, serviceAckId, serviceAckQueues))
+//                {
+//                    final int workCount = consensusModuleAdapter.poll();
+//                    if (Thread.currentThread().isInterrupted())
+//                    {
+//                        throw new InterruptedException();
+//                    }
+//                    aeronClientInvoker.invoke();
+//
+//                    idleStrategy.idle(workCount);
+//                }
+//                ++serviceAckId;
+//            }
+//            catch (final InterruptedException ex)
+//            {
+//                ctx.countedErrorHandler().onError(ex);
+//            }
+
             aeron.removeUnavailableCounterHandler(unavailableCounterHandlerRegistrationId);
 
             final CountedErrorHandler errorHandler = ctx.countedErrorHandler();

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -284,6 +284,30 @@ final class ConsensusModuleAgent
     {
         if (!aeron.isClosed())
         {
+            final long logPosition = commitPosition.get();
+            serviceProxy.terminationPosition(logPosition, ctx.countedErrorHandler());
+
+//            try
+//            {
+//                idleStrategy.reset();
+//                while (!ServiceAck.hasReached(logPosition, serviceAckId, serviceAckQueues))
+//                {
+//                    final int workCount = consensusModuleAdapter.poll();
+//                    if (Thread.currentThread().isInterrupted())
+//                    {
+//                        throw new InterruptedException();
+//                    }
+//                    aeronClientInvoker.invoke();
+//
+//                    idleStrategy.idle(workCount);
+//                }
+//                ++serviceAckId;
+//            }
+//            catch (final InterruptedException ex)
+//            {
+//                ctx.countedErrorHandler().onError(ex);
+//            }
+
             aeron.removeUnavailableCounterHandler(unavailableCounterHandlerRegistrationId);
 
             final CountedErrorHandler errorHandler = ctx.countedErrorHandler();

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -287,7 +287,7 @@ final class ConsensusModuleAgent
             final long logPosition = commitPosition.get();
             if (0 < ctx.serviceCount())
             {
-                serviceProxy.terminationPosition(logPosition, ctx.countedErrorHandler());
+                serviceProxy.terminationPosition(logPosition, false, ctx.countedErrorHandler());
             }
 
             aeron.removeUnavailableCounterHandler(unavailableCounterHandlerRegistrationId);
@@ -2504,7 +2504,7 @@ final class ConsensusModuleAgent
                     state(ConsensusModule.State.TERMINATING, "terminationPosition=" + terminationPosition);
                     if (serviceCount > 0)
                     {
-                        serviceProxy.terminationPosition(terminationPosition, ctx.countedErrorHandler());
+                        serviceProxy.terminationPosition(terminationPosition, true, ctx.countedErrorHandler());
                     }
                     else
                     {
@@ -2617,7 +2617,7 @@ final class ConsensusModuleAgent
                     terminationLeadershipTermId = leadershipTermId;
                     if (serviceCount > 0)
                     {
-                        serviceProxy.terminationPosition(terminationPosition, errorHandler);
+                        serviceProxy.terminationPosition(terminationPosition, true, errorHandler);
                     }
                     else
                     {
@@ -3125,7 +3125,7 @@ final class ConsensusModuleAgent
         {
             if (serviceCount > 0)
             {
-                serviceProxy.terminationPosition(terminationPosition, ctx.countedErrorHandler());
+                serviceProxy.terminationPosition(terminationPosition, true, ctx.countedErrorHandler());
             }
             else
             {
@@ -3298,7 +3298,7 @@ final class ConsensusModuleAgent
         aeron.removeUnavailableCounterHandler(unavailableCounterHandlerRegistrationId);
         if (serviceCount > 0)
         {
-            serviceProxy.terminationPosition(0, ctx.countedErrorHandler());
+            serviceProxy.terminationPosition(0, true, ctx.countedErrorHandler());
         }
         tryStopLogRecording();
         state(ConsensusModule.State.CLOSED, terminationReason);

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -285,7 +285,10 @@ final class ConsensusModuleAgent
         if (!aeron.isClosed())
         {
             final long logPosition = commitPosition.get();
-            serviceProxy.terminationPosition(logPosition, ctx.countedErrorHandler());
+            if (0 < ctx.serviceCount())
+            {
+                serviceProxy.terminationPosition(logPosition, ctx.countedErrorHandler());
+            }
 
             aeron.removeUnavailableCounterHandler(unavailableCounterHandlerRegistrationId);
 

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -287,27 +287,6 @@ final class ConsensusModuleAgent
             final long logPosition = commitPosition.get();
             serviceProxy.terminationPosition(logPosition, ctx.countedErrorHandler());
 
-//            try
-//            {
-//                idleStrategy.reset();
-//                while (!ServiceAck.hasReached(logPosition, serviceAckId, serviceAckQueues))
-//                {
-//                    final int workCount = consensusModuleAdapter.poll();
-//                    if (Thread.currentThread().isInterrupted())
-//                    {
-//                        throw new InterruptedException();
-//                    }
-//                    aeronClientInvoker.invoke();
-//
-//                    idleStrategy.idle(workCount);
-//                }
-//                ++serviceAckId;
-//            }
-//            catch (final InterruptedException ex)
-//            {
-//                ctx.countedErrorHandler().onError(ex);
-//            }
-
             aeron.removeUnavailableCounterHandler(unavailableCounterHandlerRegistrationId);
 
             final CountedErrorHandler errorHandler = ctx.countedErrorHandler();

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ServiceProxy.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ServiceProxy.java
@@ -189,7 +189,7 @@ final class ServiceProxy implements AutoCloseable
         throw new ClusterException("failed to send cluster members extended response: result=" + result);
     }
 
-    void terminationPosition(final long logPosition, final ErrorHandler errorHandler)
+    void terminationPosition(final long logPosition, final boolean ackRequired, final ErrorHandler errorHandler)
     {
         if (!publication.isClosed())
         {
@@ -204,7 +204,8 @@ final class ServiceProxy implements AutoCloseable
                 {
                     serviceTerminationPositionEncoder
                         .wrapAndApplyHeader(bufferClaim.buffer(), bufferClaim.offset(), messageHeaderEncoder)
-                        .logPosition(logPosition);
+                        .logPosition(logPosition)
+                        .ackRequired(ackRequired ? BooleanType.TRUE : BooleanType.FALSE);
 
                     bufferClaim.commit();
 

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusterTerminationException.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusterTerminationException.java
@@ -17,24 +17,22 @@ package io.aeron.cluster.service;
 
 import org.agrona.concurrent.AgentTerminationException;
 
+import java.io.Serial;
+
 /**
  * Used to terminate the {@link org.agrona.concurrent.Agent} within a cluster in an expected/unexpected fashion.
  */
 public class ClusterTerminationException extends AgentTerminationException
 {
-    private static final long serialVersionUID = -2705156056823180407L;
-
-    /**
-     * Is expected termination?
-     */
-    private final boolean isExpected;
+    @Serial
+    private static final long serialVersionUID = 6809832984207126795L;
 
     /**
      * Construct an exception used to terminate the cluster with {@link #isExpected()} set to true.
      */
     public ClusterTerminationException()
     {
-        this(true);
+        super(true);
     }
 
     /**
@@ -44,17 +42,6 @@ public class ClusterTerminationException extends AgentTerminationException
      */
     public ClusterTerminationException(final boolean isExpected)
     {
-        super(isExpected ? "expected termination" : "unexpected termination");
-        this.isExpected = isExpected;
-    }
-
-    /**
-     * Whether the termination is expected.
-     *
-     * @return true if expected otherwise false.
-     */
-    public boolean isExpected()
-    {
-        return isExpected;
+        super(isExpected ? "expected termination" : "unexpected termination", isExpected);
     }
 }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceAgent.java
@@ -133,6 +133,7 @@ final class ClusteredServiceAgent extends ClusteredServiceAgentRhsPadding implem
     private long closeHandlerRegistrationId;
     private long ackId = 0;
     private long terminationPosition = NULL_POSITION;
+    private boolean terminationAckRequired = true;
     private long markFileUpdateDeadlineMs;
     private long lastSlowTickNs;
     private long clusterTime;
@@ -469,9 +470,10 @@ final class ClusteredServiceAgent extends ClusteredServiceAgentRhsPadding implem
             logChannel);
     }
 
-    void onServiceTerminationPosition(final long logPosition)
+    void onServiceTerminationPosition(final long logPosition, final boolean ackRequired)
     {
         terminationPosition = logPosition;
+        terminationAckRequired = ackRequired;
     }
 
     void onRequestServiceAck(final long logPosition)
@@ -1173,7 +1175,7 @@ final class ClusteredServiceAgent extends ClusteredServiceAgentRhsPadding implem
                     "service terminate: logPosition=" + logPosition + " > terminationPosition=" + terminationPosition));
             }
 
-            terminate(logPosition == terminationPosition);
+            terminate(logPosition == terminationPosition, terminationAckRequired);
         }
 
         if (NULL_POSITION != requestedAckPosition && logPosition >= requestedAckPosition)
@@ -1196,7 +1198,7 @@ final class ClusteredServiceAgent extends ClusteredServiceAgentRhsPadding implem
         return workCount;
     }
 
-    private void terminate(final boolean isTerminationExpected)
+    private void terminate(final boolean isTerminationExpected, final boolean terminationAckRequired)
     {
         isServiceActive = false;
         activeLifecycleCallback = LIFECYCLE_CALLBACK_ON_TERMINATE;
@@ -1213,22 +1215,25 @@ final class ClusteredServiceAgent extends ClusteredServiceAgentRhsPadding implem
             activeLifecycleCallback = LIFECYCLE_CALLBACK_NONE;
         }
 
-        try
+        if (terminationAckRequired)
         {
-            int attempts = 5;
-            final long id = ackId++;
-            while (!consensusModuleProxy.ack(logPosition, clusterTime, id, NULL_VALUE, serviceId))
+            try
             {
-                if (0 == --attempts)
+                int attempts = 5;
+                final long id = ackId++;
+                while (!consensusModuleProxy.ack(logPosition, clusterTime, id, NULL_VALUE, serviceId))
                 {
-                    break;
+                    if (0 == --attempts)
+                    {
+                        break;
+                    }
+                    idle();
                 }
-                idle();
             }
-        }
-        catch (final Exception ex)
-        {
-            ctx.countedErrorHandler().onError(ex);
+            catch (final Exception ex)
+            {
+                ctx.countedErrorHandler().onError(ex);
+            }
         }
 
         terminationPosition = NULL_VALUE;

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ServiceAdapter.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ServiceAdapter.java
@@ -91,7 +91,9 @@ final class ServiceAdapter implements AutoCloseable
                     messageHeaderDecoder.blockLength(),
                     messageHeaderDecoder.version());
 
-                clusteredServiceAgent.onServiceTerminationPosition(serviceTerminationPositionDecoder.logPosition());
+                clusteredServiceAgent.onServiceTerminationPosition(
+                    serviceTerminationPositionDecoder.logPosition(),
+                    BooleanType.TRUE == serviceTerminationPositionDecoder.ackRequired());
                 break;
 
             case RequestServiceAckDecoder.TEMPLATE_ID:

--- a/aeron-cluster/src/main/resources/cluster/aeron-cluster-codecs.xml
+++ b/aeron-cluster/src/main/resources/cluster/aeron-cluster-codecs.xml
@@ -2,7 +2,7 @@
 <sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
                    package="io.aeron.cluster.codecs"
                    id="111"
-                   version="16"
+                   version="17"
                    semanticVersion="5.4"
                    description="Message Codecs for communicating with, and within, an Aeron Cluster."
                    byteOrder="littleEndian">
@@ -380,7 +380,7 @@
                  id="42"
                  description="Consensus Module instructing a service to terminate at a given position.">
         <field name="logPosition"              id="1" type="int64"/>
-        <field name="ackRequired"              id="2" type="BooleanType"/>
+        <field name="ackRequired"              id="2" type="BooleanType" sinceVersion="17"/>
     </sbe:message>
 
     <sbe:message name="ClusterMembersExtendedResponse"

--- a/aeron-cluster/src/main/resources/cluster/aeron-cluster-codecs.xml
+++ b/aeron-cluster/src/main/resources/cluster/aeron-cluster-codecs.xml
@@ -380,6 +380,7 @@
                  id="42"
                  description="Consensus Module instructing a service to terminate at a given position.">
         <field name="logPosition"              id="1" type="int64"/>
+        <field name="ackRequired"              id="2" type="BooleanType"/>
     </sbe:message>
 
     <sbe:message name="ClusterMembersExtendedResponse"

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
@@ -199,6 +199,25 @@ class ClusterTest
     }
 
     @Test
+    @InterruptAfter(30)
+    void shouldStopFollowerAndRestartFollowerGracefully()
+    {
+        cluster = aCluster().withStaticNodes(3).start();
+        systemTestWatcher.cluster(cluster);
+
+        final TestNode leader = cluster.awaitLeader();
+        assertEquals(1, leader.consensusModule().context().electionCounter().get());
+        final TestNode follower = cluster.followers().get(0);
+        assertEquals(1, follower.consensusModule().context().electionCounter().get());
+        awaitElectionClosed(follower);
+
+        cluster.connectClient();
+        cluster.sendAndAwaitMessages(10);
+        cluster.stopNodeGracefully(follower);
+        cluster.waitForServiceTermination(follower);
+    }
+
+    @Test
     @InterruptAfter(40)
     void shouldNotifyClientOfNewLeader()
     {

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/StubClusteredService.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/StubClusteredService.java
@@ -31,6 +31,7 @@ public class StubClusteredService implements ClusteredService
 {
     protected Cluster cluster;
     protected IdleStrategy idleStrategy;
+    private volatile boolean isTerminated;
 
     public void onStart(final Cluster cluster, final Image snapshotImage)
     {
@@ -70,6 +71,7 @@ public class StubClusteredService implements ClusteredService
 
     public void onTerminate(final Cluster cluster)
     {
+        isTerminated = true;
     }
 
     protected long serviceCorrelationId(final int correlationId)
@@ -99,5 +101,10 @@ public class StubClusteredService implements ClusteredService
                     Publication.errorString(result) + ", clusterSessionId=" + session.id());
             }
         }
+    }
+
+    public boolean isTerminated()
+    {
+        return isTerminated;
     }
 }

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
@@ -2548,6 +2548,23 @@ public final class TestCluster implements AutoCloseable
         }
     }
 
+    public void stopNodeGracefully(final TestNode follower)
+    {
+        follower.consensusModule().close();
+    }
+
+    public void waitForServiceTermination(final TestNode follower)
+    {
+        final TestNode.TestService[] services = follower.services();
+        for (final TestNode.TestService service : services)
+        {
+            while (!service.isTerminated())
+            {
+                Tests.sleep(1);
+            }
+        }
+    }
+
     private class BackupQueryRunner implements AutoCloseable
     {
         private final ExpandableArrayBuffer expandableArrayBuffer = new ExpandableArrayBuffer(128);

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
@@ -2562,6 +2562,23 @@ public final class TestCluster implements AutoCloseable
         }
     }
 
+    public void stopNodeGracefully(final TestNode follower)
+    {
+        follower.consensusModule().close();
+    }
+
+    public void waitForServiceTermination(final TestNode follower)
+    {
+        final TestNode.TestService[] services = follower.services();
+        for (final TestNode.TestService service : services)
+        {
+            while (!service.isTerminated())
+            {
+                Tests.sleep(1);
+            }
+        }
+    }
+
     private class BackupQueryRunner implements AutoCloseable
     {
         private final ExpandableArrayBuffer expandableArrayBuffer = new ExpandableArrayBuffer(128);

--- a/build.gradle
+++ b/build.gradle
@@ -237,7 +237,8 @@ subprojects {
                 "-XX:HeapDumpPath=${baseLogFileName}-heap.hprof",
                 "-XX:+UseParallelGC",
                 "-Xlog:gc*,safepoint=info,arguments=info:file=${baseLogFileName}-gc.log:time",
-                "-XX:ErrorFile=${baseLogFileName}-crash.log")
+                "-XX:ErrorFile=${baseLogFileName}-crash.log",
+                "-Xshare:off")
 
         useJUnitPlatform {
             if (test.name != 'slowTest' && test.name != 'bindingsTest' && test.name != 'topologyTest')

--- a/build.gradle
+++ b/build.gradle
@@ -242,7 +242,8 @@ subprojects {
                 "-XX:HeapDumpPath=${baseLogFileName}-heap.hprof",
                 "-XX:+UseParallelGC",
                 "-Xlog:gc*,safepoint=info,arguments=info:file=${baseLogFileName}-gc.log:time",
-                "-XX:ErrorFile=${baseLogFileName}-crash.log")
+                "-XX:ErrorFile=${baseLogFileName}-crash.log",
+                "-Xshare:off")
 
         useJUnitPlatform {
             if (test.name != 'slowTest' && test.name != 'bindingsTest'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agrona = "2.5.0"
+agrona = "2.6.0-SNAPSHOT"
 asciidoctorj = "2.5.13"
 asm = "9.10.1"
 byteBuddy = "1.18.11"


### PR DESCRIPTION
Use a clean termination when the ClusteredServiceContainer closed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster shutdown coordination and bumps the inter-component SBE schema (v17), which can affect rolling upgrades and termination ordering; behavior is covered by a new graceful-stop test.
> 
> **Overview**
> When **ConsensusModuleAgent** closes, it now notifies clustered services at the current **commit position** with **`ackRequired=false`**, so services run **`onTerminate`** and exit without blocking on a consensus-module ack while the module is already shutting down. Cluster-driven shutdown, abort, and follower termination paths still send **`ackRequired=true`**.
> 
> The **`ServiceTerminationPosition`** wire message gains an **`ackRequired`** field (schema **v17**). **`ClusteredServiceAgent`** only sends the termination ack to the consensus module when that flag is set.
> 
> **`ClusterTerminationException`** now inherits expected/unexpected termination from Agrona’s **`AgentTerminationException`** instead of storing its own flag.
> 
> Adds a system test for graceful follower stop plus test helpers; bumps Agrona to **2.6.0-SNAPSHOT** and adds **`-Xshare:off`** for JVM tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c4a1d09c76ea8b44c5c8cdb6cac253b5a928d4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->