### PR TITLE
Use Async Archive Connect for Standby Snapshot Replicator

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -3564,7 +3564,7 @@ final class ConsensusModuleAgent
                 {
                     idleStrategy.idle(standbySnapshotReplicator.poll(ctx.clusterClock().timeNanos()));
                 }
-                catch (final ClusterException ex)
+                catch (final AeronException ex)
                 {
                     ctx.countedErrorHandler().onError(ex);
                     break;
@@ -3597,7 +3597,7 @@ final class ConsensusModuleAgent
                     standbySnapshotReplicator = null;
                 }
             }
-            catch (final ClusterException ex)
+            catch (final AeronException ex)
             {
                 ctx.countedErrorHandler().onError(ex);
                 CloseHelper.quietClose(standbySnapshotReplicator);

--- a/aeron-cluster/src/main/java/io/aeron/cluster/StandbySnapshotReplicator.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/StandbySnapshotReplicator.java
@@ -35,7 +35,9 @@ import static io.aeron.archive.status.RecordingPos.NULL_RECORDING_ID;
 class StandbySnapshotReplicator implements AutoCloseable
 {
     private final int memberId;
-    private final AeronArchive archive;
+    private final AeronArchive.Context archiveCtx;
+    private AeronArchive.AsyncConnect asyncConnect;
+    private AeronArchive archive;
     private final RecordingLog recordingLog;
     private final int serviceCount;
     private final String archiveControlChannel;
@@ -51,7 +53,7 @@ class StandbySnapshotReplicator implements AutoCloseable
 
     StandbySnapshotReplicator(
         final int memberId,
-        final AeronArchive archive,
+        final AeronArchive.Context archiveCtx,
         final RecordingLog recordingLog,
         final int serviceCount,
         final String archiveControlChannel,
@@ -61,7 +63,7 @@ class StandbySnapshotReplicator implements AutoCloseable
         final Counter snapshotCounter)
     {
         this.memberId = memberId;
-        this.archive = archive;
+        this.archiveCtx = archiveCtx;
         this.recordingLog = recordingLog;
         this.serviceCount = serviceCount;
         this.archiveControlChannel = archiveControlChannel;
@@ -81,10 +83,10 @@ class StandbySnapshotReplicator implements AutoCloseable
         final String replicationChannel,
         final int fileSyncLevel, final Counter snapshotCounter)
     {
-        final AeronArchive archive = AeronArchive.connect(archiveCtx.clone().errorHandler(null));
+        final AeronArchive.Context localArchiveCtx = archiveCtx.clone().errorHandler(null);
         final StandbySnapshotReplicator standbySnapshotReplicator = new StandbySnapshotReplicator(
             memberId,
-            archive,
+            localArchiveCtx,
             recordingLog,
             serviceCount,
             archiveControlChannel,
@@ -92,13 +94,42 @@ class StandbySnapshotReplicator implements AutoCloseable
             replicationChannel,
             fileSyncLevel,
             snapshotCounter);
-        archive.context().recordingSignalConsumer(standbySnapshotReplicator::onSignal);
+        localArchiveCtx.recordingSignalConsumer(standbySnapshotReplicator::onSignal);
         return standbySnapshotReplicator;
     }
 
+    @SuppressWarnings("methodLength")
     int poll(final long nowNs)
     {
         int workCount = 0;
+
+        if (null == archive)
+        {
+            if (null == asyncConnect)
+            {
+                asyncConnect = AeronArchive.asyncConnect(archiveCtx);
+                workCount += 1;
+            }
+
+            final int step = asyncConnect.step();
+            final AeronArchive aeronArchive = asyncConnect.poll();
+
+            if (null == aeronArchive)
+            {
+                if (asyncConnect.step() != step)
+                {
+                    workCount += 1;
+                }
+            }
+            else
+            {
+                archive = aeronArchive;
+                asyncConnect = null;
+                workCount += 1;
+            }
+
+            return workCount;
+        }
 
         if (null == recordingReplication)
         {
@@ -244,7 +275,7 @@ class StandbySnapshotReplicator implements AutoCloseable
 
     public void close()
     {
-        CloseHelper.quietClose(archive);
+        CloseHelper.quietCloseAll(archive, asyncConnect);
     }
 
     private static final class SnapshotReplicationEntry

--- a/aeron-cluster/src/test/java/io/aeron/cluster/StandbySnapshotReplicatorTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/StandbySnapshotReplicatorTest.java
@@ -61,7 +61,9 @@ class StandbySnapshotReplicatorTest
     private final AeronArchive.Context ctx = new AeronArchive.Context();
     private final int memberId = 12;
     private final int fileSyncLevel = 1;
+    private final int pollsForActiveArchive = 3;
 
+    private final AeronArchive.AsyncConnect mockConnect = mock(AeronArchive.AsyncConnect.class);
     private final AeronArchive mockArchive = mock(AeronArchive.class);
     private final MultipleRecordingReplication mockMultipleRecordingReplication0 = mock(
         MultipleRecordingReplication.class, "host0");
@@ -73,6 +75,7 @@ class StandbySnapshotReplicatorTest
     void setUp()
     {
         when(mockArchive.context()).thenReturn(ctx);
+        when(mockConnect.poll()).thenReturn(null, null, mockArchive);
     }
 
     @TempDir
@@ -114,7 +117,7 @@ class StandbySnapshotReplicatorTest
                     .when(() -> MultipleRecordingReplication.newInstance(
                         any(), anyInt(), any(), any(), anyLong(), anyLong()))
                     .thenReturn(mockMultipleRecordingReplication0);
-                staticMockArchive.when(() -> AeronArchive.connect(any())).thenReturn(mockArchive);
+                staticMockArchive.when(() -> AeronArchive.asyncConnect(any())).thenReturn(mockConnect);
 
                 final StandbySnapshotReplicator standbySnapshotReplicator = StandbySnapshotReplicator.newInstance(
                     memberId,
@@ -129,6 +132,7 @@ class StandbySnapshotReplicatorTest
 
                 when(mockMultipleRecordingReplication0.isComplete()).thenReturn(true);
 
+                fastForwardSnapshotReplicatorToHaveArchiveClient(standbySnapshotReplicator, nowNs);
                 assertNotEquals(0, standbySnapshotReplicator.poll(nowNs));
                 assertTrue(standbySnapshotReplicator.isComplete());
 
@@ -179,7 +183,7 @@ class StandbySnapshotReplicatorTest
                 .when(() -> MultipleRecordingReplication.newInstance(
                     any(), anyInt(), any(), any(), anyLong(), anyLong()))
                 .thenReturn(mockMultipleRecordingReplication0);
-            staticMockArchive.when(() -> AeronArchive.connect(any())).thenReturn(mockArchive);
+            staticMockArchive.when(() -> AeronArchive.asyncConnect(any())).thenReturn(mockConnect);
 
             final StandbySnapshotReplicator standbySnapshotReplicator = StandbySnapshotReplicator.newInstance(
                 memberId,
@@ -192,6 +196,7 @@ class StandbySnapshotReplicatorTest
                 fileSyncLevel,
                 snapshotCounter);
 
+            fastForwardSnapshotReplicatorToHaveArchiveClient(standbySnapshotReplicator, 0);
             standbySnapshotReplicator.poll(0);
             verify(mockArchive).pollForRecordingSignals();
             standbySnapshotReplicator.onSignal(2, 11, 23, 29, 37, RecordingSignal.START);
@@ -213,7 +218,7 @@ class StandbySnapshotReplicatorTest
                 .when(() -> MultipleRecordingReplication.newInstance(
                     any(), anyInt(), any(), any(), anyLong(), anyLong()))
                 .thenReturn(mockMultipleRecordingReplication0);
-            staticMockArchive.when(() -> AeronArchive.connect(any())).thenReturn(mockArchive);
+            staticMockArchive.when(() -> AeronArchive.asyncConnect(any())).thenReturn(mockConnect);
 
             final StandbySnapshotReplicator standbySnapshotReplicator = StandbySnapshotReplicator.newInstance(
                 memberId,
@@ -225,6 +230,7 @@ class StandbySnapshotReplicatorTest
                 replicationChannel,
                 fileSyncLevel, snapshotCounter);
 
+            fastForwardSnapshotReplicatorToHaveArchiveClient(standbySnapshotReplicator, 0);
             standbySnapshotReplicator.poll(0);
             assertTrue(standbySnapshotReplicator.isComplete());
             verifyNoInteractions(snapshotCounter);
@@ -267,7 +273,7 @@ class StandbySnapshotReplicatorTest
                     any(), anyInt(), contains("host1"), any(), anyLong(), anyLong()))
                 .thenReturn(mockMultipleRecordingReplication1);
 
-            staticMockArchive.when(() -> AeronArchive.connect(any())).thenReturn(mockArchive);
+            staticMockArchive.when(() -> AeronArchive.asyncConnect(any())).thenReturn(mockConnect);
 
             final StandbySnapshotReplicator standbySnapshotReplicator = StandbySnapshotReplicator.newInstance(
                 memberId,
@@ -283,6 +289,7 @@ class StandbySnapshotReplicatorTest
             when(mockMultipleRecordingReplication0.poll(anyLong())).thenThrow(new ClusterException("fail"));
             when(mockMultipleRecordingReplication1.isComplete()).thenReturn(true);
 
+            fastForwardSnapshotReplicatorToHaveArchiveClient(standbySnapshotReplicator, nowNs);
             standbySnapshotReplicator.poll(nowNs);
             standbySnapshotReplicator.poll(nowNs);
 
@@ -330,7 +337,7 @@ class StandbySnapshotReplicatorTest
                     any(), anyInt(), contains("host1"), any(), anyLong(), anyLong()))
                 .thenReturn(mockMultipleRecordingReplication1);
 
-            staticMockArchive.when(() -> AeronArchive.connect(any())).thenReturn(mockArchive);
+            staticMockArchive.when(() -> AeronArchive.asyncConnect(any())).thenReturn(mockConnect);
             when(mockArchive.pollForRecordingSignals()).thenThrow(new ArchiveException("fail")).thenReturn(1);
 
             final StandbySnapshotReplicator standbySnapshotReplicator = StandbySnapshotReplicator.newInstance(
@@ -346,6 +353,7 @@ class StandbySnapshotReplicatorTest
 
             when(mockMultipleRecordingReplication1.isComplete()).thenReturn(true);
 
+            fastForwardSnapshotReplicatorToHaveArchiveClient(standbySnapshotReplicator, nowNs);
             standbySnapshotReplicator.poll(nowNs);
             standbySnapshotReplicator.poll(nowNs);
 
@@ -393,7 +401,7 @@ class StandbySnapshotReplicatorTest
                     any(), anyInt(), contains("host1"), any(), anyLong(), anyLong()))
                 .thenReturn(mockMultipleRecordingReplication1);
 
-            staticMockArchive.when(() -> AeronArchive.connect(any())).thenReturn(mockArchive);
+            staticMockArchive.when(() -> AeronArchive.asyncConnect(any())).thenReturn(mockConnect);
 
             when(mockMultipleRecordingReplication0.poll(anyLong())).thenThrow(new ClusterException("fail"));
             when(mockMultipleRecordingReplication1.poll(anyLong())).thenThrow(new ClusterException("fail"));
@@ -409,6 +417,7 @@ class StandbySnapshotReplicatorTest
                 fileSyncLevel,
                 snapshotCounter);
 
