### PR TITLE
[C++] Avoid allocation for common vectored offers

### DIFF
--- a/aeron-client/src/main/cpp_wrapper/ExclusivePublication.h
+++ b/aeron-client/src/main/cpp_wrapper/ExclusivePublication.h
@@ -444,7 +444,10 @@ public:
         BufferIterator lastBuffer,
         const on_reserved_value_supplier_t &reservedValueSupplier = DEFAULT_RESERVED_VALUE_SUPPLIER)
     {
-        std::vector<aeron_iovec_t> iov;
+        static constexpr std::size_t IOVEC_STACK_CAPACITY = 16;
+        std::array<aeron_iovec_t, IOVEC_STACK_CAPACITY> stackIov;
+        std::vector<aeron_iovec_t> overflowIov;
+        std::size_t iovCount = 0;
         std::size_t length = 0;
         for (BufferIterator it = startBuffer; it != lastBuffer; ++it)
         {
@@ -459,11 +462,27 @@ public:
             aeron_iovec_t buf;
             buf.iov_base = it->buffer();
             buf.iov_len = it->capacity();
-            iov.push_back(buf);
+
+            if (iovCount < IOVEC_STACK_CAPACITY)
+            {
+                stackIov[iovCount] = buf;
+            }
+            else
+            {
+                if (overflowIov.empty())
+                {
+                    overflowIov.reserve(IOVEC_STACK_CAPACITY * 2);
+                    overflowIov.insert(overflowIov.end(), stackIov.begin(), stackIov.end());
+                }
+                overflowIov.push_back(buf);
+            }
+            iovCount++;
         }
 
+        aeron_iovec_t *iov = 0 == iovCount ?
+            nullptr : (iovCount <= IOVEC_STACK_CAPACITY ? stackIov.data() : overflowIov.data());
         const std::int64_t position = aeron_exclusive_publication_offerv(
-            m_publication, iov.data(), iov.size(), reservedValueSupplierCallback, (void *)&reservedValueSupplier);
+            m_publication, iov, iovCount, reservedValueSupplierCallback, (void *)&reservedValueSupplier);
 
         if (AERON_PUBLICATION_ERROR == position)
         {

--- a/aeron-client/src/main/cpp_wrapper/Publication.h
+++ b/aeron-client/src/main/cpp_wrapper/Publication.h
@@ -436,7 +436,10 @@ public:
         BufferIterator lastBuffer,
         const on_reserved_value_supplier_t &reservedValueSupplier = DEFAULT_RESERVED_VALUE_SUPPLIER)
     {
-        std::vector<aeron_iovec_t> iov;
+        static constexpr std::size_t IOVEC_STACK_CAPACITY = 16;
+        std::array<aeron_iovec_t, IOVEC_STACK_CAPACITY> stackIov;
+        std::vector<aeron_iovec_t> overflowIov;
+        std::size_t iovCount = 0;
         std::size_t length = 0;
         for (BufferIterator it = startBuffer; it != lastBuffer; ++it)
         {
@@ -451,11 +454,27 @@ public:
             aeron_iovec_t buf;
             buf.iov_base = it->buffer();
             buf.iov_len = it->capacity();
-            iov.push_back(buf);
+
+            if (iovCount < IOVEC_STACK_CAPACITY)
+            {
+                stackIov[iovCount] = buf;
+            }
+            else
+            {
+                if (overflowIov.empty())
+                {
+                    overflowIov.reserve(IOVEC_STACK_CAPACITY * 2);
+                    overflowIov.insert(overflowIov.end(), stackIov.begin(), stackIov.end());
+                }
+                overflowIov.push_back(buf);
+            }
+            iovCount++;
         }
 
+        aeron_iovec_t *iov = 0 == iovCount ?
+            nullptr : (iovCount <= IOVEC_STACK_CAPACITY ? stackIov.data() : overflowIov.data());
         const std::int64_t position = aeron_publication_offerv(
-            m_publication, iov.data(), iov.size(), reservedValueSupplierCallback, (void *)&reservedValueSupplier);
+            m_publication, iov, iovCount, reservedValueSupplierCallback, (void *)&reservedValueSupplier);
 
         if (AERON_PUBLICATION_ERROR == position)
         {

--- a/aeron-client/src/test/cpp_wrapper/PubSubTest.cpp
+++ b/aeron-client/src/test/cpp_wrapper/PubSubTest.cpp
@@ -250,6 +250,30 @@ TEST_P(PubSubTest, shouldSubscribeExclusivePublish)
                 EXPECT_EQ(initialTermId, header.initialTermId());
             },
             1), invoker);
