### PR TITLE
Read-only cnc file access for Java tooling

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -23,6 +23,7 @@ executed. (https://github.com/aeron-io/aeron/issues/2092/[#2092])
 * **[Driver/C]** Receiver work count calculation aligned with Java side.
 * **[Java]** Upgrade to `JUnit` 6.1.2.
 * **[Java]** Upgrade to `Shadow` 9.6.0.
+* **[Client/Java]** Access cnc file with read only access for LogInspector and DriverTool
 
 == 1.52.2 (2026-07-10)
 

--- a/aeron-client/src/main/java/io/aeron/LogBuffers.java
+++ b/aeron-client/src/main/java/io/aeron/LogBuffers.java
@@ -35,6 +35,7 @@ import static io.aeron.logbuffer.LogBufferDescriptor.PARTITION_COUNT;
 import static io.aeron.logbuffer.LogBufferDescriptor.TERM_MAX_LENGTH;
 import static io.aeron.logbuffer.LogBufferDescriptor.checkPageSize;
 import static io.aeron.logbuffer.LogBufferDescriptor.checkTermLength;
+import static java.nio.channels.FileChannel.MapMode.READ_ONLY;
 import static java.nio.channels.FileChannel.MapMode.READ_WRITE;
 import static java.nio.file.StandardOpenOption.READ;
 import static java.nio.file.StandardOpenOption.SPARSE;
@@ -47,7 +48,8 @@ import static java.nio.file.StandardOpenOption.WRITE;
  */
 public final class LogBuffers implements AutoCloseable
 {
-    private static final EnumSet<StandardOpenOption> FILE_OPTIONS = EnumSet.of(READ, WRITE, SPARSE);
+    private static final EnumSet<StandardOpenOption> FILE_OPTIONS_R = EnumSet.of(READ);
+    private static final EnumSet<StandardOpenOption> FILE_OPTIONS_RW = EnumSet.of(READ, WRITE, SPARSE);
 
     private long lingerDeadlineNs = Long.MAX_VALUE;
     private int refCount;
@@ -64,6 +66,17 @@ public final class LogBuffers implements AutoCloseable
      */
     public LogBuffers(final String logFileName)
     {
+        this(logFileName, false);
+    }
+
+    /**
+     * Construct the log buffers for a given log file.
+     *
+     * @param logFileName to be mapped.
+     * @param readOnly flag to indicate if mapping should only be read-only.
+     */
+    public LogBuffers(final String logFileName, final boolean readOnly)
+    {
         int termLength = 0;
         FileChannel fileChannel = null;
         UnsafeBuffer logMetaDataBuffer = null;
@@ -71,7 +84,8 @@ public final class LogBuffers implements AutoCloseable
 
         try
         {
-            fileChannel = FileChannel.open(Paths.get(logFileName), FILE_OPTIONS);
+            final EnumSet<StandardOpenOption> fileOptions = readOnly ? FILE_OPTIONS_R : FILE_OPTIONS_RW;
+            fileChannel = FileChannel.open(Paths.get(logFileName), fileOptions);
             final long logLength = fileChannel.size();
             if (logLength < LOG_META_DATA_LENGTH)
             {
@@ -79,9 +93,10 @@ public final class LogBuffers implements AutoCloseable
                     "Log file length less than min length of " + LOG_META_DATA_LENGTH + ": length=" + logLength);
             }
 
+            final FileChannel.MapMode mapMode = readOnly ? READ_ONLY : READ_WRITE;
             if (logLength < Integer.MAX_VALUE)
             {
-                final MappedByteBuffer mappedBuffer = fileChannel.map(READ_WRITE, 0, logLength);
+                final MappedByteBuffer mappedBuffer = fileChannel.map(mapMode, 0, logLength);
                 mappedBuffer.order(ByteOrder.LITTLE_ENDIAN);
                 mappedByteBuffers = new MappedByteBuffer[]{ mappedBuffer };
 
@@ -112,7 +127,7 @@ public final class LogBuffers implements AutoCloseable
                 final long metaDataMappingLength = logLength - metaDataSectionOffset;
 
                 final MappedByteBuffer metaDataMappedBuffer = fileChannel.map(
-                    READ_WRITE, metaDataSectionOffset, metaDataMappingLength);
+                    mapMode, metaDataSectionOffset, metaDataMappingLength);
                 metaDataMappedBuffer.order(ByteOrder.LITTLE_ENDIAN);
 
                 mappedByteBuffers[LOG_META_DATA_SECTION_INDEX] = metaDataMappedBuffer;
@@ -138,7 +153,7 @@ public final class LogBuffers implements AutoCloseable
                 for (int i = 0; i < PARTITION_COUNT; i++)
                 {
                     final long position = assumedTermLength * (long)i;
-                    final MappedByteBuffer mappedBuffer = fileChannel.map(READ_WRITE, position, assumedTermLength);
+                    final MappedByteBuffer mappedBuffer = fileChannel.map(mapMode, position, assumedTermLength);
                     mappedBuffer.order(ByteOrder.LITTLE_ENDIAN);
                     mappedByteBuffers[i] = mappedBuffer;
                     termBuffers[i] = mappedBuffer;
@@ -209,7 +224,14 @@ public final class LogBuffers implements AutoCloseable
 
             for (int i = 0, length = atomicBuffer.capacity(); i < length; i += pageSize)
             {
-                atomicBuffer.compareAndSetInt(i, value, value);
+                if (buffer.isReadOnly())
+                {
+                    atomicBuffer.getIntVolatile(i);
+                }
+                else
+                {
+                    atomicBuffer.compareAndSetInt(i, value, value);
+                }
             }
         }
     }

--- a/aeron-samples/src/main/java/io/aeron/samples/DriverTool.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/DriverTool.java
@@ -61,7 +61,9 @@ public class DriverTool
         }
 
         final File cncFile = CommonContext.newDefaultCncFile();
-        final MappedByteBuffer cncByteBuffer = IoUtil.mapExistingFile(cncFile, "cnc");
+        final MappedByteBuffer cncByteBuffer = (printPidOnly || !terminateDriver) ?
+            SamplesUtil.mapExistingFileReadOnly(cncFile) :
+            IoUtil.mapExistingFile(cncFile, "cnc");
         final DirectBuffer cncMetaData = createMetaDataBuffer(cncByteBuffer);
         final int cncVersion = cncMetaData.getInt(cncVersionOffset(0));
 

--- a/aeron-samples/src/main/java/io/aeron/samples/LogInspector.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/LogInspector.java
@@ -131,7 +131,7 @@ public class LogInspector
         final boolean scanOverZeroes,
         final PrintStream out)
     {
-        try (LogBuffers logBuffers = new LogBuffers(logFileName))
+        try (LogBuffers logBuffers = new LogBuffers(logFileName, true))
         {
             out.println("======================================================================");
             out.println(new Date() + " Inspection dump for " + logFileName);


### PR DESCRIPTION
For tooling, in Java we mostly open files with read only permissions. However, LogInspector and DriverTool open/map files with read + write. We should only need read only permissions.

In both java and c, the driver tries to open cnc file with rw-rw-rw-. But most processes typically have a umask of 002 or 022, resulting in the driver creating cnc file with rw-rw-r— or rw-r—r—, respectively. With respect to tooling, in Java we open/map files with read only (except LogInspector and DriverTool). 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible API default; changes are limited to diagnostic tooling and mmap open modes, not driver or client messaging paths.
> 
> **Overview**
> Java observability tooling no longer needs write access to shared memory files, which fixes failures when the Aeron driver creates CNC/log files with group-only or owner-only write bits (typical umask).
> 
> **`LogBuffers`** gains an optional `readOnly` constructor flag: files open with read-only options and mmap in `READ_ONLY` mode. Page touching on read-only maps uses volatile reads instead of compare-and-set. Default construction remains read-write for existing clients.
> 
> **`LogInspector`** constructs `LogBuffers` with `readOnly=true`. **`DriverTool`** maps the CNC file read-only for normal inspection and pid-only modes; the `terminate` path still uses read-write mapping so it can signal the driver.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 182d2b6af7d7b1b59db2c299f6320cc2764d3681. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->