### PR TITLE
Added "isLeadershipConfirmedSince" method to the ConsensusModuleAgent API

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusterMember.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusterMember.java
@@ -53,6 +53,11 @@ public final class ClusterMember
     private long changeCorrelationId = NULL_VALUE;
     private long logPosition = NULL_POSITION;
     private long timeOfLastAppendPositionNs = NULL_VALUE;
+    // ReadIndex leadership confirmation: the highest counter this member echoed (LeadershipConfirmAck) and the
+    // term it echoed it in. The term gate is essential -- a leftover counter from a prior leadership must never
+    // count towards a confirmation in the current term. Compared wrap-safe.
+    private int confirmationCounter;
+    private long confirmationCounterTermId = NULL_VALUE;
     private ExclusivePublication publication;
     private String consensusChannel;
     private final String consensusEndpoint;
@@ -146,6 +151,7 @@ public final class ClusterMember
         candidateTermId = NULL_VALUE;
         leadershipTermId = NULL_VALUE;
         logPosition = NULL_POSITION;
+        confirmationCounterTermId = NULL_VALUE;
     }
 
     /**
@@ -892,6 +898,80 @@ public final class ClusterMember
         }
 
         return rankedPositions[length - 1];
+    }
+
+    /**
+     * Set the confirmation counter a member has echoed (via {@code LeadershipConfirmAck}) together with the term
+     * it echoed in. Only a value stored against the current leadership term counts towards a confirmation.
+     *
+     * @param confirmationCounter echoed by the member.
+     * @param leadershipTermId    the term in which the member echoed the counter.
+     * @return this for a fluent API.
+     */
+    public ClusterMember confirmationCounter(final int confirmationCounter, final long leadershipTermId)
+    {
+        this.confirmationCounter = confirmationCounter;
+        this.confirmationCounterTermId = leadershipTermId;
+        return this;
+    }
+
+    /**
+     * The highest confirmation counter this member has echoed.
+     *
+     * @return the highest confirmation counter this member has echoed.
+     */
+    public int confirmationCounter()
+    {
+        return confirmationCounter;
+    }
+
+    /**
+     * The leadership term in which the member last echoed its {@link #confirmationCounter()}.
+     *
+     * @return the leadership term of the last echoed confirmation counter, or {@link Aeron#NULL_VALUE} if none.
+     */
+    public long confirmationCounterTermId()
+    {
+        return confirmationCounterTermId;
+    }
+
+    /**
+     * Has a quorum confirmed the leader is still the leader strictly after the point captured by
+     * {@code confirmationToken}? The hosting member ({@code leaderMemberId}) is always counted; a non-self member
+     * counts iff it echoed a confirmation counter in {@code leadershipTermId} that is strictly beyond
+     * {@code confirmationToken} (wrap-safe). Because a counter is minted by the leader and only advances on a
+     * confirmation round, an acknowledgement in flight before the token was captured carries an older counter and
+     * cannot count -- so, unlike a receive-time check, this cannot be faked by a stale in-flight message.
+     *
+     * @param members          of the cluster (typically the active members, including the hosting node).
+     * @param leadershipTermId the term a non-self member must have echoed in to be counted.
+     * @param leaderMemberId   id of the hosting (leader) member, which is always counted.
+     * @param confirmationToken counter captured (e.g. from {@code triggerQuorumConfirmation}); a member must have
+     *                          echoed a strictly greater counter (wrap-safe) to be counted.
+     * @return {@code true} if a quorum (counting the hosting member) qualifies, otherwise {@code false}.
+     */
+    public static boolean hasQuorumConfirmedSince(
+        final ClusterMember[] members,
+        final long leadershipTermId,
+        final int leaderMemberId,
+        final int confirmationToken)
+    {
+        final int quorum = quorumThreshold(members.length);
+        int confirmed = 0;
+        for (final ClusterMember member : members)
+        {
+            if (member.id == leaderMemberId ||
+                (member.confirmationCounterTermId == leadershipTermId &&
+                0 < (member.confirmationCounter - confirmationToken)))
+            {
+                if (++confirmed >= quorum)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusAdapter.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusAdapter.java
@@ -41,6 +41,7 @@ class ConsensusAdapter implements FragmentHandler, AutoCloseable
     private final NewLeadershipTermDecoder newLeadershipTermDecoder = new NewLeadershipTermDecoder();
     private final AppendPositionDecoder appendPositionDecoder = new AppendPositionDecoder();
     private final CommitPositionDecoder commitPositionDecoder = new CommitPositionDecoder();
+    private final LeadershipConfirmAckDecoder leadershipConfirmAckDecoder = new LeadershipConfirmAckDecoder();
     private final CatchupPositionDecoder catchupPositionDecoder = new CatchupPositionDecoder();
     private final StopCatchupDecoder stopCatchupDecoder = new StopCatchupDecoder();
 
@@ -193,7 +194,21 @@ class ConsensusAdapter implements FragmentHandler, AutoCloseable
                 consensusModuleAgent.onCommitPosition(
                     commitPositionDecoder.leadershipTermId(),
                     commitPositionDecoder.logPosition(),
-                    commitPositionDecoder.leaderMemberId());
+                    commitPositionDecoder.leaderMemberId(),
+                    commitPositionDecoder.confirmationCounter());
+                break;
+
+            case LeadershipConfirmAckDecoder.TEMPLATE_ID:
+                leadershipConfirmAckDecoder.wrap(
+                    buffer,
+                    offset + MessageHeaderDecoder.ENCODED_LENGTH,
+                    messageHeaderDecoder.blockLength(),
+                    messageHeaderDecoder.version());
+
+                consensusModuleAgent.onLeadershipConfirmAck(
+                    leadershipConfirmAckDecoder.leadershipTermId(),
+                    leadershipConfirmAckDecoder.followerMemberId(),
+                    leadershipConfirmAckDecoder.confirmationCounter());
                 break;
 
             case CatchupPositionDecoder.TEMPLATE_ID:

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -123,6 +123,9 @@ final class ConsensusModuleAgent
     static final long SLOW_TICK_INTERVAL_NS = MILLISECONDS.toNanos(10);
     static final short APPEND_POSITION_FLAG_NONE = 0;
     static final short APPEND_POSITION_FLAG_CATCHUP = 1;
+    // Reserved "absent" sentinel for the ReadIndex confirmation counter (matches the SBE int32 nullValue). A
+    // leader never mints this value, so it unambiguously marks a pre-v17 peer or an un-received counter.
+    static final int NULL_CONFIRMATION_COUNTER = Integer.MIN_VALUE;
 
     private final long leaderHeartbeatIntervalNs;
     private final long leaderHeartbeatTimeoutNs;
@@ -134,6 +137,16 @@ final class ConsensusModuleAgent
     private long terminationLeadershipTermId = NULL_VALUE;
     private long notifiedCommitPosition = 0;
     private long lastAppendPosition = NULL_POSITION;
+    // Leader: monotonic per-leadership round counter for ReadIndex-style leadership confirmation. Advances only
+    // when a confirmation round is broadcast (see triggerQuorumConfirmation), never on a plain commit-advance
+    // broadcast, so a follower acks at most once per round. Compared wrap-safe.
+    private int confirmationCounter = NULL_CONFIRMATION_COUNTER;
+    // Leader: a linearizable-read caller requested a confirmation round; coalesced to <=1 broadcast per duty cycle.
+    private boolean confirmationRoundPending = false;
+    // Follower: highest confirmation counter received from the current leader, echoed back once (per advance) via
+    // LeadershipConfirmAck so the leader confirms leadership after a captured token without receive-time races.
+    private int lastReceivedConfirmationCounter = NULL_CONFIRMATION_COUNTER;
+    private boolean confirmAckPending = false;
     private long lastQuorumBacktrackCommitPosition = NULL_POSITION;
     private long timeOfLastLogUpdateNs = 0;
     private long timeOfLastAppendPositionUpdateNs = 0;
@@ -602,6 +615,78 @@ final class ConsensusModuleAgent
     public ClusterMember clusterMember()
     {
         return thisMember;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public long triggerQuorumConfirmation()
+    {
+        // Not leader, or still in election: no confirmation is possible yet (confirmationCounter is not a valid
+        // token until electionComplete resets it and publishCommitPosition stops sending the absent sentinel).
+        if (Cluster.Role.LEADER != role || null != election)
+        {
+            return NULL_VALUE;
+        }
+
+        // Request a coalesced confirmation round. The duty cycle broadcasts at most one CommitPosition per cycle
+        // carrying an advanced counter, which followers echo via LeadershipConfirmAck. A quorum echoing strictly
+        // beyond the returned token proves leadership was recognised after this call, giving a ~1 RTT
+        // linearizable read without a log barrier.
+        confirmationRoundPending = true;
+
+        // Pack the leadership term (high 32 bits) with the counter (low 32 bits) so the token can only confirm
+        // within this term -- a token minted in an earlier term cannot be satisfied after a re-election.
+        return (leadershipTermId << 32) | (confirmationCounter & 0xFFFF_FFFFL);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean isLeadershipConfirmedSince(final long confirmationToken)
+    {
+        // Not the confirmed leader, in an election, or the not-leader sentinel: cannot confirm.
+        if (Cluster.Role.LEADER != role || null != election || NULL_VALUE == confirmationToken)
+        {
+            return false;
+        }
+
+        // The token packs the leadership term (high 32 bits) with the confirmation counter (low 32 bits). A
+        // token minted in a different term must never confirm -- this guards against reusing a token captured
+        // before a deposition against a later re-election of this node.
+        if ((confirmationToken >>> 32) != (leadershipTermId & 0xFFFF_FFFFL))
+        {
+            return false;
+        }
+
+        final int tokenCounter = (int)confirmationToken;
+        if (NULL_CONFIRMATION_COUNTER == tokenCounter)
+        {
+            return false;
+        }
+
+        return ClusterMember.hasQuorumConfirmedSince(activeMembers, leadershipTermId, memberId, tokenCounter);
+    }
+
+    void onLeadershipConfirmAck(final long leadershipTermId, final int followerMemberId, final int confirmationCounter)
+    {
+        if (null == election && Cluster.Role.LEADER == role && leadershipTermId == this.leadershipTermId &&
+            NULL_CONFIRMATION_COUNTER != confirmationCounter)
+        {
+            final ClusterMember follower = clusterMemberByIdMap.get(followerMemberId);
+            if (null != follower)
+            {
+                follower.confirmationCounter(confirmationCounter, leadershipTermId);
+            }
+        }
+    }
+
+    private int nextConfirmationCounter(final int counter)
+    {
+        final int next = counter + 1;
+        // Skip the reserved sentinels so a live token is never confused with "absent" (NULL_CONFIRMATION_COUNTER)
+        // or the not-leader signal (NULL_VALUE) returned by triggerQuorumConfirmation.
+        return (NULL_CONFIRMATION_COUNTER == next || NULL_VALUE == next) ? next + 1 : next;
     }
 
     public void onLoadBeginSnapshot(
@@ -1080,7 +1165,8 @@ final class ConsensusModuleAgent
             .timeOfLastAppendPositionNs(clusterClock.timeNanos());
     }
 
-    void onCommitPosition(final long leadershipTermId, final long logPosition, final int leaderMemberId)
+    void onCommitPosition(
+        final long leadershipTermId, final long logPosition, final int leaderMemberId, final int confirmationCounter)
     {
         logOnCommitPosition(memberId, leadershipTermId, logPosition, leaderMemberId);
 
@@ -1100,6 +1186,15 @@ final class ConsensusModuleAgent
             {
                 notifiedCommitPosition = max(notifiedCommitPosition, logPosition);
                 timeOfLastLogUpdateNs = nowNs;
+                // Echo an advanced confirmation counter once, so a leader-triggered round confirms leadership in
+                // ~1 RTT (see updateFollowerPosition -> LeadershipConfirmAck). An unchanged counter sends nothing,
+                // so plain commit traffic is not amplified.
+                if (NULL_CONFIRMATION_COUNTER != confirmationCounter &&
+                    confirmationCounter != lastReceivedConfirmationCounter)
+                {
+                    lastReceivedConfirmationCounter = confirmationCounter;
+                    confirmAckPending = true;
+                }
             }
         }
         else if (leadershipTermId > this.leadershipTermId)
@@ -1888,6 +1983,9 @@ final class ConsensusModuleAgent
             timerService.currentTime(clusterTimeUnit.convert(nowNs, NANOSECONDS));
             ClusterControl.ToggleState.activate(controlToggle);
             sessionManager.prepareSessionsForNewTerm(election.isLeaderStartup());
+            // Fresh confirmation epoch for this leadership; per-member echoes are gated on the current term.
+            confirmationCounter = 0;
+            confirmationRoundPending = false;
         }
         else
         {
@@ -1895,6 +1993,9 @@ final class ConsensusModuleAgent
             timeOfLastAppendPositionUpdateNs = nowNs;
             timeOfLastAppendPositionSendNs = nowNs;
             localLogChannel = null;
+            // Drop any pending confirmation echo from a prior term so it cannot be sent against the new leader.
+            lastReceivedConfirmationCounter = NULL_CONFIRMATION_COUNTER;
+            confirmAckPending = false;
         }
         NodeControl.ToggleState.activate(nodeControlToggle);
 
@@ -2682,8 +2783,20 @@ final class ConsensusModuleAgent
     private int updateFollowerPosition(final long nowNs)
     {
         final long recordedPosition = null != appendPosition ? appendPosition.get() : logRecordingStopPosition;
-        return updateFollowerPosition(
+        int workCount = updateFollowerPosition(
             leaderMember.publication(), nowNs, leadershipTermId, recordedPosition, APPEND_POSITION_FLAG_NONE);
+
+        // Echo the leader's confirmation counter (ReadIndex round). Sent only when a new counter arrived, so this
+        // adds no traffic outside active linearizable-read confirmation.
+        if (confirmAckPending &&
+            consensusPublisher.leadershipConfirmAck(
+                leaderMember.publication(), leadershipTermId, memberId, lastReceivedConfirmationCounter))
+        {
+            confirmAckPending = false;
+            workCount += 1;
+        }
+
+        return workCount;
     }
 
     private int updateFollowerPosition(
@@ -2845,6 +2958,7 @@ final class ConsensusModuleAgent
 
         final long leaderCommitPosition = commitPosition.getPlain();
         if (quorumPosition > leaderCommitPosition ||
+            confirmationRoundPending ||
             nowNs >= (timeOfLastLogUpdateNs + leaderHeartbeatIntervalNs))
         {
             if (quorumPosition < leaderCommitPosition && leaderCommitPosition > lastQuorumBacktrackCommitPosition)
@@ -2852,6 +2966,14 @@ final class ConsensusModuleAgent
                 lastQuorumBacktrackCommitPosition = leaderCommitPosition;
                 ctx.countedErrorHandler().onError(new ClusterEvent("quorum position went backwards: " +
                     "leaderCommitPosition=" + leaderCommitPosition + " quorumPosition=" + quorumPosition));
+            }
+
+            // Advance the confirmation counter only when a round was requested, so followers ack once per round
+            // rather than on every commit-position broadcast.
+            if (confirmationRoundPending)
+            {
+                confirmationCounter = nextConfirmationCounter(confirmationCounter);
+                confirmationRoundPending = false;
             }
 
             publishCommitPosition(quorumPosition, leadershipTermId);
@@ -2868,11 +2990,17 @@ final class ConsensusModuleAgent
 
     void publishCommitPosition(final long commitPosition, final long leadershipTermId)
     {
+        // During an election this is broadcast under the new term while confirmationCounter may still hold a
+        // prior leadership's value (it is reset in electionComplete, which runs after these election-phase
+        // broadcasts). Send the "absent" sentinel until the election completes so a follower cannot echo a
+        // counter that would confirm leadership before a post-election confirmation round.
+        final int counterToSend = null == election ? confirmationCounter : NULL_CONFIRMATION_COUNTER;
         for (final ClusterMember member : activeMembers)
         {
             if (member.id() != memberId)
             {
-                consensusPublisher.commitPosition(member.publication(), leadershipTermId, commitPosition, memberId);
+                consensusPublisher.commitPosition(
+                    member.publication(), leadershipTermId, commitPosition, memberId, counterToSend);
             }
         }
     }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleControl.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleControl.java
@@ -124,4 +124,33 @@ public interface ConsensusModuleControl
      * @return cluster member for this node.
      */
     ClusterMember clusterMember();
+
+    /**
+     * Is this node still the leader, confirmed by a quorum of members that recognise the current leadership term
+     * and have echoed a confirmation counter strictly beyond {@code confirmationToken}? {@code false} if this node
+     * is not the leader or fewer than a quorum have done so.
+     *
+     * <p>The token encodes a logical counter (not a clock time), so confirmation cannot be faked by an
+     * acknowledgement that was already in flight before the token was captured -- such a message carries an older
+     * counter. The token is also scoped to the leadership term in which it was issued: a token minted in an
+     * earlier term never confirms after a re-election, so this returns {@code false} rather than a stale result.
+     * Capture the token from {@link #triggerQuorumConfirmation()} after the read point, then poll this method.
+     *
+     * <p>Non-blocking; poll from {@link ConsensusModuleExtension#consensusWork(long)}.
+     *
+     * @param confirmationToken captured from {@link #triggerQuorumConfirmation()} in the current leadership term;
+     *                          a quorum must have echoed a strictly greater counter (wrap-safe) in that term.
+     * @return {@code true} if leadership is confirmed by a fresh quorum, otherwise {@code false}.
+     */
+    boolean isLeadershipConfirmedSince(long confirmationToken);
+
+    /**
+     * Request a coalesced leader confirmation round so followers acknowledge promptly, letting
+     * {@link #isLeadershipConfirmedSince(long)} confirm leadership in ~1 RTT rather than waiting for the periodic
+     * keep-alive. Multiple calls within a duty cycle share a single round.
+     *
+     * @return a term-scoped confirmation token to pass to {@link #isLeadershipConfirmedSince(long)}, or
+     *         {@link io.aeron.Aeron#NULL_VALUE} if this node is not the leader or an election is in progress.
+     */
+    long triggerQuorumConfirmation();
 }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusPublisher.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusPublisher.java
@@ -39,6 +39,7 @@ final class ConsensusPublisher
     private final NewLeadershipTermEncoder newLeadershipTermEncoder = new NewLeadershipTermEncoder();
     private final AppendPositionEncoder appendPositionEncoder = new AppendPositionEncoder();
     private final CommitPositionEncoder commitPositionEncoder = new CommitPositionEncoder();
+    private final LeadershipConfirmAckEncoder leadershipConfirmAckEncoder = new LeadershipConfirmAckEncoder();
     private final CatchupPositionEncoder catchupPositionEncoder = new CatchupPositionEncoder();
     private final StopCatchupEncoder stopCatchupEncoder = new StopCatchupEncoder();
     private final TerminationPositionEncoder terminationPositionEncoder = new TerminationPositionEncoder();
@@ -274,7 +275,8 @@ final class ConsensusPublisher
         final ExclusivePublication publication,
         final long leadershipTermId,
         final long logPosition,
-        final int leaderMemberId)
+        final int leaderMemberId,
+        final int confirmationCounter)
     {
         if (null == publication)
         {
@@ -293,7 +295,8 @@ final class ConsensusPublisher
                     .wrapAndApplyHeader(bufferClaim.buffer(), bufferClaim.offset(), messageHeaderEncoder)
                     .leadershipTermId(leadershipTermId)
                     .logPosition(logPosition)
-                    .leaderMemberId(leaderMemberId);
+                    .leaderMemberId(leaderMemberId)
+                    .confirmationCounter(confirmationCounter);
 
                 bufferClaim.commit();
 
@@ -303,6 +306,43 @@ final class ConsensusPublisher
             checkResult(position, publication);
         }
         while (--attempts > 0);
+    }
+
+    boolean leadershipConfirmAck(
+        final ExclusivePublication publication,
+        final long leadershipTermId,
+        final int followerMemberId,
+        final int confirmationCounter)
+    {
+        if (null == publication)
+        {
+            return false;
+        }
+
+        final int length = MessageHeaderEncoder.ENCODED_LENGTH + LeadershipConfirmAckEncoder.BLOCK_LENGTH;
+
+        int attempts = SEND_ATTEMPTS;
+        do
+        {
+            final long position = publication.tryClaim(length, bufferClaim);
+            if (position > 0)
+            {
+                leadershipConfirmAckEncoder
+                    .wrapAndApplyHeader(bufferClaim.buffer(), bufferClaim.offset(), messageHeaderEncoder)
+                    .leadershipTermId(leadershipTermId)
+                    .followerMemberId(followerMemberId)
+                    .confirmationCounter(confirmationCounter);
+
+                bufferClaim.commit();
+
+                return true;
+            }
+
+            checkResult(position, publication);
+        }
+        while (--attempts > 0);
+
+        return false;
     }
 
     boolean catchupPosition(

--- a/aeron-cluster/src/main/resources/cluster/aeron-cluster-codecs.xml
+++ b/aeron-cluster/src/main/resources/cluster/aeron-cluster-codecs.xml
@@ -2,7 +2,7 @@
 <sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
                    package="io.aeron.cluster.codecs"
                    id="111"
-                   version="16"
+                   version="17"
                    semanticVersion="5.4"
                    description="Message Codecs for communicating with, and within, an Aeron Cluster."
                    byteOrder="littleEndian">
@@ -507,6 +507,10 @@
         <field name="leadershipTermId"         id="1" type="int64"/>
         <field name="logPosition"              id="2" type="int64"/>
         <field name="leaderMemberId"           id="3" type="int32"/>
+        <!-- Monotonic leader-minted round counter for ReadIndex-style leadership confirmation. Advances only
+             on a confirmation round; echoed by followers in LeadershipConfirmAck. int32 (not int64) keeps this
+             message within the 24-byte body / single 64-byte Aeron frame; compared wrap-safe. -->
+        <field name="confirmationCounter"      id="4" type="int32" sinceVersion="17"/>
     </sbe:message>
 
     <sbe:message name="CatchupPosition"
@@ -523,6 +527,15 @@
                  description="The leader informs the follower it can stop the catchup process.">
         <field name="leadershipTermId"         id="1" type="int64"/>
         <field name="followerMemberId"         id="2" type="int32"/>
+    </sbe:message>
+
+    <sbe:message name="LeadershipConfirmAck"
+                 id="58"
+                 description="A follower echoes the leader's confirmation counter to prove it recognises the
+                              current leader in the current term, supporting ReadIndex-style linearizable reads.">
+        <field name="leadershipTermId"         id="1" type="int64"/>
+        <field name="followerMemberId"         id="2" type="int32"/>
+        <field name="confirmationCounter"      id="3" type="int32"/>
     </sbe:message>
 
     <sbe:message name="AddPassiveMember"

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ClusterMemberTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ClusterMemberTest.java
@@ -28,6 +28,7 @@ import static io.aeron.cluster.ClusterMember.isQuorumCandidate;
 import static io.aeron.cluster.ClusterMember.isQuorumLeader;
 import static io.aeron.cluster.ClusterMember.isUnanimousCandidate;
 import static io.aeron.cluster.ClusterMember.isUnanimousLeader;
+import static io.aeron.cluster.ClusterMember.hasQuorumConfirmedSince;
 import static io.aeron.cluster.ClusterMember.quorumPosition;
 import static io.aeron.cluster.ClusterMember.quorumThreshold;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -232,6 +233,138 @@ class ClusterMemberTest
 
         final long quorumPosition = quorumPosition(clusterMembers, positions, nowNs, timeoutNs);
         assertEquals(expectedQuorumPosition, quorumPosition);
+    }
+
+    @Test
+    void hasQuorumConfirmedSinceShouldConfirmWhenAQuorumEchoedBeyondTokenInCurrentTerm()
+    {
+        final int leaderId = 0;
+        final long term = 5;
+        final int token = 100;
+        final ClusterMember[] members = new ClusterMember[]
+        {
+            newMember(leaderId, term).confirmationCounter(100, term), // self (leader) -- always counted
+            newMember(1, term).confirmationCounter(101, term),        // echoed a later round in the current term
+            newMember(2, term).confirmationCounter(100, term)         // only echoed up to the token -- not beyond
+        };
+
+        // self + member1 = quorum of 2 -> confirmed
+        assertTrue(hasQuorumConfirmedSince(members, term, leaderId, token));
+    }
+
+    @Test
+    void hasQuorumConfirmedSinceShouldDeclineWhenOnlySelfIsBeyondToken()
+    {
+        final int leaderId = 0;
+        final long term = 5;
+        final int token = 100;
+        final ClusterMember[] members = new ClusterMember[]
+        {
+            newMember(leaderId, term).confirmationCounter(101, term),
+            newMember(1, term).confirmationCounter(100, term), // echoed only up to the token
+            newMember(2, term).confirmationCounter(99, term)   // echoed before the token
+        };
+
+        // only self qualifies (1 < quorum of 2) -> fail safe (caller falls back to a barrier)
+        assertFalse(hasQuorumConfirmedSince(members, term, leaderId, token));
+    }
+
+    @Test
+    void hasQuorumConfirmedSinceShouldNotCountStaleInFlightAcknowledgement()
+    {
+        // Bug-1 regression: a follower that echoed in the CURRENT term but only up to the captured token (i.e. an
+        // acknowledgement that was in flight before the token was captured, carrying an older counter) must NOT be
+        // counted. A receive-time check would wrongly count it and could serve a stale read.
+        final int leaderId = 0;
+        final long term = 5;
+        final int token = 100;
+        final ClusterMember[] members = new ClusterMember[]
+        {
+            newMember(leaderId, term).confirmationCounter(101, term),
+            newMember(1, term).confirmationCounter(100, term), // counter == token -> in flight before capture
+            newMember(2, term).confirmationCounter(100, term)
+        };
+
+        assertFalse(hasQuorumConfirmedSince(members, term, leaderId, token));
+    }
+
+    @Test
+    void hasQuorumConfirmedSinceShouldNotCountEchoesFromAPriorTerm()
+    {
+        final int leaderId = 0;
+        final long term = 5;
+        final int token = 100;
+        final ClusterMember[] members = new ClusterMember[]
+        {
+            newMember(leaderId, term).confirmationCounter(101, term),
+            // beyond token but PRIOR term -> must not count
+            newMember(1, term).confirmationCounter(1_000_000, term - 1),
+            newMember(2, term).confirmationCounter(1_000_000, term - 1)
+        };
+
+        assertFalse(hasQuorumConfirmedSince(members, term, leaderId, token));
+    }
+
+    @Test
+    void hasQuorumConfirmedSinceShouldNotCountAMemberThatNeverEchoedInThisTerm()
+    {
+        // A member's leadershipTermId is written by a normal AppendPosition, but confirmation must gate on the term
+        // it actually ECHOED a counter in. A current-term member that never sent a LeadershipConfirmAck (default
+        // confirmationCounterTermId == NULL_VALUE) must not be counted.
+        final int leaderId = 0;
+        final long term = 5;
+        final int token = 100;
+        final ClusterMember[] members = new ClusterMember[]
+        {
+            newMember(leaderId, term).confirmationCounter(101, term),
+            newMember(1, term, 900, 150), // current term via AppendPosition, but never echoed a confirmation
+            newMember(2, term, 800, 200)
+        };
+
+        assertFalse(hasQuorumConfirmedSince(members, term, leaderId, token));
+    }
+
+    @Test
+    void hasQuorumConfirmedSinceShouldConfirmWithMultipleEchoingFollowers()
+    {
+        final int leaderId = 0;
+        final long term = 5;
+        final int token = 100;
+        final ClusterMember[] members = new ClusterMember[]
+        {
+            newMember(leaderId, term).confirmationCounter(101, term),
+            newMember(1, term).confirmationCounter(101, term),
+            newMember(2, term).confirmationCounter(102, term)
+        };
+
+        // self + two current-term followers beyond the token -> well past quorum -> confirmed
+        assertTrue(hasQuorumConfirmedSince(members, term, leaderId, token));
+    }
+
+    @Test
+    void hasQuorumConfirmedSinceShouldBeWrapSafeAroundIntegerBoundary()
+    {
+        final int leaderId = 0;
+        final long term = 5;
+
+        // token near MAX_VALUE; a follower whose counter wrapped past it (MIN_VALUE + 1) is still "beyond".
+        final int token = Integer.MAX_VALUE;
+        final ClusterMember[] beyond = new ClusterMember[]
+        {
+            newMember(leaderId, term).confirmationCounter(Integer.MIN_VALUE + 1, term),
+            newMember(1, term).confirmationCounter(Integer.MIN_VALUE + 1, term),
+            newMember(2, term).confirmationCounter(Integer.MAX_VALUE, term) // only up to token -> not beyond
+        };
+        assertTrue(hasQuorumConfirmedSince(beyond, term, leaderId, token));
+
+        // a follower still at the token (not wrapped beyond) must not count
+        final ClusterMember[] atToken = new ClusterMember[]
+        {
+            newMember(leaderId, term).confirmationCounter(Integer.MIN_VALUE + 1, term),
+            newMember(1, term).confirmationCounter(Integer.MAX_VALUE, term),
+            newMember(2, term).confirmationCounter(Integer.MAX_VALUE, term)
+        };
+        assertFalse(hasQuorumConfirmedSince(atToken, term, leaderId, token));
     }
 
     @Test
@@ -564,6 +697,11 @@ class ClusterMemberTest
             .leadershipTermId(leadershipTermId)
             .logPosition(logPosition)
             .timeOfLastAppendPositionNs(timeOfLastAppendPositionNs);
+    }
+
+    private static ClusterMember newMember(final int id, final long leadershipTermId)
+    {
+        return newMember(id).leadershipTermId(leadershipTermId);
     }
 
     private static ClusterMember newMember(final int id)

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleAgentTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleAgentTest.java
@@ -85,6 +85,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -137,6 +138,13 @@ class ConsensusModuleAgentTest
     {
         final AtomicCounter atomicCounter = countersManager.newCounter(name, typeId);
         return new Counter(countersManager, atomicCounter.id());
+    }
+
+    // Mirrors the leadership-confirmation token packing in ConsensusModuleAgent (term in the high 32 bits,
+    // counter in the low 32 bits).
+    private static long confirmationToken(final long leadershipTermId, final int confirmationCounter)
+    {
+        return (leadershipTermId << 32) | (confirmationCounter & 0xFFFF_FFFFL);
     }
 
     @BeforeEach
@@ -484,7 +492,8 @@ class ConsensusModuleAgentTest
 
         clock.increment(444);
 
-        consensusModuleAgent.onCommitPosition(leadershipTermId, 555, 0);
+        consensusModuleAgent.onCommitPosition(
+            leadershipTermId, 555, 0, ConsensusModuleAgent.NULL_CONFIRMATION_COUNTER);
 
         assertEquals(444, consensusModuleAgent.timeOfLastLeaderUpdateNs());
     }