+
+        std::array<std::uint8_t, 16> partBytes;
+        for (std::size_t i = 0; i < partBytes.size(); i++)
+        {
+            partBytes[i] = static_cast<std::uint8_t>(i);
+        }
+        AtomicBuffer partBuffer(partBytes);
+        std::vector<AtomicBuffer> buffers(17, partBuffer);
+
+        for (std::size_t vectorLength : { std::size_t(16), std::size_t(17) })
+        {
+            POLL_FOR(0 < pub->offer(buffers.begin(), buffers.begin() + vectorLength), invoker);
+            POLL_FOR(0 < sub->poll(
+                [&](concurrent::AtomicBuffer &buffer, util::index_t offset, util::index_t length, Header &)
+                {
+                    EXPECT_EQ(vectorLength * partBytes.size(), static_cast<std::size_t>(length));
+                    for (util::index_t i = 0; i < length; i++)
+                    {
+                        EXPECT_EQ(partBytes[static_cast<std::size_t>(i) % partBytes.size()],
+                            buffer.getUInt8(offset + i));
+                    }
+                },
+                1), invoker);
+        }
     }
 
     invoker.invoke();
@@ -282,6 +306,11 @@ TEST_P(PubSubTest, shouldBlockPollSubscription)
         buffer.putString(0, message);
         AtomicBuffer buffers[]{buffer, buffer, buffer};
         POLL_FOR(0 < pub->offer(buffers, 3), invoker);
+
+        std::array<std::uint8_t, 16> partBytes = {};
+        AtomicBuffer partBuffer(partBytes);
+        std::vector<AtomicBuffer> overflowBuffers(17, partBuffer);
+        POLL_FOR(0 < pub->offer(overflowBuffers.begin(), overflowBuffers.end()), invoker);
 
         std::int64_t bytesReceived = 0;
         std::int64_t bytesConsumed = 0;


### PR DESCRIPTION
# [C++] Avoid allocation for common vectored offers

## Summary

The iterator-based vectored `offer` overloads in `Publication` and `ExclusivePublication` currently build a fresh std::vector<aeron_iovec_t>` by repeated `push_back` on every call. This change stores up to 16 iovecs in a bounded stack array and creates a vector only when the input contains more than 16 buffers. The public API, native C API, message bytes, result codes, and publication state transitions are unchanged.

## Motivation

Vectored offer is a steady-state publication API. With libstdc++ on the tested configuration, the existing implementation performs:

| Input buffers | Baseline allocations/offer attempt | Candidate |
|---:|---:|---:|
| 1 | 1 | 0 |
| 2 | 2 | 0 |
| 16 | 5 | 0 |
| 17 | 6 | 1 |

The counts were measured around the `offer` call itself in a real embedded Media Driver IPC workload. Each row covers at least 550,000 offer attempts and had zero payload-validation errors.

## Root cause

The templated overload has no buffer count in advance, so an initially empty `std::vector` grows geometrically while the input iterator is consumed. Neither the C++ wrapper nor the native `aeron_*_publication_offerv` call needs owning storage after the synchronous call returns. The prediction was that bounded non-owning stack storage would remove every allocation for common small vector counts, while a lazy vector would preserve arbitrary input sizes with fewer allocations. The allocation matrix confirmed that prediction exactly.

## Native call path

```text
Publication::offer(first, last)
  -> build transient aeron_iovec_t sequence
  -> aeron_publication_offerv
  -> native publication offer path

ExclusivePublication::offer(first, last)
  -> build transient aeron_iovec_t sequence
  -> aeron_exclusive_publication_offerv
  -> native exclusive publication offer path