+            fastForwardSnapshotReplicatorToHaveArchiveClient(standbySnapshotReplicator, nowNs);
             standbySnapshotReplicator.poll(nowNs);
             standbySnapshotReplicator.poll(nowNs);
             assertThrows(ClusterException.class, () -> standbySnapshotReplicator.poll(nowNs));
@@ -455,7 +464,7 @@ class StandbySnapshotReplicatorTest
                     any(), anyInt(), contains("host1"), any(), anyLong(), anyLong()))
                 .thenReturn(mockMultipleRecordingReplication1);
 
-            staticMockArchive.when(() -> AeronArchive.connect(any())).thenReturn(mockArchive);
+            staticMockArchive.when(() -> AeronArchive.asyncConnect(any())).thenReturn(mockConnect);
             when(mockArchive.pollForRecordingSignals()).thenThrow(new ArchiveException("fail"));
 
             final StandbySnapshotReplicator standbySnapshotReplicator = StandbySnapshotReplicator.newInstance(
@@ -469,6 +478,7 @@ class StandbySnapshotReplicatorTest
                 fileSyncLevel,
                 snapshotCounter);
 
+            fastForwardSnapshotReplicatorToHaveArchiveClient(standbySnapshotReplicator, nowNs);
             standbySnapshotReplicator.poll(nowNs);
             standbySnapshotReplicator.poll(nowNs);
             assertThrows(ClusterException.class, () -> standbySnapshotReplicator.poll(nowNs));