@@ -576,47 +585,278 @@ class ConsensusModuleAgentTest
         assertEquals(0, agent.notifiedCommitPosition());
 
         clock.increment(1);
-        agent.onCommitPosition(leadershipTermId, 100, leader.id());
+        agent.onCommitPosition(leadershipTermId, 100, leader.id(), ConsensusModuleAgent.NULL_CONFIRMATION_COUNTER);
         assertEquals(100, agent.notifiedCommitPosition());
         assertEquals(clock.timeNanos(), agent.timeOfLastLogUpdateNs());
 
         clock.increment(1);
-        agent.onCommitPosition(leadershipTermId, 200, leader.id());
+        agent.onCommitPosition(leadershipTermId, 200, leader.id(), ConsensusModuleAgent.NULL_CONFIRMATION_COUNTER);
         assertEquals(200, agent.notifiedCommitPosition());
         assertEquals(clock.timeNanos(), agent.timeOfLastLogUpdateNs());
 
         clock.increment(1);
-        agent.onCommitPosition(leadershipTermId, 50, leader.id());
+        agent.onCommitPosition(leadershipTermId, 50, leader.id(), ConsensusModuleAgent.NULL_CONFIRMATION_COUNTER);
         assertEquals(200, agent.notifiedCommitPosition());
         assertEquals(clock.timeNanos(), agent.timeOfLastLogUpdateNs());
 
         clock.increment(1);