```

Only construction of the transient C-compatible iovec sequence changes.

## Changes

- Use `std::array<aeron_iovec_t, 16>` for the common path in both wrappers.
- Lazily reserve and populate an overflow vector only after the 17th input buffer is observed.
- Preserve generic single-pass iterator support and arbitrary vector counts.
- Extend `PubSubTest` at the 16/17 boundary for both publication types.
- Validate exact concatenated bytes for the exclusive path across UDP unicast, UDP multicast, and IPC.

The capacity of 16 matches the bounded initial-vector convention already used by the C++ wrapper's `Subscription::localSocketAddresses`.

## Correctness invariants

- Iterators are dereferenced once, in their original order.
- Every `iov_base` and `iov_len` value is unchanged.
- The native offerv function is still called synchronously once per wrapper invocation.
- The reserved-value supplier callback and client data pointer are unchanged.
- Native position, fragmentation, term rotation, backpressure, administrative-action, closed-publication, and maximum-position behavior are unchanged.
- Empty ranges still reach the native function with count zero.
- No shared, atomic, publication, conductor, or driver state changes.
- Stack and overflow storage remain alive until the native call returns.
- Allocation failure remains exception-safe; the native publication has not been invoked while the transient sequence is being built.

## Correctness validation

The focused final-commit tests passed 6/6 in each configuration:

- GCC 14 Debug.
- Clang 19 Release.
- GCC ASan + UBSan + LSan.
- Clang TSan.

Each configuration covered both changed overloads and all three configured channels. The exact final full native Debug build also completed. The parallel suite passed 92/105; all 13 failures were rerun serially, where 11 passed. The two remaining file-util executables each passed all 15 tests from WSL-native `/tmp`; their `/mnt/c` runs failed because the Windows-backed mount does no support the requested non-sparse `fallocate` behavior. All 105 test executables are therefore adjudicated.

## Performance methodology

- Baseline: upstream `14d4080aab9a690f49cdc5e9a87f4edd9fd4b890`.
- Candidate: `0b4789d6cc314385b044b16b8d6e63c07a23efe0`.
- GCC 14.2, libstdc++, `-std=c++11 -O3 -DNDEBUG -fno-omit-frame-pointer -pthread`.
- Normal bounds checks; no `-march=native`, LTO, or unsafe flags.
- Separate timing binaries use the ordinary libstdc++ allocator.
- Separate allocation binaries compile an `operator new` counter behind `AERON_BENCHMARK_TRACK_ALLOCATIONS`.
- Embedded native C Media Driver, shared mode, busy-spin idle.
- Exclusive C++ publisher on CPU 2, subscriber on CPU 3, driver on CPU 4.
- `aeron:ipc`, deterministic sequence and payload validation.
- 100,000 warm-up messages, 500,000 coordinated closed-loop latency samples,
  and 5,000,000 messages for throughput per process.
- Interleaved baseline/candidate/candidate/baseline blocks.
- Deterministic 50,000-resample bootstrap of paired-block median improvements and a two-sided sign test.
- Resource gates immediately before every measurement showed no competing WSL build, profiler, or benchmark; Windows host samples were approximately 2–4 CPU-seconds out of 200 available over ten seconds.

The latency is coordinated offer-to-subscriber-ack latency under WSL2, not one-way or open-loop bare-metal latency.

## Performance results

Positive percentages mean the candidate is better.

### Two buffers, 32-byte message

100 paired blocks, 200 observations per implementation, 400 accepted executions, zero validation errors:

| Metric | Baseline median | Candidate median | Paired median improvement | Bootstrap 95% CI |
|---|---:|---:|---:|---:|
| P50 | 173 ns | 161 ns | 7.61% | 7.17% to 8.10% |
| P90 | 211 ns | 198 ns | 6.62% | 6.05% to 7.03% |
| P99 | 250.5 ns | 235 ns | 5.66% | 5.38% to 6.39% |
| P99.9 | 513.5 ns | 431.5 ns | 13.84% | 5.96% to 23.17% |
| P99.99 | 23,256 ns | 21,157.5 ns | 7.27% | 2.66% to 10.11% |
| Maximum | 151,511.5 ns | 146,601.5 ns | 3.10% | -3.13% to 7.17% |
| Throughput | 23.475 Mmsg/s | 31.296 Mmsg/s | 48.64% | 44.61% to 52.65% |

Throughput and P50/P90 each won all 100 paired blocks. P99 won 98/100. Maximum latency is statistically neutral.

### Seventeen buffers, 272-byte message

This case crosses the heap-fallback boundary. It uses 50 paired blocks, 100 observations per implementation, 200 accepted executions, and zero validation errors:

| Metric | Baseline median | Candidate median | Paired median improvement | Bootstrap 95% CI |
|---|---:|---:|---:|---:|
| P50 | 416 ns | 370.5 ns | 10.50% | 8.96% to 11.82% |
| P90 | 513 ns | 467 ns | 8.45% | 7.40% to 9.50% |
| P99 | 597 ns | 549 ns | 8.53% | 7.58% to 9.96% |
| P99.9 | 4,519 ns | 3,337 ns | 19.87% | 8.95% to 30.66% |
| P99.99 | 38,328 ns | 37,770 ns | 2.94% | -3.65% to 7.09% |
| Maximum | 187,887 ns | 186,161 ns | 3.11% | -18.87% to 18.42% |
| Throughput | 6.409 Mmsg/s | 6.498 Mmsg/s | 2.05% | -0.42% to 2.77% |

P99.99, maximum, and throughput are statistically neutral; no measured metric has a statistically supported regression.

## Regressions and trade-offs

- The stack-use report for the instantiated exclusive iterator overload grows from 208 to 480 bytes (+272 bytes).
- The external timing executable grows by 887 bytes of `.text` (89,262 to 90,149 bytes). Header-only application code size depends on instantiation.
- Offers with more than 16 buffers still allocate. The 17-buffer case performs one allocation instead of six.
- The faster producer makes more unsuccessful backpressure attempts while the consumer is saturated. This does not bypass or change backpressure; delivered throughput increases for two buffers and is neutral for 17.
- Peak RSS and hardware performance counters were not measured.

## Compatibility

- C++ source signatures and required language version are unchanged.
- No C ABI, C symbol, structure layout, or native implementation changes.
- No wire, shared-memory, frame, ordering, position, or fragmentation changes.
- No configuration or idle-strategy change.
- Portable C++11 only; no architecture intrinsic, alignment assumption, cache-line constant, or `-march=native`.

## Testing

```bash
cmake --build cppbuild/TestDebug --parallel 10

