### PR TITLE
Prevent multicast subcription conflicts with differing multicast addresses and the same port

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -23,6 +23,7 @@ executed. (https://github.com/aeron-io/aeron/issues/2092/[#2092])
 * **[Driver/C]** Receiver work count calculation aligned with Java side.
 * **[Java]** Upgrade to `JUnit` 6.1.2.
 * **[Java]** Upgrade to `Shadow` 9.6.0.
+* **[Driver/C]** Use IP_MULTICAST_ALL or IPV6_MULTICAST_ALL socket options to avoid receiving data from other multicast addresses with the same port
 
 == 1.52.2 (2026-07-10)
 

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport.c
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport.c
@@ -187,6 +187,15 @@ int aeron_udp_channel_transport_init(
             memcpy(&addr, bind_addr, sizeof(addr));
             addr.sin6_addr = in6addr_any;
 
+#if defined(__linux__) && defined(IPV6_MULTICAST_ALL)
+            int ipv6_multicast_all_disabled = 0;
+            if (aeron_setsockopt(transport->recv_fd, IPPROTO_IPV6, IPV6_MULTICAST_ALL, &ipv6_multicast_all_disabled, sizeof(int)) < 0)
+            {
+                AERON_APPEND_ERR("failed to set IPPROTO_IPV6/IPV6_MULTICAST_ALL option to: %d", ipv6_multicast_all_disabled);
+                goto error;
+            }
+#endif
+
             if (aeron_bind(transport->recv_fd, (struct sockaddr *)&addr, bind_addr_len) < 0)
             {
                 AERON_APPEND_ERR("multicast IPv6 bind, affinity=%d", affinity);
@@ -231,6 +240,15 @@ int aeron_udp_channel_transport_init(
             struct sockaddr_in addr;
             memcpy(&addr, bind_addr, sizeof(addr));
             addr.sin_addr.s_addr = INADDR_ANY;
+
+#if defined(__linux__) && defined(IP_MULTICAST_ALL)
+            int ip_multicast_all_disabled = 0;
+            if (aeron_setsockopt(transport->recv_fd, IPPROTO_IP, IP_MULTICAST_ALL, &ip_multicast_all_disabled, sizeof(int)) < 0)
+            {
+                AERON_APPEND_ERR("failed to set IPPROTO_IP/IP_MULTICAST_ALL option to: %d", ip_multicast_all_disabled);
+                goto error;
+            }
+#endif
 
             if (aeron_bind(transport->recv_fd, (struct sockaddr *)&addr, bind_addr_len) < 0)
             {

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport.c
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport.c
@@ -191,8 +191,12 @@ int aeron_udp_channel_transport_init(
             int ipv6_multicast_all_disabled = 0;
             if (aeron_setsockopt(transport->recv_fd, IPPROTO_IPV6, IPV6_MULTICAST_ALL, &ipv6_multicast_all_disabled, sizeof(int)) < 0)
             {
-                AERON_APPEND_ERR("failed to set IPPROTO_IPV6/IPV6_MULTICAST_ALL option to: %d", ipv6_multicast_all_disabled);
-                goto error;
+                if (ENOPROTOOPT != errno)
+                {
+                    AERON_APPEND_ERR(
+                        "failed to set IPPROTO_IPV6/IPV6_MULTICAST_ALL option to: %d", ipv6_multicast_all_disabled);
+                    goto error;
+                }
             }
 #endif
 
@@ -245,8 +249,12 @@ int aeron_udp_channel_transport_init(
             int ip_multicast_all_disabled = 0;
             if (aeron_setsockopt(transport->recv_fd, IPPROTO_IP, IP_MULTICAST_ALL, &ip_multicast_all_disabled, sizeof(int)) < 0)
             {
-                AERON_APPEND_ERR("failed to set IPPROTO_IP/IP_MULTICAST_ALL option to: %d", ip_multicast_all_disabled);
-                goto error;
+                if (ENOPROTOOPT != errno)
+                {
+                    AERON_APPEND_ERR(
+                        "failed to set IPPROTO_IP/IP_MULTICAST_ALL option to: %d", ip_multicast_all_disabled);
+                    goto error;
+                }
             }
 #endif
 

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport.c
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport.c
@@ -197,6 +197,10 @@ int aeron_udp_channel_transport_init(
                         "failed to set IPPROTO_IPV6/IPV6_MULTICAST_ALL option to: %d", ipv6_multicast_all_disabled);
                     goto error;
                 }
+                else
+                {
+                    aeron_err_clear();
+                }
             }
 #endif
 
@@ -254,6 +258,10 @@ int aeron_udp_channel_transport_init(
                     AERON_APPEND_ERR(
                         "failed to set IPPROTO_IP/IP_MULTICAST_ALL option to: %d", ip_multicast_all_disabled);
                     goto error;
+                }
+                else
+                {
+                    aeron_err_clear();
                 }
             }
 #endif

--- a/aeron-system-tests/src/test/java/io/aeron/MultipleMulticastsSubscriptionsTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MultipleMulticastsSubscriptionsTest.java
@@ -25,6 +25,7 @@ import io.aeron.test.Tests;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.OS;
@@ -132,6 +133,34 @@ class MultipleMulticastsSubscriptionsTest
             Tests.awaitConnected(pubB);
             Tests.awaitConnected(subA);
             Tests.awaitConnected(subB);
+        }
+    }
+
+    @Test
+    @InterruptAfter(10)
+    void shouldMulticastSubscriptionsWithSamePortNotConflict()
+    {
+        launch(context);
+
+        final String uriA = "aeron:udp?endpoint=239.192.181.39:15492|interface=127.0.0.1";
+        final String uriB = "aeron:udp?endpoint=239.192.181.99:15492|interface=127.0.0.1";
+
+        final Aeron.Context aeronCtx = new Aeron.Context()
+            .aeronDirectoryName(driver.aeronDirectoryName())
+            .useConductorAgentInvoker(true);
+
+        try (Aeron aeron = Aeron.connect(aeronCtx);
+             Subscription subA = aeron.addSubscription(uriA, 9382);
+             Subscription subB = aeron.addSubscription(uriB, 9382);
+             Publication pub = aeron.addPublication(uriB, 9382))
+        {
+            Tests.await(() ->
+            {
+                aeron.conductorAgentInvoker().invoke();
+                return subB.isConnected() && pub.isConnected();
+            });
+
+            Assertions.assertFalse(subA.isConnected());
         }
     }
 }

--- a/aeron-system-tests/src/test/java/io/aeron/MultipleMulticastsSubscriptionsTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MultipleMulticastsSubscriptionsTest.java
@@ -24,6 +24,7 @@ import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.Tests;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
+import org.agrona.collections.MutableInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,6 +32,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.Objects;
 
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
@@ -149,18 +152,24 @@ class MultipleMulticastsSubscriptionsTest
             .aeronDirectoryName(driver.aeronDirectoryName())
             .useConductorAgentInvoker(true);
 
+        final MutableInteger subAImages = new MutableInteger(0);
+        final MutableInteger subBImages = new MutableInteger(0);
         try (Aeron aeron = Aeron.connect(aeronCtx);
-             Subscription subA = aeron.addSubscription(uriA, 9382);
-             Subscription subB = aeron.addSubscription(uriB, 9382);
+             Subscription subA = aeron.addSubscription(uriA, 9382, i -> subAImages.incrementAndGet(), i -> {});
+             Subscription subB = aeron.addSubscription(uriB, 9382, i -> subBImages.incrementAndGet(), i -> {});
              Publication pub = aeron.addPublication(uriB, 9382))
         {
+            Objects.requireNonNull(subA);
+            Objects.requireNonNull(subB);
+            Objects.requireNonNull(pub);
+
             Tests.await(() ->
             {
                 aeron.conductorAgentInvoker().invoke();
-                return subB.isConnected() && pub.isConnected();
+                return subBImages.get() > 0;
             });
 
-            Assertions.assertFalse(subA.isConnected());
+            Assertions.assertEquals(0, subAImages.get());
         }
     }
 }


### PR DESCRIPTION
When using multicast on Aeron we bind to INADDR_ANY or in6addr_any. In linux, this means that 2 multicast subscriptions with different addresses and the same port will accidentally receive each other's images and data through setting IP_MULTICAST_ALL or IPV6_MULTICAST_ALL. Mac and windows appear to handle this. Java doesn't have this problem on linux as it sets these socket options if they exist.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multicast receive socket setup in the C driver, which can affect which packets subscriptions see on Linux; the change is small and covered by a regression test.
> 
> **Overview**
> On Linux, multicast receive sockets bound to `INADDR_ANY` / `in6addr_any` can deliver traffic from **other multicast groups that share the same UDP port**. The C driver now sets **`IP_MULTICAST_ALL`** and **`IPV6_MULTICAST_ALL`** to `0` on the receive fd before bind (when those options exist), matching behavior the Java driver already applies.
> 
> Socket setup failures other than `ENOPROTOOPT` still fail channel open; unsupported platforms ignore the option. A new system test asserts that two subscriptions on different multicast addresses but the **same port** do not cross-deliver images when only one group has a publication.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db774b798b3ead8501fb42821ece5ffb94ca0582. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->