-        agent.onCommitPosition(leadershipTermId, -1, leader.id());
+        agent.onCommitPosition(leadershipTermId, -1, leader.id(), ConsensusModuleAgent.NULL_CONFIRMATION_COUNTER);
         assertEquals(200, agent.notifiedCommitPosition());
         assertEquals(clock.timeNanos(), agent.timeOfLastLogUpdateNs());
 
         final long lastUpdateNs = clock.timeNanos();
         clock.increment(1);
-        agent.onCommitPosition(leadershipTermId - 1, 5000, leader.id());
+        agent.onCommitPosition(leadershipTermId - 1, 5000, leader.id(), ConsensusModuleAgent.NULL_CONFIRMATION_COUNTER);
         assertEquals(200, agent.notifiedCommitPosition());
         assertEquals(lastUpdateNs, agent.timeOfLastLogUpdateNs());
 
         clock.increment(5);
-        agent.onCommitPosition(leadershipTermId, 700, -100);
+        agent.onCommitPosition(leadershipTermId, 700, -100, ConsensusModuleAgent.NULL_CONFIRMATION_COUNTER);
         assertEquals(200, agent.notifiedCommitPosition());
         assertEquals(lastUpdateNs, agent.timeOfLastLogUpdateNs());
 
         clock.increment(3);
         agent.role(Cluster.Role.CANDIDATE);