cppbuild/TestDebug/binaries/pubSubTest \
  '--gtest_filter=*shouldSubscribeExclusivePublish*:*shouldBlockPollSubscription*'

ctest --test-dir cppbuild/TestDebug --output-on-failure \
  --parallel 10 --timeout 120
ctest --test-dir cppbuild/TestDebug --rerun-failed \
  --output-on-failure --parallel 1 --timeout 180
```

Equivalent focused runs passed in `cppbuild/ClangRelease`,
`cppbuild/Sanitize`, and `cppbuild/ThreadSanitize`.

## Limitations

- Timing was performed under Debian 13 on WSL2, not a dedicated Linux system.
- WSL did not expose usable cycles, instructions, branch, or cache events.
- Only x86-64 was executed.
- UDP correctness was tested; UDP performance and cross-language interop were
  not benchmarked because no protocol-facing code changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Wrapper-only performance optimization with identical API and native semantics; risk is limited to stack/overflow iovec assembly correctness, mitigated by new boundary tests.
> 
> **Overview**
> The iterator-based vectored `offer` overloads in **`Publication`** and **`ExclusivePublication`** no longer build a fresh `std::vector<aeron_iovec_t>` on every call. They fill up to **16** `aeron_iovec_t` entries in a stack `std::array` and only lazily allocate a heap vector when more than 16 input buffers are present (copying the stack slice into the vector on first overflow). The native `aeron_*_publication_offerv` call is unchanged aside from passing a raw pointer and count instead of `vector::data()` / `size()`.
> 
> **`PubSubTest`** gains coverage at the 16/17 buffer boundary: exclusive publish validates concatenated payload bytes for both lengths, and block-poll adds a 17-buffer vectored offer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1690cb2b5368f0dcae16ff3ab0a2419fc66abda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->