### PR TITLE
Fix round-robin start duplication after index wrap in client poll and driver send rotation

### DIFF
--- a/aeron-client/src/main/c/aeron_subscription.c
+++ b/aeron-client/src/main/c/aeron_subscription.c
@@ -441,11 +441,12 @@ int aeron_subscription_poll(
 
     size_t length = image_list->length;
     size_t fragments_read = 0;
-    if (subscription->round_robin_index >= length)
-    {
-        subscription->round_robin_index = 0;
-    }
     size_t starting_index = subscription->round_robin_index++;
+    if (starting_index >= length)
+    {
+        starting_index = 0;
+        subscription->round_robin_index = 1;
+    }
 
     for (size_t i = starting_index; i < length && fragments_read < fragment_limit; i++)
     {
@@ -491,11 +492,12 @@ int aeron_subscription_controlled_poll(
 
     size_t length = image_list->length;
     size_t fragments_read = 0;
-    if (subscription->round_robin_index >= length)
-    {
-        subscription->round_robin_index = 0;
-    }
     size_t starting_index = subscription->round_robin_index++;
+    if (starting_index >= length)
+    {
+        starting_index = 0;
+        subscription->round_robin_index = 1;
+    }
 
     for (size_t i = starting_index; i < length && fragments_read < fragment_limit; i++)
     {

--- a/aeron-client/src/main/c/aeron_subscription.c
+++ b/aeron-client/src/main/c/aeron_subscription.c
@@ -441,11 +441,11 @@ int aeron_subscription_poll(
 
     size_t length = image_list->length;
     size_t fragments_read = 0;
-    size_t starting_index = subscription->round_robin_index++;
-    if (starting_index >= length)
+    if (subscription->round_robin_index >= length)
     {
-        subscription->round_robin_index = starting_index = 0;
+        subscription->round_robin_index = 0;
     }
+    size_t starting_index = subscription->round_robin_index++;
 
     for (size_t i = starting_index; i < length && fragments_read < fragment_limit; i++)
     {
@@ -491,11 +491,11 @@ int aeron_subscription_controlled_poll(
 
     size_t length = image_list->length;
     size_t fragments_read = 0;
-    size_t starting_index = subscription->round_robin_index++;
-    if (starting_index >= length)
+    if (subscription->round_robin_index >= length)
     {
-        subscription->round_robin_index = starting_index = 0;
+        subscription->round_robin_index = 0;
     }
+    size_t starting_index = subscription->round_robin_index++;
 
     for (size_t i = starting_index; i < length && fragments_read < fragment_limit; i++)
     {

--- a/aeron-client/src/main/java/io/aeron/Subscription.java
+++ b/aeron-client/src/main/java/io/aeron/Subscription.java
@@ -191,11 +191,12 @@ public final class Subscription extends SubscriptionFields implements AutoClosea
         final int length = images.length;
         int fragmentsRead = 0;
 
-        if (roundRobinIndex >= length)
+        int startingIndex = roundRobinIndex++;
+        if (startingIndex >= length)
         {
-            roundRobinIndex = 0;
+            startingIndex = 0;
+            roundRobinIndex = 1;
         }
-        final int startingIndex = roundRobinIndex++;
 
         for (int i = startingIndex; i < length && fragmentsRead < fragmentLimit; i++)
         {
@@ -231,11 +232,12 @@ public final class Subscription extends SubscriptionFields implements AutoClosea
         final int length = images.length;
         int fragmentsRead = 0;
 
-        if (roundRobinIndex >= length)
+        int startingIndex = roundRobinIndex++;
+        if (startingIndex >= length)
         {
-            roundRobinIndex = 0;
+            startingIndex = 0;
+            roundRobinIndex = 1;
         }
-        final int startingIndex = roundRobinIndex++;
 
         for (int i = startingIndex; i < length && fragmentsRead < fragmentLimit; i++)
         {

--- a/aeron-client/src/main/java/io/aeron/Subscription.java
+++ b/aeron-client/src/main/java/io/aeron/Subscription.java
@@ -191,11 +191,11 @@ public final class Subscription extends SubscriptionFields implements AutoClosea
         final int length = images.length;
         int fragmentsRead = 0;
 
-        int startingIndex = roundRobinIndex++;
-        if (startingIndex >= length)
+        if (roundRobinIndex >= length)
         {
-            roundRobinIndex = startingIndex = 0;
+            roundRobinIndex = 0;
         }
+        final int startingIndex = roundRobinIndex++;
 
         for (int i = startingIndex; i < length && fragmentsRead < fragmentLimit; i++)
         {
@@ -231,11 +231,11 @@ public final class Subscription extends SubscriptionFields implements AutoClosea
         final int length = images.length;
         int fragmentsRead = 0;
 
-        int startingIndex = roundRobinIndex++;
-        if (startingIndex >= length)
+        if (roundRobinIndex >= length)
         {
-            roundRobinIndex = startingIndex = 0;
+            roundRobinIndex = 0;
         }
+        final int startingIndex = roundRobinIndex++;
 
         for (int i = startingIndex; i < length && fragmentsRead < fragmentLimit; i++)
         {

--- a/aeron-client/src/test/java/io/aeron/SubscriptionTest.java
+++ b/aeron-client/src/test/java/io/aeron/SubscriptionTest.java
@@ -15,6 +15,7 @@
  */
 package io.aeron;
 
+import io.aeron.logbuffer.ControlledFragmentHandler;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.Header;
 import io.aeron.logbuffer.LogBufferDescriptor;
@@ -30,6 +31,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 
 import static io.aeron.Aeron.NULL_VALUE;
 import static io.aeron.status.ChannelEndpointStatus.*;
@@ -156,6 +159,67 @@ class SubscriptionTest
             });
 
         assertEquals(2, subscription.poll(fragmentHandler, FRAGMENT_COUNT_LIMIT));
+    }
+
+    @Test
+    void shouldRoundRobinStartingImageWhenPollingWithExhaustedFragmentLimit()
+    {
+        subscription.addImage(imageOneMock);
+        subscription.addImage(imageTwoMock);
+
+        final List<Image> polledImages = new ArrayList<>();
+        when(imageOneMock.poll(any(FragmentHandler.class), anyInt())).then(
+            (invocation) ->
+            {
+                polledImages.add(imageOneMock);
+                return 1;
+            });
+        when(imageTwoMock.poll(any(FragmentHandler.class), anyInt())).then(
+            (invocation) ->
+            {
+                polledImages.add(imageTwoMock);
+                return 1;
+            });
+
+        for (int i = 0; i < 6; i++)
+        {
+            assertEquals(1, subscription.poll(fragmentHandler, 1));
+        }
+
+        assertEquals(
+            List.of(imageOneMock, imageTwoMock, imageOneMock, imageTwoMock, imageOneMock, imageTwoMock),
+            polledImages);
+    }
+
+    @Test
+    void shouldRoundRobinStartingImageWhenControlledPollingWithExhaustedFragmentLimit()
+    {
+        final ControlledFragmentHandler controlledFragmentHandler = mock(ControlledFragmentHandler.class);
+        subscription.addImage(imageOneMock);
+        subscription.addImage(imageTwoMock);
+
+        final List<Image> polledImages = new ArrayList<>();
+        when(imageOneMock.controlledPoll(any(ControlledFragmentHandler.class), anyInt())).then(
+            (invocation) ->
+            {
+                polledImages.add(imageOneMock);
+                return 1;
+            });
+        when(imageTwoMock.controlledPoll(any(ControlledFragmentHandler.class), anyInt())).then(
+            (invocation) ->
+            {
+                polledImages.add(imageTwoMock);
+                return 1;
+            });
+
+        for (int i = 0; i < 6; i++)
+        {
+            assertEquals(1, subscription.controlledPoll(controlledFragmentHandler, 1));
+        }
+
+        assertEquals(
+            List.of(imageOneMock, imageTwoMock, imageOneMock, imageTwoMock, imageOneMock, imageTwoMock),
+            polledImages);
     }
 
     @ValueSource(longs = { INITIALIZING, ERRORED, CLOSING })

--- a/aeron-driver/src/main/c/aeron_driver_sender.c
+++ b/aeron-driver/src/main/c/aeron_driver_sender.c
@@ -402,7 +402,8 @@ int aeron_driver_sender_do_send(aeron_driver_sender_t *sender, int64_t now_ns)
 
     if (starting_index >= length)
     {
-        sender->round_robin_index = starting_index = 0;
+        starting_index = 0;
+        sender->round_robin_index = 1;
     }
 
     for (size_t i = starting_index; i < length; i++)

--- a/aeron-driver/src/main/c/media/aeron_udp_destination_tracker.c
+++ b/aeron-driver/src/main/c/media/aeron_udp_destination_tracker.c
@@ -114,7 +114,8 @@ int aeron_udp_destination_tracker_send(
     int starting_index = tracker->round_robin_index++;
     if (starting_index >= length)
     {
-        tracker->round_robin_index = starting_index = 0;
+        starting_index = 0;
+        tracker->round_robin_index = 1;
     }
 
     for (int i = starting_index; i < length; i++)

--- a/aeron-driver/src/main/java/io/aeron/driver/Sender.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Sender.java
@@ -222,7 +222,8 @@ public final class Sender extends SenderRhsPadding implements Agent
         int startingIndex = roundRobinIndex++;
         if (startingIndex >= length)
         {
-            roundRobinIndex = startingIndex = 0;
+            startingIndex = 0;
+            roundRobinIndex = 1;
         }
 
         for (int i = startingIndex; i < length; i++)

--- a/aeron-driver/src/main/java/io/aeron/driver/media/SendChannelEndpoint.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/SendChannelEndpoint.java
@@ -830,7 +830,8 @@ class ManualSndMultiDestination extends MultiSndDestination
         int startingIndex = roundRobinIndex++;
         if (startingIndex >= length)
         {
-            roundRobinIndex = startingIndex = 0;
+            startingIndex = 0;
+            roundRobinIndex = 1;
         }
 
         int result = bytesToSend;
@@ -1011,7 +1012,8 @@ class DynamicSndMultiDestination extends MultiSndDestination
         int startingIndex = roundRobinIndex++;
         if (startingIndex >= length)
         {
-            roundRobinIndex = startingIndex = 0;
+            startingIndex = 0;
+            roundRobinIndex = 1;
         }
 
         int result = bytesToSend;


### PR DESCRIPTION
The round-robin rotation used by `Subscription.poll`/`controlledPoll` and the driver send paths resets the index to zero on the call that wraps, after the starting index has already been consumed. The next call therefore starts at slot 0 again: with N slots the starting sequence is `0, 1, ..., N-1, 0` repeating (slot 0 twice per cycle) instead of `0, 1, ..., N-1`.

For subscription polling this skews service: when `fragmentLimit` is reached before all images are visited, image 0 is drained on 2 of every N+1 polls (2 of 3 with two images) rather than 1 of N. No data is lost or duplicated, and since ordering across images is unspecified, no application can correctly depend on the previous starting order. In the driver send loops there is no early exit, so only first-position priority is skewed.

Fix: clamp the starting index after consuming it and leave the rotation index one past the consumed slot, so the call after a wrap starts at the next slot and the consumed index remains in bounds at point of use.

One incidental state change: after a call with no slots the rotation index is left at 1 rather than 0, so the first call after slots appear may start at slot 1. The starting slot is unspecified and no slot is excluded from the rotation; avoiding this would cost an extra length check on the wrap path.

Prior art:

- Issue #129 (2014) reported the original rotation check being reversed with unbounded index growth; the fix for it introduced the current increment-then-reset shape. The duplicate start after the wrap was not part of that discussion.
- PR #531 (2018) changed the mechanism to resume mid-cycle from a persisted index. It was merged and then reverted (#532) because the persisted index was used as a loop bound without being re-clamped, causing index out of bounds in cluster tests after the image array shrank. The fix proposed here is stateless per call and clamps the index at the point of use every call, so it does not share that failure mode.

Applied to all sites sharing the idiom:

- `Subscription.poll` / `Subscription.controlledPoll` (Java client)
- `aeron_subscription_poll` / `aeron_subscription_controlled_poll` (C client, and via delegation the C++ wrapper)
- `Sender.doSend`, both `SendChannelEndpoint` destination send paths (Java driver)
- `aeron_driver_sender_do_send`, `aeron_udp_destination_tracker` send rotation (C driver)

Adds `SubscriptionTest` cases asserting alternating drain order across six polls with fragment limit 1 for `poll` and `controlledPoll`, which fail against the previous rotation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hot-path fair rotation in client polling and driver UDP send loops; behavior is fairer only (no protocol change) but affects production message-delivery ordering across images/destinations.
> 
> **Overview**
> Fixes **round-robin rotation** so the slot after an index wrap is not started twice. On wrap, the consumed starting index is clamped to `0` while the persisted rotation index is set to `1`, so the next call advances to the next slot instead of repeating index `0`.
> 
> The same one-line idiom change is applied everywhere it was used: **`Subscription.poll` / `controlledPoll`** and C **`aeron_subscription_poll` / `controlled_poll`**, driver **`Sender.doSend`**, **`SendChannelEndpoint`** manual/dynamic multi-destination send, and C **`aeron_driver_sender_do_send`** / **`aeron_udp_destination_tracker_send`**.
> 
> Adds **`SubscriptionTest`** coverage that six consecutive polls with **fragment limit 1** and two images alternate which image is visited first (for both `poll` and `controlledPoll`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae9841a0ec80e9c35858ddf688138b92e8d2ccca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->