-        agent.onCommitPosition(leadershipTermId, 555, leader.id());
+        agent.onCommitPosition(leadershipTermId, 555, leader.id(), ConsensusModuleAgent.NULL_CONFIRMATION_COUNTER);
         assertEquals(200, agent.notifiedCommitPosition());
         assertEquals(lastUpdateNs, agent.timeOfLastLogUpdateNs());
 
         clock.increment(2);
         agent.role(Cluster.Role.LEADER);
-        agent.onCommitPosition(leadershipTermId, 999, leader.id());
+        agent.onCommitPosition(leadershipTermId, 999, leader.id(), ConsensusModuleAgent.NULL_CONFIRMATION_COUNTER);
         assertEquals(200, agent.notifiedCommitPosition());
         assertEquals(lastUpdateNs, agent.timeOfLastLogUpdateNs());
+    }
+
+    @Test
+    void followerEchoesAdvancedConfirmationCounterOncePerRound() throws Exception
+    {
+        final TestClusterClock clock = new TestClusterClock(TimeUnit.MILLISECONDS);
+        ctx.epochClock(clock.asEpochClock()).clusterClock(clock);
+
+        final ConsensusModuleAgent agent = new ConsensusModuleAgent(ctx);
+        agent.state(ConsensusModule.State.ACTIVE, "");
+        agent.role(Cluster.Role.FOLLOWER);
+        final long leadershipTermId = 42;
+        agent.leadershipTermId(leadershipTermId);
+        final ClusterMember leader = new ClusterMember(1, "", "", "", "", "", "");
+        Tests.setField(agent, "leaderMember", leader);
+        Tests.setField(agent, "appendPosition", mock(ReadableCounter.class));
+
+        final ConsensusPublisher mockPublisher = mock(ConsensusPublisher.class);
+        when(mockPublisher.leadershipConfirmAck(any(), anyLong(), anyInt(), anyInt())).thenReturn(TRUE);
+        Tests.setField(agent, "consensusPublisher", mockPublisher);
+
+        final java.lang.reflect.Method sendFollowerPosition =
+            ConsensusModuleAgent.class.getDeclaredMethod("updateFollowerPosition", long.class);
+        sendFollowerPosition.setAccessible(true);
+
+        // A commit-position carrying an advanced counter from the current leader is echoed once, tagged with the
+        // follower's own current term and member id.
+        agent.onCommitPosition(leadershipTermId, 100, leader.id(), 7);
+        sendFollowerPosition.invoke(agent, clock.timeNanos());
+        verify(mockPublisher).leadershipConfirmAck(any(), eq(leadershipTermId), eq(0), eq(7));
+
+        // The same counter arriving again (e.g. on plain commit traffic) must not be echoed again -> no amplification.
+        reset(mockPublisher);
+        when(mockPublisher.leadershipConfirmAck(any(), anyLong(), anyInt(), anyInt())).thenReturn(TRUE);
+        agent.onCommitPosition(leadershipTermId, 200, leader.id(), 7);
+        sendFollowerPosition.invoke(agent, clock.timeNanos());
+        verify(mockPublisher, never()).leadershipConfirmAck(any(), anyLong(), anyInt(), anyInt());
+
+        // A pre-v17 leader (null counter) is never echoed.
+        agent.onCommitPosition(leadershipTermId, 300, leader.id(), ConsensusModuleAgent.NULL_CONFIRMATION_COUNTER);
+        sendFollowerPosition.invoke(agent, clock.timeNanos());
+        verify(mockPublisher, never()).leadershipConfirmAck(any(), anyLong(), anyInt(), anyInt());
+    }
+
+    @Test
+    void leaderConfirmsLeadershipOnlyWhenAQuorumEchoesBeyondTheToken()
+    {
+        final TestClusterClock clock = new TestClusterClock(TimeUnit.MILLISECONDS);
+        ctx.epochClock(clock.asEpochClock()).clusterClock(clock);
+
+        final ConsensusModuleAgent agent = new ConsensusModuleAgent(ctx);
+        agent.state(ConsensusModule.State.ACTIVE, "");
+        agent.role(Cluster.Role.LEADER);
+        final long leadershipTermId = 42;
+        agent.leadershipTermId(leadershipTermId);
+
+        final ClusterMember[] members = new ClusterMember[]
+        {
+            new ClusterMember(0, "", "", "", "", "", ""), // self (ctx.clusterMemberId == 0)
+            new ClusterMember(1, "", "", "", "", "", ""),
+            new ClusterMember(2, "", "", "", "", "", "")
+        };
+        final org.agrona.collections.Int2ObjectHashMap<ClusterMember> map =
+            new org.agrona.collections.Int2ObjectHashMap<>();
+        ClusterMember.addClusterMemberIds(members, map);
+        Tests.setField(agent, "activeMembers", members);
+        Tests.setField(agent, "clusterMemberByIdMap", map);
+
+        // Only self so far -> below quorum of 2.
+        assertFalse(agent.isLeadershipConfirmedSince(confirmationToken(leadershipTermId, 4)));
+
+        // Follower 1 echoes counter 5 in the current term -> self + follower 1 = quorum.
+        agent.onLeadershipConfirmAck(leadershipTermId, 1, 5);
+        assertTrue(agent.isLeadershipConfirmedSince(confirmationToken(leadershipTermId, 4)));
+        // ...but a token at or beyond what was echoed is not yet confirmed (in-flight/older acks cannot fake it).
+        assertFalse(agent.isLeadershipConfirmedSince(confirmationToken(leadershipTermId, 5)));
+
+        // An echo from a prior term must not be counted.
+        agent.onLeadershipConfirmAck(leadershipTermId - 1, 2, 1000);
+        assertFalse(agent.isLeadershipConfirmedSince(confirmationToken(leadershipTermId, 5)));
+
+        // Follower 2 echoes beyond the token in the current term -> confirmed again.
+        agent.onLeadershipConfirmAck(leadershipTermId, 2, 6);
+        assertTrue(agent.isLeadershipConfirmedSince(confirmationToken(leadershipTermId, 5)));
+    }
+
+    @Test
+    void confirmationIsUnavailableWhileAnElectionIsInProgress()
+    {
+        final TestClusterClock clock = new TestClusterClock(TimeUnit.MILLISECONDS);
+        ctx.epochClock(clock.asEpochClock()).clusterClock(clock);
+
+        final ConsensusModuleAgent agent = new ConsensusModuleAgent(ctx);
+        agent.state(ConsensusModule.State.ACTIVE, "");
+        agent.role(Cluster.Role.LEADER);
+        final long leadershipTermId = 42;
+        agent.leadershipTermId(leadershipTermId);
+
+        final ClusterMember[] members = new ClusterMember[]
+        {
+            new ClusterMember(0, "", "", "", "", "", ""),
+            new ClusterMember(1, "", "", "", "", "", "")
+        };
+        final org.agrona.collections.Int2ObjectHashMap<ClusterMember> map =
+            new org.agrona.collections.Int2ObjectHashMap<>();
+        ClusterMember.addClusterMemberIds(members, map);
+        Tests.setField(agent, "activeMembers", members);
+        Tests.setField(agent, "clusterMemberByIdMap", map);
+
+        final ConsensusPublisher mockPublisher = mock(ConsensusPublisher.class);
+        Tests.setField(agent, "consensusPublisher", mockPublisher);
+        // A stale counter from a prior leadership that must not leak into the new term.
+        Tests.setField(agent, "confirmationCounter", 500);
+
+        // During an election: no token is handed out, and the stale counter is replaced by the absent sentinel
+        // on the wire so a follower cannot echo it and confirm before a post-election round.
+        Tests.setField(agent, "election", mock(Election.class));
+        assertEquals(Aeron.NULL_VALUE, agent.triggerQuorumConfirmation());
+        agent.publishCommitPosition(1000L, leadershipTermId);
+        verify(mockPublisher).commitPosition(
+            any(), eq(leadershipTermId), eq(1000L), eq(0), eq(ConsensusModuleAgent.NULL_CONFIRMATION_COUNTER));
+
+        // Once the election completes, the real counter is both handed out and broadcast.
+        reset(mockPublisher);
+        Tests.setField(agent, "election", null);
+        // The token packs the term with the counter; the wire counter is still the raw int (unaffected).
+        assertEquals(confirmationToken(leadershipTermId, 500), agent.triggerQuorumConfirmation());
+        agent.publishCommitPosition(1000L, leadershipTermId);
+        verify(mockPublisher).commitPosition(any(), eq(leadershipTermId), eq(1000L), eq(0), eq(500));
+    }
+
+    @Test
+    void isLeadershipConfirmedSinceRejectsReservedSentinelTokens()
+    {
+        final TestClusterClock clock = new TestClusterClock(TimeUnit.MILLISECONDS);
+        ctx.epochClock(clock.asEpochClock()).clusterClock(clock);
+
+        final ConsensusModuleAgent agent = new ConsensusModuleAgent(ctx);
+        agent.state(ConsensusModule.State.ACTIVE, "");
+        agent.role(Cluster.Role.LEADER);
+        final long leadershipTermId = 42;
+        agent.leadershipTermId(leadershipTermId);
+
+        final ClusterMember[] members = new ClusterMember[]
+        {
+            new ClusterMember(0, "", "", "", "", "", ""),
+            new ClusterMember(1, "", "", "", "", "", "")
+        };
+        final org.agrona.collections.Int2ObjectHashMap<ClusterMember> map =
+            new org.agrona.collections.Int2ObjectHashMap<>();
+        ClusterMember.addClusterMemberIds(members, map);
+        Tests.setField(agent, "activeMembers", members);
+        Tests.setField(agent, "clusterMemberByIdMap", map);
+
+        // A follower has echoed a high counter, so a real token confirms...
+        agent.onLeadershipConfirmAck(leadershipTermId, 1, 1000);
+        assertTrue(agent.isLeadershipConfirmedSince(confirmationToken(leadershipTermId, 5)));
+
+        // ...but the reserved sentinels must never confirm, even though every echo compares "beyond" them.
+        assertFalse(agent.isLeadershipConfirmedSince(Aeron.NULL_VALUE));
+        assertFalse(agent.isLeadershipConfirmedSince(ConsensusModuleAgent.NULL_CONFIRMATION_COUNTER));
+    }
+
+    @Test
+    void tokenFromAnEarlierTermDoesNotConfirmAfterReElection()
+    {
+        final TestClusterClock clock = new TestClusterClock(TimeUnit.MILLISECONDS);
+        ctx.epochClock(clock.asEpochClock()).clusterClock(clock);
+
+        final ConsensusModuleAgent agent = new ConsensusModuleAgent(ctx);
+        agent.state(ConsensusModule.State.ACTIVE, "");
+        agent.role(Cluster.Role.LEADER);
+        final long termA = 42;
+        agent.leadershipTermId(termA);
+
+        final ClusterMember[] members = new ClusterMember[]
+        {
+            new ClusterMember(0, "", "", "", "", "", ""),
+            new ClusterMember(1, "", "", "", "", "", "")
+        };
+        final org.agrona.collections.Int2ObjectHashMap<ClusterMember> map =
+            new org.agrona.collections.Int2ObjectHashMap<>();
+        ClusterMember.addClusterMemberIds(members, map);
+        Tests.setField(agent, "activeMembers", members);
+        Tests.setField(agent, "clusterMemberByIdMap", map);
+
+        // Capture a token in term A; a quorum confirms it in term A. (confirmationCounter is 0 after
+        // electionComplete; set it here since this test does not run a full election.)
+        Tests.setField(agent, "confirmationCounter", 0);
+        final long tokenTermA = agent.triggerQuorumConfirmation();
+        agent.onLeadershipConfirmAck(termA, 1, 1000);
+        assertTrue(agent.isLeadershipConfirmedSince(tokenTermA));
+
+        // This node is deposed and re-elected (a later term); a quorum confirms in the new term.
+        final long termB = termA + 2;
+        agent.leadershipTermId(termB);
+        agent.onLeadershipConfirmAck(termB, 1, 1000);
+
+        // The stale term-A token must NOT confirm in term B, even though a quorum has echoed in term B.
+        assertFalse(agent.isLeadershipConfirmedSince(tokenTermA));
+        // A fresh term-B token does confirm.
+        assertTrue(agent.isLeadershipConfirmedSince(confirmationToken(termB, 0)));
+    }
+
+    @Test
+    void confirmationTokenUsesUnsignedTermBits()
+    {
+        final TestClusterClock clock = new TestClusterClock(TimeUnit.MILLISECONDS);
+        ctx.epochClock(clock.asEpochClock()).clusterClock(clock);
+
+        final ConsensusModuleAgent agent = new ConsensusModuleAgent(ctx);
+        agent.state(ConsensusModule.State.ACTIVE, "");
+        agent.role(Cluster.Role.LEADER);
+        // A term whose low 32 bits have the sign bit set: extraction must be unsigned (>>> not >>).
+        final long leadershipTermId = 0x1_8000_0000L;
+        agent.leadershipTermId(leadershipTermId);
+
+        final ClusterMember[] members = new ClusterMember[]
+        {
+            new ClusterMember(0, "", "", "", "", "", ""),
+            new ClusterMember(1, "", "", "", "", "", "")
+        };
+        final org.agrona.collections.Int2ObjectHashMap<ClusterMember> map =
+            new org.agrona.collections.Int2ObjectHashMap<>();
+        ClusterMember.addClusterMemberIds(members, map);
+        Tests.setField(agent, "activeMembers", members);
+        Tests.setField(agent, "clusterMemberByIdMap", map);
+
+        final long token = confirmationToken(leadershipTermId, 5);
+        agent.onLeadershipConfirmAck(leadershipTermId, 1, 6);
+        assertTrue(agent.isLeadershipConfirmedSince(token));
     }
 
     @Test


