### PR TITLE
[Cluster] change Aeron thread names in Cluster to follow newly established conventions

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackup.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackup.java
@@ -222,6 +222,9 @@ public final class ClusterBackup implements AutoCloseable
     private final AgentInvoker agentInvoker;
     private final AgentRunner agentRunner;
 
+    static final String AERON_CLUSTER_BACKUP_THREAD_NAME = "aeron-cl-bu";
+    static final String AERON_CLUSTER_BACKUP_THREAD_NAME_CLASSIC = "cluster-backup";
+
     private ClusterBackup(final ClusterBackup.Context ctx)
     {
         try

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackupAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackupAgent.java
@@ -61,6 +61,8 @@ import static io.aeron.archive.client.AeronArchive.NULL_LENGTH;
 import static io.aeron.archive.client.AeronArchive.NULL_POSITION;
 import static io.aeron.archive.client.AeronArchive.NULL_TIMESTAMP;
 import static io.aeron.archive.codecs.SourceLocation.REMOTE;
+import static io.aeron.cluster.ClusterBackup.AERON_CLUSTER_BACKUP_THREAD_NAME;
+import static io.aeron.cluster.ClusterBackup.AERON_CLUSTER_BACKUP_THREAD_NAME_CLASSIC;
 import static io.aeron.cluster.ClusterBackup.State.BACKING_UP;
 import static io.aeron.cluster.ClusterBackup.State.BACKUP_QUERY;
 import static io.aeron.cluster.ClusterBackup.State.CLOSED;
@@ -107,6 +109,7 @@ public final class ClusterBackupAgent implements Agent
     private final long unavailableCounterHandlerRegistrationId;
     private final PublicationGroup<ExclusivePublication> consensusPublicationGroup;
     private final LogSourceValidator logSourceValidator;
+    private final String roleName;
 
     private ClusterBackup.State state = BACKUP_QUERY;
 
@@ -172,6 +175,7 @@ public final class ClusterBackupAgent implements Agent
         liveLogPositionCounter = ctx.liveLogPositionCounter();
         nextQueryDeadlineMsCounter = ctx.nextQueryDeadlineMsCounter();
         logSourceValidator = new LogSourceValidator(ctx.sourceType());
+        roleName = threadName(AERON_CLUSTER_BACKUP_THREAD_NAME, AERON_CLUSTER_BACKUP_THREAD_NAME_CLASSIC);
     }
 
     /**
@@ -315,7 +319,7 @@ public final class ClusterBackupAgent implements Agent
     @Override
     public String roleName()
     {
-        return "cluster-backup";
+        return roleName;
     }
 
     private void reset()

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
@@ -101,6 +101,7 @@ import static io.aeron.CommonContext.TERM_OFFSET_PARAM_NAME;
 import static io.aeron.CommonContext.UDP_CHANNEL;
 import static io.aeron.CommonContext.driverFilePageSize;
 import static io.aeron.CommonContext.fallbackLogger;
+import static io.aeron.CommonContext.threadName;
 import static io.aeron.cluster.ConsensusModule.Configuration.CLUSTER_CLIENT_TIMEOUT_COUNT_TYPE_ID;
 import static io.aeron.cluster.ConsensusModule.Configuration.CLUSTER_CLOCK_PROP_NAME;
 import static io.aeron.cluster.ConsensusModule.Configuration.CLUSTER_NODE_ROLE_TYPE_ID;
@@ -276,6 +277,8 @@ public final class ConsensusModule implements AutoCloseable
     private final ConsensusModuleAgent conductor;
     private final AgentRunner conductorRunner;
     private final AgentInvoker conductorInvoker;
+
+    static final String AERON_CLUSTER_CONSENSUS_THREAD_NAME = "aeron-cl-cm";
 
     ConsensusModule(final Context ctx)
     {
@@ -1848,7 +1851,8 @@ public final class ConsensusModule implements AutoCloseable
 
             if (Strings.isEmpty(agentRoleName))
             {
-                agentRoleName = "consensus-module-" + clusterId + "-" + clusterMemberId;
+                agentRoleName = threadName(
+                    AERON_CLUSTER_CONSENSUS_THREAD_NAME, "consensus-module-" + clusterId + "-" + clusterMemberId);
             }
 
             final ExpandableArrayBuffer buffer = new ExpandableArrayBuffer();

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceContainer.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceContainer.java
@@ -70,6 +70,7 @@ import java.util.function.Supplier;
 
 import static io.aeron.ChannelUri.addAliasIfAbsent;
 import static io.aeron.CommonContext.driverFilePageSize;
+import static io.aeron.CommonContext.threadName;
 import static io.aeron.cluster.service.ClusteredServiceContainer.Configuration.LIVENESS_TIMEOUT_MS;
 import static io.aeron.cluster.service.ClusteredServiceContainer.Configuration.MAX_SERVICE_COUNT;
 import static io.aeron.cluster.service.ClusteredServiceContainer.Configuration.SERVICE_NAME_PROP_NAME;
@@ -107,6 +108,8 @@ public final class ClusteredServiceContainer implements AutoCloseable
 
     private final Context ctx;
     private final AgentRunner serviceAgentRunner;
+
+    static final String AERON_CLUSTER_CLUSTERED_SERVICE_THREAD_NAME_PREFIX = "aeron-cl-cs-";
 
     private ClusteredServiceContainer(final Context ctx)
     {
@@ -920,7 +923,9 @@ public final class ClusteredServiceContainer implements AutoCloseable
 
             if (Strings.isEmpty(serviceName))
             {
-                serviceName = "clustered-service-" + clusterId + "-" + serviceId;
+                serviceName = threadName(
+                    AERON_CLUSTER_CLUSTERED_SERVICE_THREAD_NAME_PREFIX + serviceId,
+                    "clustered-service-" + clusterId + "-" + serviceId);
             }
 
             if (null == aeron)

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterThreadNamingTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterThreadNamingTest.java
@@ -23,6 +23,7 @@ import io.aeron.cluster.service.ClusteredServiceContainer;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.test.EventLogExtension;
+import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.TestContexts;
 import io.aeron.test.Tests;
@@ -41,7 +42,6 @@ import java.lang.management.ThreadMXBean;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import static io.aeron.CommonContext.THREAD_NAMING_CLASSIC;
@@ -88,6 +88,7 @@ public class ClusterThreadNamingTest
 
     @ParameterizedTest
     @MethodSource("threadNamingModes")
+    @InterruptAfter(5)
     void shouldUseCorrectThreadNamesByNamingMode(
         final String threadNamingMode,
         final String consensusAgentRoleNameOverride,
@@ -125,6 +126,7 @@ public class ClusterThreadNamingTest
 
     @ParameterizedTest
     @MethodSource("clusteredServiceDefaultThreadNamingModes")
+    @InterruptAfter(5)
     @SuppressWarnings("try")
     void shouldUseCorrectDefaultClusteredServiceThreadNamesPerMode(
         final String threadNamingMode, final String expectedName, @TempDir final Path tmpDir)
@@ -165,13 +167,12 @@ public class ClusterThreadNamingTest
                         .ingressChannel("aeron:udp")
                         .clusterId(0)
                         .clusterMemberId(0)
-                        .deleteDirOnStart(true)))
+                        .deleteDirOnStart(true));
+                ClusteredServiceContainer container = ClusteredServiceContainer.launch(context))
             {
-
-                try (ClusteredServiceContainer container = ClusteredServiceContainer.launch(context))
-                {
-                    awaitThreads(expectedName);
-                }
+                Tests.await(() ->
+                    ElectionState.CLOSED == ElectionState.get(consensusModule.context().electionStateCounter()));
+                awaitThreads(expectedName);
             }
         }
         finally
@@ -199,7 +200,6 @@ public class ClusterThreadNamingTest
                     .sorted()
                     .toArray(String[]::new);
                 return Arrays.equals(sortedExpected, actual);
-            },
-            TimeUnit.SECONDS.toNanos(5));
+            });
     }
 }

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterThreadNamingTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterThreadNamingTest.java
@@ -22,11 +22,15 @@ import io.aeron.cluster.service.ClusteredService;
 import io.aeron.cluster.service.ClusteredServiceContainer;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
+import io.aeron.test.EventLogExtension;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.TestContexts;
 import io.aeron.test.Tests;
 import io.aeron.test.cluster.ClusterTests;
 import io.aeron.test.cluster.StubClusteredService;
+import io.aeron.test.cluster.TestCluster;
 import io.aeron.test.driver.TestMediaDriver;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -46,148 +50,84 @@ import static io.aeron.CommonContext.THREAD_NAMING_PROP_NAME;
 import static io.aeron.cluster.ClusterBackup.AERON_CLUSTER_BACKUP_THREAD_NAME;
 import static io.aeron.cluster.ClusterBackup.AERON_CLUSTER_BACKUP_THREAD_NAME_CLASSIC;
 import static io.aeron.cluster.ConsensusModule.AERON_CLUSTER_CONSENSUS_THREAD_NAME;
-import static io.aeron.test.TestContexts.LOCALHOST_SINGLE_HOST_CLUSTER_MEMBERS;
+import static io.aeron.test.cluster.TestCluster.aCluster;
 import static java.lang.management.ManagementFactory.getThreadMXBean;
 
+@ExtendWith({ EventLogExtension.class, InterruptingTestCallback.class })
 public class ClusterThreadNamingTest
 {
-
-    private static Stream<Arguments> clusterBackupThreadNamingModes()
+    private static Stream<Arguments> threadNamingModes()
     {
+        // NOTE: The following cases do not cover the clustered service defaults.
         return Stream.of(
-            Arguments.of(THREAD_NAMING_CLASSIC, AERON_CLUSTER_BACKUP_THREAD_NAME_CLASSIC),
-            Arguments.of(THREAD_NAMING_NEW, AERON_CLUSTER_BACKUP_THREAD_NAME));
+            Arguments.of(
+                THREAD_NAMING_CLASSIC, null, null,
+                new String[]{
+                    AERON_CLUSTER_BACKUP_THREAD_NAME_CLASSIC,
+                    "consensus-module-0-0"
+                }),
+            Arguments.of(
+                THREAD_NAMING_NEW, null, null,
+                new String[]{
+                    AERON_CLUSTER_BACKUP_THREAD_NAME,
+                    AERON_CLUSTER_CONSENSUS_THREAD_NAME
+                }),
+            Arguments.of(
+                THREAD_NAMING_CLASSIC, "consensus-override", "clustered-service-override",
+                new String[]{
+                    AERON_CLUSTER_BACKUP_THREAD_NAME_CLASSIC,
+                    "consensus-override",
+                    "clustered-service-override" }),
+            Arguments.of(
+                THREAD_NAMING_NEW, "consensus-override", "clustered-service-override",
+                new String[]{
+                    AERON_CLUSTER_BACKUP_THREAD_NAME,
+                    "consensus-override",
+                    "clustered-service-override" }));
     }
 
     @ParameterizedTest
-    @MethodSource("clusterBackupThreadNamingModes")
+    @MethodSource("threadNamingModes")
+    void shouldUseCorrectThreadNamesByNamingMode(
+        final String threadNamingMode,
+        final String consensusAgentRoleNameOverride,
+        final String clusterServiceNameOverride,
+        final String[] expectedThreadNames)
+    {
+        System.setProperty(THREAD_NAMING_PROP_NAME, threadNamingMode);
+        try
+        {
+            try (
+                TestCluster cluster = aCluster()
+                    .withStaticNodes(3)
+                    .withConsensusModuleAgentRoleName(consensusAgentRoleNameOverride)
+                    .withClusterServiceName(clusterServiceNameOverride)
+                    .start())
+            {
+                cluster.awaitLeader();
+                cluster.startClusterBackupNode(true);
+                awaitThreads(expectedThreadNames);
+            }
+
+        }
+        finally
+        {
+            System.clearProperty(THREAD_NAMING_PROP_NAME);
+        }
+    }
+
+    private static Stream<Arguments> clusteredServiceDefaultThreadNamingModes()
+    {
+        return Stream.of(
+            Arguments.of(THREAD_NAMING_CLASSIC, "clustered-service-0-0"),
+            Arguments.of(THREAD_NAMING_NEW, "aeron-cl-cs-0"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("clusteredServiceDefaultThreadNamingModes")
     @SuppressWarnings("try")
-    void shouldUseCorrectClusterBackupThreadName(
+    void shouldUseCorrectDefaultClusteredServiceThreadNamesPerMode(
         final String threadNamingMode, final String expectedName, @TempDir final Path tmpDir)
-    {
-        System.setProperty(THREAD_NAMING_PROP_NAME, threadNamingMode);
-        try
-        {
-            final String aeronDirectoryName = tmpDir.resolve("aeron").toString();
-            try (TestMediaDriver mediaDriver = TestMediaDriver.launch(new MediaDriver.Context()
-                    .aeronDirectoryName(aeronDirectoryName)
-                    .threadingMode(ThreadingMode.SHARED)
-                    .termBufferSparseFile(true)
-                    .dirDeleteOnStart(true), null);
-                Archive archive = Archive.launch(TestContexts.localhostArchive()
-                    .aeronDirectoryName(aeronDirectoryName)
-                    .archiveDir(tmpDir.resolve("archive").toFile())
-                    .threadingMode(ArchiveThreadingMode.SHARED)
-                    .deleteArchiveOnStart(true)))
-            {
-
-                try (ClusterBackup clusterBackup = ClusterBackup.launch(new ClusterBackup.Context()
-                    .aeronDirectoryName(aeronDirectoryName)
-                    .clusterDir(tmpDir.resolve("cluster").toFile())
-                    .errorHandler(ClusterTests.errorHandler(0))
-                    .consensusChannel("aeron:udp?endpoint=localhost:0")
-                    .clusterConsensusEndpoints("localhost:20001")
-                    .catchupEndpoint("localhost:0")
-                    .deleteDirOnStart(true)))
-                {
-                    awaitThread(expectedName);
-                }
-            }
-        }
-        finally
-        {
-            System.clearProperty(THREAD_NAMING_PROP_NAME);
-        }
-    }
-
-    private static Stream<Arguments> consensusModuleThreadNamingModes()
-    {
-        return Stream.of(
-            Arguments.of(THREAD_NAMING_CLASSIC, null, "consensus-module-0-0"),
-            Arguments.of(THREAD_NAMING_NEW, null, AERON_CLUSTER_CONSENSUS_THREAD_NAME),
-            Arguments.of(THREAD_NAMING_CLASSIC, "consensus-override", "consensus-override"),
-            Arguments.of(THREAD_NAMING_NEW, "consensus-override", "consensus-override"));
-    }
-
-    @ParameterizedTest
-    @MethodSource("consensusModuleThreadNamingModes")
-    @SuppressWarnings("try")
-    void shouldUseCorrectConsensusModuleThreadName(
-        final String threadNamingMode,
-        final String agentRoleNameOverride,
-        final String expectedName,
-        @TempDir final Path tmpDir)
-    {
-        System.setProperty(THREAD_NAMING_PROP_NAME, threadNamingMode);
-        try
-        {
-            final String aeronDirectoryName = tmpDir.resolve("aeron").toString();
-            final ConsensusModule.Context context = TestContexts.localhostConsensusModule()
-                .aeronDirectoryName(aeronDirectoryName)
-                .clusterDir(tmpDir.resolve("cluster").toFile())
-                .errorHandler(ClusterTests.errorHandler(0))
-                .terminationHook(ClusterTests.NOOP_TERMINATION_HOOK)
-                .logChannel("aeron:ipc")
-                .replicationChannel("aeron:udp?endpoint=localhost:0")
-                .ingressChannel("aeron:udp")
-                .clusterId(0)
-                .clusterMemberId(0)
-                .deleteDirOnStart(true);
-            if (null != agentRoleNameOverride)
-            {
-                context.agentRoleName(agentRoleNameOverride);
-            }
-
-            try (TestMediaDriver mediaDriver = TestMediaDriver.launch(new MediaDriver.Context()
-                    .aeronDirectoryName(aeronDirectoryName)
-                    .threadingMode(ThreadingMode.SHARED)
-                    .termBufferSparseFile(true)
-                    .dirDeleteOnStart(true), null);
-                Archive archive = Archive.launch(TestContexts.localhostArchive()
-                    .aeronDirectoryName(aeronDirectoryName)
-                    .archiveDir(tmpDir.resolve("archive").toFile())
-                    .threadingMode(ArchiveThreadingMode.SHARED)
-                    .deleteArchiveOnStart(true));
-                ConsensusModule consensusModule = ConsensusModule.launch(context))
-            {
-
-                final ClusteredService clusteredService = new StubClusteredService();
-                try (ClusteredServiceContainer container = ClusteredServiceContainer.launch(
-                    new ClusteredServiceContainer.Context()
-                        .aeronDirectoryName(aeronDirectoryName)
-                        .clusterDir(tmpDir.resolve("cluster").toFile())
-                        .clusteredService(clusteredService)
-                        .errorHandler(ClusterTests.errorHandler(0))
-                        .clusterId(0)
-                        .serviceId(0)))
-                {
-                    awaitThread(expectedName);
-                }
-            }
-        }
-        finally
-        {
-            System.clearProperty(THREAD_NAMING_PROP_NAME);
-        }
-    }
-
-    private static Stream<Arguments> clusteredServiceThreadNamingModes()
-    {
-        return Stream.of(
-            Arguments.of(THREAD_NAMING_CLASSIC, null, "clustered-service-0-0"),
-            Arguments.of(THREAD_NAMING_NEW, null, "aeron-cl-cs-0"),
-            Arguments.of(THREAD_NAMING_CLASSIC, "clustered-service-override", "clustered-service-override"),
-            Arguments.of(THREAD_NAMING_NEW, "clustered-service-override", "clustered-service-override"));
-    }
-
-    @ParameterizedTest
-    @MethodSource("clusteredServiceThreadNamingModes")
-    @SuppressWarnings("try")
-    void shouldUseCorrectClusteredServiceThreadName(
-        final String threadNamingMode,
-        final String serviceNameOverride,
-        final String expectedName,
-        @TempDir final Path tmpDir)
     {
         System.setProperty(THREAD_NAMING_PROP_NAME, threadNamingMode);
         try
@@ -201,38 +141,36 @@ public class ClusterThreadNamingTest
                 .errorHandler(ClusterTests.errorHandler(0))
                 .clusterId(0)
                 .serviceId(0);
-            if (null != serviceNameOverride)
-            {
-                context.serviceName(serviceNameOverride);
-            }
 
-            try (TestMediaDriver mediaDriver = TestMediaDriver.launch(new MediaDriver.Context()
-                    .aeronDirectoryName(aeronDirectoryName)
-                    .threadingMode(ThreadingMode.SHARED)
-                    .termBufferSparseFile(true)
-                    .dirDeleteOnStart(true), null);
-                Archive archive = Archive.launch(TestContexts.localhostArchive()
-                    .aeronDirectoryName(aeronDirectoryName)
-                    .archiveDir(tmpDir.resolve("archive").toFile())
-                    .threadingMode(ArchiveThreadingMode.SHARED)
-                    .deleteArchiveOnStart(true));
-                ConsensusModule consensusModule = ConsensusModule.launch(new ConsensusModule.Context()
-                    .aeronDirectoryName(aeronDirectoryName)
-                    .clusterDir(tmpDir.resolve("cluster").toFile())
-                    .errorHandler(ClusterTests.errorHandler(0))
-                    .terminationHook(ClusterTests.NOOP_TERMINATION_HOOK)
-                    .logChannel("aeron:ipc")
-                    .replicationChannel("aeron:udp?endpoint=localhost:0")
-                    .ingressChannel("aeron:udp")
-                    .clusterMembers(LOCALHOST_SINGLE_HOST_CLUSTER_MEMBERS)
-                    .clusterId(0)
-                    .clusterMemberId(0)
-                    .deleteDirOnStart(true)))
+            try (TestMediaDriver mediaDriver = TestMediaDriver.launch(
+                    new MediaDriver.Context()
+                        .aeronDirectoryName(aeronDirectoryName)
+                        .threadingMode(ThreadingMode.SHARED)
+                        .termBufferSparseFile(true)
+                        .dirDeleteOnStart(true), null);
+                Archive archive = Archive.launch(
+                    TestContexts.localhostArchive()
+                        .aeronDirectoryName(aeronDirectoryName)
+                        .archiveDir(tmpDir.resolve("archive").toFile())
+                        .threadingMode(ArchiveThreadingMode.SHARED)
+                        .deleteArchiveOnStart(true));
+                ConsensusModule consensusModule = ConsensusModule.launch(
+                    TestContexts.localhostConsensusModule()
+                        .aeronDirectoryName(aeronDirectoryName)
+                        .clusterDir(tmpDir.resolve("cluster").toFile())
+                        .errorHandler(ClusterTests.errorHandler(0))
+                        .terminationHook(ClusterTests.NOOP_TERMINATION_HOOK)
+                        .logChannel("aeron:ipc")
+                        .replicationChannel("aeron:udp?endpoint=localhost:0")
+                        .ingressChannel("aeron:udp")
+                        .clusterId(0)
+                        .clusterMemberId(0)
+                        .deleteDirOnStart(true)))
             {
 
                 try (ClusteredServiceContainer container = ClusteredServiceContainer.launch(context))
                 {
-                    awaitThread(expectedName);
+                    awaitThreads(expectedName);
                 }
             }
         }
@@ -242,20 +180,26 @@ public class ClusterThreadNamingTest
         }
     }
 
-    private static void awaitThread(final String expectedName)
+    private static void awaitThreads(final String... expectedThreadNames)
     {
         final ThreadMXBean threadBean = getThreadMXBean();
+        final String[] sortedExpected = expectedThreadNames.clone();
+        Arrays.sort(sortedExpected);
 
         Tests.await(
             () ->
             {
                 final long[] threadIds = threadBean.getAllThreadIds();
                 final ThreadInfo[] threadInfos = threadBean.getThreadInfo(threadIds, 0);
-                return Arrays.stream(threadInfos)
+                final String[] actual = Arrays.stream(threadInfos)
                     .filter(Objects::nonNull)
                     .map(ThreadInfo::getThreadName)
-                    .anyMatch(expectedName::equals);
+                    .filter(name -> Arrays.binarySearch(sortedExpected, name) >= 0)
+                    .distinct()
+                    .sorted()
+                    .toArray(String[]::new);
+                return Arrays.equals(sortedExpected, actual);
             },
-            TimeUnit.SECONDS.toNanos(1));
+            TimeUnit.SECONDS.toNanos(5));
     }
 }

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterThreadNamingTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterThreadNamingTest.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2014-2026 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aeron.cluster;
+
+import io.aeron.archive.Archive;
+import io.aeron.archive.ArchiveThreadingMode;
+import io.aeron.cluster.service.ClusteredService;
+import io.aeron.cluster.service.ClusteredServiceContainer;
+import io.aeron.driver.MediaDriver;
+import io.aeron.driver.ThreadingMode;
+import io.aeron.test.TestContexts;
+import io.aeron.test.Tests;
+import io.aeron.test.cluster.ClusterTests;
+import io.aeron.test.cluster.StubClusteredService;
+import io.aeron.test.driver.TestMediaDriver;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import static io.aeron.CommonContext.THREAD_NAMING_CLASSIC;
+import static io.aeron.CommonContext.THREAD_NAMING_NEW;
+import static io.aeron.CommonContext.THREAD_NAMING_PROP_NAME;
+import static io.aeron.cluster.ClusterBackup.AERON_CLUSTER_BACKUP_THREAD_NAME;
+import static io.aeron.cluster.ClusterBackup.AERON_CLUSTER_BACKUP_THREAD_NAME_CLASSIC;
+import static io.aeron.cluster.ConsensusModule.AERON_CLUSTER_CONSENSUS_THREAD_NAME;
+import static io.aeron.test.TestContexts.LOCALHOST_SINGLE_HOST_CLUSTER_MEMBERS;
+import static java.lang.management.ManagementFactory.getThreadMXBean;
+
+public class ClusterThreadNamingTest
+{
+
+    private static Stream<Arguments> clusterBackupThreadNamingModes()
+    {
+        return Stream.of(
+            Arguments.of(THREAD_NAMING_CLASSIC, AERON_CLUSTER_BACKUP_THREAD_NAME_CLASSIC),
+            Arguments.of(THREAD_NAMING_NEW, AERON_CLUSTER_BACKUP_THREAD_NAME));
+    }
+
+    @ParameterizedTest
+    @MethodSource("clusterBackupThreadNamingModes")
+    @SuppressWarnings("try")
+    void shouldUseCorrectClusterBackupThreadName(
+        final String threadNamingMode, final String expectedName, @TempDir final Path tmpDir)
+    {
+        System.setProperty(THREAD_NAMING_PROP_NAME, threadNamingMode);
+        try
+        {
+            final String aeronDirectoryName = tmpDir.resolve("aeron").toString();
+            try (TestMediaDriver mediaDriver = TestMediaDriver.launch(new MediaDriver.Context()
+                    .aeronDirectoryName(aeronDirectoryName)
+                    .threadingMode(ThreadingMode.SHARED)
+                    .termBufferSparseFile(true)
+                    .dirDeleteOnStart(true), null);
+                Archive archive = Archive.launch(TestContexts.localhostArchive()
+                    .aeronDirectoryName(aeronDirectoryName)
+                    .archiveDir(tmpDir.resolve("archive").toFile())
+                    .threadingMode(ArchiveThreadingMode.SHARED)
+                    .deleteArchiveOnStart(true)))
+            {
+
+                try (ClusterBackup clusterBackup = ClusterBackup.launch(new ClusterBackup.Context()
+                    .aeronDirectoryName(aeronDirectoryName)
+                    .clusterDir(tmpDir.resolve("cluster").toFile())
+                    .errorHandler(ClusterTests.errorHandler(0))
+                    .consensusChannel("aeron:udp?endpoint=localhost:0")
+                    .clusterConsensusEndpoints("localhost:20001")
+                    .catchupEndpoint("localhost:0")
+                    .deleteDirOnStart(true)))
+                {
+                    awaitThread(expectedName);
+                }
+            }
+        }
+        finally
+        {
+            System.clearProperty(THREAD_NAMING_PROP_NAME);
+        }
+    }
+
+    private static Stream<Arguments> consensusModuleThreadNamingModes()
+    {
+        return Stream.of(
+            Arguments.of(THREAD_NAMING_CLASSIC, null, "consensus-module-0-0"),
+            Arguments.of(THREAD_NAMING_NEW, null, AERON_CLUSTER_CONSENSUS_THREAD_NAME),
+            Arguments.of(THREAD_NAMING_CLASSIC, "consensus-override", "consensus-override"),
+            Arguments.of(THREAD_NAMING_NEW, "consensus-override", "consensus-override"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("consensusModuleThreadNamingModes")
+    @SuppressWarnings("try")
+    void shouldUseCorrectConsensusModuleThreadName(
+        final String threadNamingMode,
+        final String agentRoleNameOverride,
+        final String expectedName,
+        @TempDir final Path tmpDir)
+    {
+        System.setProperty(THREAD_NAMING_PROP_NAME, threadNamingMode);
+        try
+        {
+            final String aeronDirectoryName = tmpDir.resolve("aeron").toString();
+            final ConsensusModule.Context context = TestContexts.localhostConsensusModule()
+                .aeronDirectoryName(aeronDirectoryName)
+                .clusterDir(tmpDir.resolve("cluster").toFile())
+                .errorHandler(ClusterTests.errorHandler(0))
+                .terminationHook(ClusterTests.NOOP_TERMINATION_HOOK)
+                .logChannel("aeron:ipc")
+                .replicationChannel("aeron:udp?endpoint=localhost:0")
+                .ingressChannel("aeron:udp")
+                .clusterId(0)
+                .clusterMemberId(0)
+                .deleteDirOnStart(true);
+            if (null != agentRoleNameOverride)
+            {
+                context.agentRoleName(agentRoleNameOverride);
+            }
+
+            try (TestMediaDriver mediaDriver = TestMediaDriver.launch(new MediaDriver.Context()
+                    .aeronDirectoryName(aeronDirectoryName)
+                    .threadingMode(ThreadingMode.SHARED)
+                    .termBufferSparseFile(true)
+                    .dirDeleteOnStart(true), null);
+                Archive archive = Archive.launch(TestContexts.localhostArchive()
+                    .aeronDirectoryName(aeronDirectoryName)
+                    .archiveDir(tmpDir.resolve("archive").toFile())
+                    .threadingMode(ArchiveThreadingMode.SHARED)
+                    .deleteArchiveOnStart(true));
+                ConsensusModule consensusModule = ConsensusModule.launch(context))
+            {
+
+                final ClusteredService clusteredService = new StubClusteredService();
+                try (ClusteredServiceContainer container = ClusteredServiceContainer.launch(
+                    new ClusteredServiceContainer.Context()
+                        .aeronDirectoryName(aeronDirectoryName)
+                        .clusterDir(tmpDir.resolve("cluster").toFile())
+                        .clusteredService(clusteredService)
+                        .errorHandler(ClusterTests.errorHandler(0))
+                        .clusterId(0)
+                        .serviceId(0)))
+                {
+                    awaitThread(expectedName);
+                }
+            }
+        }
+        finally
+        {
+            System.clearProperty(THREAD_NAMING_PROP_NAME);
+        }
+    }
+
+    private static Stream<Arguments> clusteredServiceThreadNamingModes()
+    {
+        return Stream.of(
+            Arguments.of(THREAD_NAMING_CLASSIC, null, "clustered-service-0-0"),
+            Arguments.of(THREAD_NAMING_NEW, null, "aeron-cl-cs-0"),
+            Arguments.of(THREAD_NAMING_CLASSIC, "clustered-service-override", "clustered-service-override"),
+            Arguments.of(THREAD_NAMING_NEW, "clustered-service-override", "clustered-service-override"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("clusteredServiceThreadNamingModes")
+    @SuppressWarnings("try")
+    void shouldUseCorrectClusteredServiceThreadName(
+        final String threadNamingMode,
+        final String serviceNameOverride,
+        final String expectedName,
+        @TempDir final Path tmpDir)
+    {
+        System.setProperty(THREAD_NAMING_PROP_NAME, threadNamingMode);
+        try
+        {
+            final String aeronDirectoryName = tmpDir.resolve("aeron").toString();
+            final ClusteredService clusteredService = new StubClusteredService();
+            final ClusteredServiceContainer.Context context = new ClusteredServiceContainer.Context()
+                .aeronDirectoryName(aeronDirectoryName)
+                .clusterDir(tmpDir.resolve("cluster").toFile())
+                .clusteredService(clusteredService)
+                .errorHandler(ClusterTests.errorHandler(0))
+                .clusterId(0)
+                .serviceId(0);
+            if (null != serviceNameOverride)
+            {
+                context.serviceName(serviceNameOverride);
+            }
+
+            try (TestMediaDriver mediaDriver = TestMediaDriver.launch(new MediaDriver.Context()
+                    .aeronDirectoryName(aeronDirectoryName)
+                    .threadingMode(ThreadingMode.SHARED)
+                    .termBufferSparseFile(true)
+                    .dirDeleteOnStart(true), null);
+                Archive archive = Archive.launch(TestContexts.localhostArchive()
+                    .aeronDirectoryName(aeronDirectoryName)
+                    .archiveDir(tmpDir.resolve("archive").toFile())
+                    .threadingMode(ArchiveThreadingMode.SHARED)
+                    .deleteArchiveOnStart(true));
+                ConsensusModule consensusModule = ConsensusModule.launch(new ConsensusModule.Context()
+                    .aeronDirectoryName(aeronDirectoryName)
+                    .clusterDir(tmpDir.resolve("cluster").toFile())
+                    .errorHandler(ClusterTests.errorHandler(0))
+                    .terminationHook(ClusterTests.NOOP_TERMINATION_HOOK)
+                    .logChannel("aeron:ipc")
+                    .replicationChannel("aeron:udp?endpoint=localhost:0")
+                    .ingressChannel("aeron:udp")
+                    .clusterMembers(LOCALHOST_SINGLE_HOST_CLUSTER_MEMBERS)
+                    .clusterId(0)
+                    .clusterMemberId(0)
+                    .deleteDirOnStart(true)))
+            {
+
+                try (ClusteredServiceContainer container = ClusteredServiceContainer.launch(context))
+                {
+                    awaitThread(expectedName);
+                }
+            }
+        }
+        finally
+        {
+            System.clearProperty(THREAD_NAMING_PROP_NAME);
+        }
+    }
+
+    private static void awaitThread(final String expectedName)
+    {
+        final ThreadMXBean threadBean = getThreadMXBean();
+
+        Tests.await(
+            () ->
+            {
+                final long[] threadIds = threadBean.getAllThreadIds();
+                final ThreadInfo[] threadInfos = threadBean.getThreadInfo(threadIds, 0);
+                return Arrays.stream(threadInfos)
+                    .filter(Objects::nonNull)
+                    .map(ThreadInfo::getThreadName)
+                    .anyMatch(expectedName::equals);
+            },
+            TimeUnit.SECONDS.toNanos(1));
+    }
+}

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
@@ -223,6 +223,8 @@ public final class TestCluster implements AutoCloseable
     private String logChannel;
     private String ingressChannel;
     private String egressChannel;
+    private String consensusModuleAgentRoleName;
+    private String clusterServiceName;
     private AuthorisationServiceSupplier authorisationServiceSupplier;
     private AuthenticatorSupplier authenticationSupplier;
     private TimerServiceSupplier timerServiceSupplier;
@@ -445,6 +447,7 @@ public final class TestCluster implements AutoCloseable
         context.extensionSupplier = extensionSupplier;
         context.errorCounterSupplier = errorCounterSupplier;
         context.snapshotCounterSupplier = snapshotCounterSupplier;
+        context.clusterServiceName = clusterServiceName;
 
         context.aeronArchiveContext
             .lock(NoOpLock.INSTANCE)
@@ -495,6 +498,7 @@ public final class TestCluster implements AutoCloseable
             .clusterDir(new File(baseDirName, "consensus-module"))
             .ingressChannel(ingressChannel)
             .logChannel(logChannel)
+            .agentRoleName(consensusModuleAgentRoleName)
             .consensusChannel(CONSENSUS_CHANNEL)
             .replicationChannel(clusterReplicationChannel(index))
             .archiveContext(context.aeronArchiveContext.clone()
@@ -754,6 +758,16 @@ public final class TestCluster implements AutoCloseable
     public void egressChannel(final String egressChannel)
     {
         this.egressChannel = egressChannel;
+    }
+
+    public void consensusModuleAgentRoleName(final String consensusModuleAgentRoleName)
+    {
+        this.consensusModuleAgentRoleName = consensusModuleAgentRoleName;
+    }
+
+    public void clusterServiceName(final String serviceName)
+    {
+        this.clusterServiceName = serviceName;
     }
 
     public void egressListener(final EgressListener egressListener)
@@ -2701,6 +2715,8 @@ public final class TestCluster implements AutoCloseable
         private String logChannel = LOG_CHANNEL;
         private String ingressChannel = INGRESS_CHANNEL;
         private String egressChannel = EGRESS_CHANNEL;
+        private String consensusModuleAgentRoleName;
+        private String clusterServiceName;
         private AuthorisationServiceSupplier authorisationServiceSupplier;
         private AuthenticatorSupplier authenticationSupplier = new DefaultAuthenticatorSupplier();
         private TimerServiceSupplier timerServiceSupplier;
@@ -2819,6 +2835,18 @@ public final class TestCluster implements AutoCloseable
         public Builder withEgressChannel(final String egressChannel)
         {
             this.egressChannel = egressChannel;
+            return this;
+        }
+
+        public Builder withConsensusModuleAgentRoleName(final String consensusModuleAgentRoleName)
+        {
+            this.consensusModuleAgentRoleName = consensusModuleAgentRoleName;
+            return this;
+        }
+
+        public Builder withClusterServiceName(final String clusterServiceName)
+        {
+            this.clusterServiceName = clusterServiceName;
             return this;
         }
 
@@ -2961,6 +2989,8 @@ public final class TestCluster implements AutoCloseable
             testCluster.logChannel(logChannel);
             testCluster.ingressChannel(ingressChannel);
             testCluster.egressChannel(egressChannel);
+            testCluster.consensusModuleAgentRoleName(consensusModuleAgentRoleName);
+            testCluster.clusterServiceName(clusterServiceName);
             testCluster.authenticationSupplier(authenticationSupplier);
             testCluster.authorisationServiceSupplier(authorisationServiceSupplier);
             testCluster.timerServiceSupplier(timerServiceSupplier);

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/TestNode.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/TestNode.java
@@ -200,7 +200,9 @@ public final class TestNode implements AutoCloseable
                     .markFileDir(context.consensusModuleContext.markFileDir())
                     .clusteredService(services[i])
                     .snapshotDurationThresholdNs(TimeUnit.MILLISECONDS.toNanos(100))
-                    .serviceName("clustered-service-" + clusterId + "-" + memberId + "-" + i)
+                    .serviceName(null != context.clusterServiceName ?
+                        context.clusterServiceName :
+                        "clustered-service-" + clusterId + "-" + memberId + "-" + i)
                     .serviceId(i);
                 containers[i] = ClusteredServiceContainer.launch(ctx);
             }
@@ -1342,6 +1344,7 @@ public final class TestNode implements AutoCloseable
         Supplier<ConsensusModuleExtension> extensionSupplier;
         Function<Aeron, Counter> errorCounterSupplier;
         Function<Aeron, Counter> snapshotCounterSupplier;
+        String clusterServiceName;
 
         Context(final TestService[] services, final String hostName, final String nodeMappings)
         {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Naming-only change with classic mode preserving existing thread names; explicit role/service name overrides are unchanged.
> 
> **Overview**
> Cluster backup, consensus module, and clustered service agents now pick their **default** `roleName`/thread labels via `CommonContext.threadName()`, using short `aeron-cl-*` names when **new** thread naming is enabled and keeping the previous names under **classic** mode.
> 
> **Consensus module** defaults move from `consensus-module-{clusterId}-{memberId}` to `aeron-cl-cm` (classic unchanged). **Cluster backup** uses `aeron-cl-bu` vs `cluster-backup`. **Clustered services** use `aeron-cl-cs-{serviceId}` vs `clustered-service-{clusterId}-{serviceId}` when `serviceName` is not set explicitly.
> 
> Adds **`ClusterThreadNamingTest`** (system property `aeron.thread.naming`) and extends **`TestCluster`** with optional consensus agent role and cluster service name overrides for those tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e57bedc98b6b47ae89b73d7f5e81b4c89c3eeb0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->