### PR TITLE
Update distinct error log message. O != 0

### DIFF
--- a/aeron-client/src/main/java/io/aeron/CommonContext.java
+++ b/aeron-client/src/main/java/io/aeron/CommonContext.java
@@ -1170,7 +1170,7 @@ public class CommonContext implements Cloneable
         else
         {
             out.println();
-            out.println("O distinct errors observed");
+            out.println("0 distinct errors observed");
         }
 
         return distinctErrorCount;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-string typo fix in diagnostic output only; no behavior or API changes.
> 
> **Overview**
> Fixes a typo in `CommonContext.printErrorLog` when the error buffer has no entries: the message now prints **`0 distinct errors observed`** instead of **`O distinct errors observed`** (letter O mistaken for zero).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9eeeec324da3b8502755a4641c12d4f430eafd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->