### PR DESCRIPTION
Given a timestamp, isLeadershipConfirmedSince returns true if a quorum of cluster members has actively ACK'd and confirmed that the leader is still the leader sometime _after_ the timestamp.

This allows users to confirm a given quorum read is linearizably "fresh" (issue the read, then check that isLeadershipConfirmedSince == true); otherwise, a user would have to issue a read and then perform an expensive no-op write operation as a barrier to ensure linearizable freshness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes consensus wire format and leader/follower commit-path behaviour; incorrect quorum or token handling could allow stale linearizable reads or break mixed-version clusters until all nodes upgrade.
> 
> **Overview**
> Adds **ReadIndex-style leadership confirmation** so a leader can verify a quorum still recognises it **after** a read point, without a log barrier write. Extensions call **`triggerQuorumConfirmation()`** for a term-scoped token, then poll **`isLeadershipConfirmedSince(token)`** from consensus work.
> 
> The wire protocol bumps cluster codecs to **v17**: **`CommitPosition`** carries a monotonic **`confirmationCounter`** (advanced only on explicit confirmation rounds, not every commit broadcast), and followers reply with a new **`LeadershipConfirmAck`**. Quorum logic counts members who echoed a counter **strictly beyond** the token in the **current leadership term** (wrap-safe), so stale in-flight acks and prior-term echoes cannot confirm.
> 
> **`ConsensusModuleAgent`** coalesces confirmation rounds per duty cycle, sends an absent sentinel during elections, and resets confirmation state on **`electionComplete`**. **`ClusterMember.hasQuorumConfirmedSince`** implements the quorum check with per-member echo tracking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3963362e92fe1c20f95f5cbc3432d26fd6245005. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->