@@ -504,7 +514,7 @@ class StandbySnapshotReplicatorTest
                     any(), anyInt(), any(), any(), anyLong(), anyLong()))
                 .thenReturn(mockMultipleRecordingReplication0);
 
-            staticMockArchive.when(() -> AeronArchive.connect(any())).thenReturn(mockArchive);
+            staticMockArchive.when(() -> AeronArchive.asyncConnect(any())).thenReturn(mockConnect);
 
             final StandbySnapshotReplicator standbySnapshotReplicator = StandbySnapshotReplicator.newInstance(
                 memberId,
@@ -517,11 +527,21 @@ class StandbySnapshotReplicatorTest
                 fileSyncLevel,
                 snapshotCounter);
 
+            fastForwardSnapshotReplicatorToHaveArchiveClient(standbySnapshotReplicator, nowNs);
             standbySnapshotReplicator.poll(nowNs);
             standbySnapshotReplicator.poll(nowNs);
 
             verify(mockMultipleRecordingReplication0, never()).poll(anyLong());
             verifyNoInteractions(snapshotCounter);
+        }
+    }
+
+    private void fastForwardSnapshotReplicatorToHaveArchiveClient(
+            final StandbySnapshotReplicator standbySnapshotReplicator, final long nowNs)
+    {
+        for (int i = 0; i < pollsForActiveArchive; ++i)
+        {
+            standbySnapshotReplicator.poll(nowNs);
         }
     }
 }


### PR DESCRIPTION
This commit is to make the standby snapshot replicator use aeron archive async connect. This led to a decrease in max latency from 7ms to sub-millis in Ryan's performance test where we take/replicate a standby snapshot during a regular cluster echo test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cluster recovery/replication timing on the consensus agent path; behavior change is intentional for latency but async connect adds state that must be closed correctly on failure.
> 
> **Overview**
> **Standby snapshot replication** no longer blocks the consensus module on a synchronous `AeronArchive.connect()`. `StandbySnapshotReplicator` keeps an `AeronArchive.Context`, drives `AeronArchive.asyncConnect()` inside `poll()` until a client exists, then runs replication as before; `close()` tears down both the archive client and any in-flight async connect.
> 
> `ConsensusModuleAgent` now catches **`AeronException`** (instead of only `ClusterException`) around standby replication polling so archive/connect failures are reported and the replicator is cleared consistently.
> 
> Tests mock **`asyncConnect`** and use a small poll loop to advance past the connect phase before asserting replication behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c09cb7ef44be1a0b52204a90469a454475f68695. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->