### PR TITLE
[Archive] Change Aeron thread names in Archive to follow newly established conventions while maintaining support for old names

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/Archive.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Archive.java
@@ -121,6 +121,17 @@ import static org.agrona.SystemUtil.loadPropertiesFiles;
 @Versioned
 public final class Archive implements AutoCloseable
 {
+    static final String AERON_ARCHIVE_RECORDER_THREAD_NAME = "aeron-ar-rec";
+    static final String AERON_ARCHIVE_REPLAYER_THREAD_NAME = "aeron-ar-rep";
+    static final String AERON_ARCHIVE_CONDUCTOR_THREAD_NAME = "aeron-ar-cnd";
+    static final String AERON_ARCHIVE_SHARED_THREAD_NAME = "aeron-ar-shd";
+
+    static final String AERON_ARCHIVE_RECORDER_THREAD_NAME_CLASSIC = "archive-recorder";
+    static final String AERON_ARCHIVE_REPLAYER_THREAD_NAME_CLASSIC = "archive-replayer";
+    static final String AERON_ARCHIVE_CONDUCTOR_THREAD_NAME_CLASSIC = "archive-conductor";
+    static final String AERON_ARCHIVE_SHARED_THREAD_NAME_CLASSIC = "archive-conductor";
+
+
     private final Context ctx;
     private final AgentRunner conductorRunner;
     private final AgentInvoker conductorInvoker;

--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveConductor.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveConductor.java
@@ -84,6 +84,12 @@ import static io.aeron.CommonContext.MTU_LENGTH_PARAM_NAME;
 import static io.aeron.CommonContext.SPARSE_PARAM_NAME;
 import static io.aeron.CommonContext.SPY_PREFIX;
 import static io.aeron.CommonContext.TERM_LENGTH_PARAM_NAME;
+import static io.aeron.CommonContext.threadName;
+import static io.aeron.archive.Archive.AERON_ARCHIVE_CONDUCTOR_THREAD_NAME_CLASSIC;
+import static io.aeron.archive.Archive.AERON_ARCHIVE_RECORDER_THREAD_NAME;
+import static io.aeron.archive.Archive.AERON_ARCHIVE_RECORDER_THREAD_NAME_CLASSIC;
+import static io.aeron.archive.Archive.AERON_ARCHIVE_REPLAYER_THREAD_NAME;
+import static io.aeron.archive.Archive.AERON_ARCHIVE_REPLAYER_THREAD_NAME_CLASSIC;
 import static io.aeron.archive.Archive.Configuration.MARK_FILE_UPDATE_INTERVAL_MS;
 import static io.aeron.archive.Archive.Configuration.RECORDING_SEGMENT_SUFFIX;
 import static io.aeron.archive.Archive.segmentFileName;
@@ -174,7 +180,12 @@ abstract class ArchiveConductor
 
     ArchiveConductor(final Archive.Context ctx)
     {
-        super("archive-conductor", ctx.countedErrorHandler());
+        this(ctx, AERON_ARCHIVE_CONDUCTOR_THREAD_NAME_CLASSIC);
+    }
+
+    ArchiveConductor(final Archive.Context ctx, final String roleName)
+    {
+        super(roleName, ctx.countedErrorHandler());
 
         this.ctx = ctx;
 
@@ -2690,7 +2701,8 @@ abstract class ArchiveConductor
 
         Recorder(final CountedErrorHandler errorHandler, final Archive.Context context)
         {
-            super("archive-recorder", errorHandler);
+            super(threadName(
+                AERON_ARCHIVE_RECORDER_THREAD_NAME, AERON_ARCHIVE_RECORDER_THREAD_NAME_CLASSIC), errorHandler);
             totalWriteBytesCounter = context.totalWriteBytesCounter();
             totalWriteTimeCounter = context.totalWriteTimeCounter();
             maxWriteTimeCounter = context.maxWriteTimeCounter();
@@ -2736,7 +2748,8 @@ abstract class ArchiveConductor
 
         Replayer(final CountedErrorHandler errorHandler, final Archive.Context context)
         {
-            super("archive-replayer", errorHandler);
+            super(threadName(
+                AERON_ARCHIVE_REPLAYER_THREAD_NAME, AERON_ARCHIVE_REPLAYER_THREAD_NAME_CLASSIC), errorHandler);
             totalReadBytesCounter = context.totalReadBytesCounter();
             totalReadTimeCounter = context.totalReadTimeCounter();
             maxReadTimeCounter = context.maxReadTimeCounter();

--- a/aeron-archive/src/main/java/io/aeron/archive/DedicatedModeArchiveConductor.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/DedicatedModeArchiveConductor.java
@@ -22,6 +22,10 @@ import org.agrona.concurrent.status.AtomicCounter;
 
 import java.util.concurrent.CountDownLatch;
 
+import static io.aeron.CommonContext.threadName;
+import static io.aeron.archive.Archive.AERON_ARCHIVE_CONDUCTOR_THREAD_NAME;
+import static io.aeron.archive.Archive.AERON_ARCHIVE_CONDUCTOR_THREAD_NAME_CLASSIC;
+
 final class DedicatedModeArchiveConductor extends ArchiveConductor
 {
     private static final int COMMAND_LIMIT = 10;
@@ -32,7 +36,7 @@ final class DedicatedModeArchiveConductor extends ArchiveConductor
 
     DedicatedModeArchiveConductor(final Archive.Context ctx)
     {
-        super(ctx);
+        super(ctx, threadName(AERON_ARCHIVE_CONDUCTOR_THREAD_NAME, AERON_ARCHIVE_CONDUCTOR_THREAD_NAME_CLASSIC));
         closeQueue = new ManyToOneConcurrentLinkedQueue<>();
     }
 

--- a/aeron-archive/src/main/java/io/aeron/archive/SharedModeArchiveConductor.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/SharedModeArchiveConductor.java
@@ -19,6 +19,10 @@ import org.agrona.CloseHelper;
 import org.agrona.concurrent.AgentInvoker;
 import org.agrona.concurrent.CountedErrorHandler;
 
+import static io.aeron.CommonContext.threadName;
+import static io.aeron.archive.Archive.AERON_ARCHIVE_SHARED_THREAD_NAME;
+import static io.aeron.archive.Archive.AERON_ARCHIVE_SHARED_THREAD_NAME_CLASSIC;
+
 final class SharedModeArchiveConductor extends ArchiveConductor
 {
     private AgentInvoker replayerAgentInvoker;
@@ -26,7 +30,7 @@ final class SharedModeArchiveConductor extends ArchiveConductor
 
     SharedModeArchiveConductor(final Archive.Context ctx)
     {
-        super(ctx);
+        super(ctx, threadName(AERON_ARCHIVE_SHARED_THREAD_NAME, AERON_ARCHIVE_SHARED_THREAD_NAME_CLASSIC));
     }
 
     public void onStart()

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveThreadNamingTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveThreadNamingTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2014-2026 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aeron.archive;
+
+import io.aeron.CommonContext;
+import io.aeron.driver.MediaDriver;
+import io.aeron.driver.ThreadingMode;
+import io.aeron.test.TestContexts;
+import io.aeron.test.Tests;
+import io.aeron.test.driver.TestMediaDriver;
+import org.agrona.SystemUtil;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.File;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import static io.aeron.CommonContext.THREAD_NAMING_CLASSIC;
+import static io.aeron.CommonContext.THREAD_NAMING_NEW;
+import static io.aeron.archive.Archive.AERON_ARCHIVE_CONDUCTOR_THREAD_NAME;
+import static io.aeron.archive.Archive.AERON_ARCHIVE_CONDUCTOR_THREAD_NAME_CLASSIC;
+import static io.aeron.archive.Archive.AERON_ARCHIVE_RECORDER_THREAD_NAME;
+import static io.aeron.archive.Archive.AERON_ARCHIVE_RECORDER_THREAD_NAME_CLASSIC;
+import static io.aeron.archive.Archive.AERON_ARCHIVE_REPLAYER_THREAD_NAME;
+import static io.aeron.archive.Archive.AERON_ARCHIVE_REPLAYER_THREAD_NAME_CLASSIC;
+import static io.aeron.archive.Archive.AERON_ARCHIVE_SHARED_THREAD_NAME;
+import static io.aeron.archive.Archive.AERON_ARCHIVE_SHARED_THREAD_NAME_CLASSIC;
+import static io.aeron.archive.ArchiveSystemTests.CATALOG_CAPACITY;
+import static io.aeron.archive.ArchiveSystemTests.TERM_LENGTH;
+import static java.lang.management.ManagementFactory.getThreadMXBean;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+public class ArchiveThreadNamingTest
+{
+
+    private static Stream<Arguments> expectedNamePerThreadingMode()
+    {
+        return Stream.of(
+            Arguments.of(
+                ArchiveThreadingMode.DEDICATED,
+                THREAD_NAMING_CLASSIC,
+                new String[]{
+                    AERON_ARCHIVE_RECORDER_THREAD_NAME_CLASSIC,
+                    AERON_ARCHIVE_REPLAYER_THREAD_NAME_CLASSIC,
+                    AERON_ARCHIVE_CONDUCTOR_THREAD_NAME_CLASSIC
+                }),
+            Arguments.of(
+                ArchiveThreadingMode.DEDICATED,
+                THREAD_NAMING_NEW,
+                new String[]{
+                    AERON_ARCHIVE_RECORDER_THREAD_NAME,
+                    AERON_ARCHIVE_REPLAYER_THREAD_NAME,
+                    AERON_ARCHIVE_CONDUCTOR_THREAD_NAME
+                }),
+            Arguments.of(
+                ArchiveThreadingMode.SHARED,
+                THREAD_NAMING_CLASSIC,
+                new String[]{
+                    AERON_ARCHIVE_SHARED_THREAD_NAME_CLASSIC
+                }),
+            Arguments.of(
+                ArchiveThreadingMode.SHARED,
+                THREAD_NAMING_NEW,
+                new String[]{
+                    AERON_ARCHIVE_SHARED_THREAD_NAME
+                })
+
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("expectedNamePerThreadingMode")
+    @SuppressWarnings("try")
+    public void shouldHaveCorrectArchiveThreadNames(
+        final ArchiveThreadingMode threadingMode,
+        final String threadNaming,
+        final String[] expectedThreadNames)
+    {
+        System.setProperty(CommonContext.THREAD_NAMING_PROP_NAME, threadNaming);
+        try
+        {
+            final String aeronDirectoryName = CommonContext.generateRandomDirName();
+            final MediaDriver.Context driverCtx = new MediaDriver.Context()
+                .aeronDirectoryName(aeronDirectoryName)
+                .termBufferSparseFile(true)
+                .threadingMode(ThreadingMode.SHARED)
+                .spiesSimulateConnection(false)
+                .dirDeleteOnStart(true)
+                .dirDeleteOnShutdown(true);
+            final File archiveDir = new File(SystemUtil.tmpDirName(), "archive");
+            final Archive.Context archiveCtx = TestContexts.localhostArchive()
+                .catalogCapacity(CATALOG_CAPACITY)
+                .segmentFileLength(TERM_LENGTH)
+                .aeronDirectoryName(aeronDirectoryName)
+                .deleteArchiveOnStart(true)
+                .archiveDir(archiveDir)
+                .fileSyncLevel(0)
+                .maxConcurrentRecordings(50)
+                .threadingMode(threadingMode);
+
+            try (TestMediaDriver driver = TestMediaDriver.launch(driverCtx, null);
+                Archive archive = Archive.launch(archiveCtx);)
+            {
+                Arrays.sort(expectedThreadNames);
+                final ThreadMXBean threadBean = getThreadMXBean();
+                final String[][] desiredThreads = { new String[0] };
+
+                Tests.await(
+                    () ->
+                    {
+                        final long[] threadIds = threadBean.getAllThreadIds();
+                        final ThreadInfo[] threadInfos = threadBean.getThreadInfo(threadIds, 0);
+                        desiredThreads[0] = Arrays.stream(threadInfos)
+                            .filter(Objects::nonNull)
+                            .map(ThreadInfo::getThreadName)
+                            .filter(threadName -> Arrays.asList(expectedThreadNames).contains(threadName))
+                            .sorted()
+                            .toArray(String[]::new);
+
+                        return Arrays.equals(expectedThreadNames, desiredThreads[0]);
+                    },
+                    TimeUnit.SECONDS.toNanos(5));
+
+                assertArrayEquals(expectedThreadNames, desiredThreads[0]);
+            }
+        }
+        finally
+        {
+            System.clearProperty(CommonContext.THREAD_NAMING_PROP_NAME);
+        }
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Observability-only change to thread display names with classic names preserved by default; no recording/replay logic changes.
> 
> **Overview**
> Archive agent threads (conductor, recorder, replayer, and shared-mode composite) now pick their **Java thread names** via `CommonContext.threadName()` and the `aeron.thread.naming` system property, aligned with the driver’s new naming scheme.
> 
> **New** prefixed names (`aeron-ar-rec`, `aeron-ar-rep`, `aeron-ar-cnd`, `aeron-ar-shd`) are used when naming is `new`; **classic** names (`archive-recorder`, `archive-replayer`, `archive-conductor`) remain the default. `ArchiveConductor` accepts an explicit role name; dedicated and shared conductors pass the appropriate name into the base constructor, and nested `Recorder`/`Replayer` agents use the same helper.
> 
> `ArchiveThreadNamingTest` launches the archive under `DEDICATED` and `SHARED` threading modes with both naming modes and asserts the expected thread names via `ThreadMXBean`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08d54070f376d598f4b9fb051d7d91528b0df495. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->