### PR TITLE
[Java] Map EMPTY_RECORDING in ArchiveException.errorCodeAsString

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/client/ArchiveException.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/client/ArchiveException.java
@@ -321,6 +321,7 @@ public class ArchiveException extends AeronException
             case UNKNOWN_REPLICATION -> "UNKNOWN_REPLICATION";
             case UNAUTHORISED_ACTION -> "UNAUTHORISED_ACTION";
             case REPLICATION_CONNECTION_FAILURE -> "REPLICATION_CONNECTION_FAILURE";
+            case EMPTY_RECORDING -> "EMPTY_RECORDING";
             case INVALID_POSITION -> "INVALID_POSITION";
             default -> "unknown error code: " + errorCode;
         };

--- a/aeron-archive/src/test/java/io/aeron/archive/client/ArchiveExceptionTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/client/ArchiveExceptionTest.java
@@ -39,7 +39,9 @@ class ArchiveExceptionTest
         "11,STORAGE_SPACE",
         "12,UNKNOWN_REPLICATION",
         "13,UNAUTHORISED_ACTION",
-        "14,REPLICATION_CONNECTION_FAILURE" })
+        "14,REPLICATION_CONNECTION_FAILURE",
+        "15,EMPTY_RECORDING",
+        "16,INVALID_POSITION" })
     void errorCodeAsString(final int errorCode, final String expected)
     {
         assertEquals(expected, ArchiveException.errorCodeAsString(errorCode));


### PR DESCRIPTION
`ArchiveException.errorCodeAsString(int)` maps every archive error code to its symbolic name except `EMPTY_RECORDING` (15), which falls through to `"unknown error code: 15"`. The later-numbered `INVALID_POSITION` (16) is handled, so the gap is just the one code.

It's a live error, not a dead constant — `ArchiveConductor` sends `EMPTY_RECORDING` to clients (`controlSession.sendErrorResponse(..., ArchiveException.EMPTY_RECORDING, ...)`), so a client formatting it for logs/diagnostics currently gets a meaningless string.

Fix: add the missing `case EMPTY_RECORDING`. The parameterized `errorCodeAsString` test stopped at 14, so I also added rows for 15 (fails before this change) and 16 (was untested).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small client-side string mapping and test updates; no protocol or archive behavior changes.
> 
> **Overview**
> **`ArchiveException.errorCodeAsString`** now returns **`EMPTY_RECORDING`** for error code 15 instead of **`unknown error code: 15`**. That code is already sent to clients (e.g. empty replay in **`ArchiveConductor`**), so logs and diagnostics get a readable name.
> 
> The parameterized **`errorCodeAsString`** test adds cases for **15** and **16** (`INVALID_POSITION`), which were missing or only partially covered before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03b6f4d2f04ef7bb855b7159d63212b6f610bfbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->