### PR TITLE
[Java] Introduce TestPropertiesUtil (from aeron-sequencer) for managing system properties in tests and use it for thread naming tests.

### DIFF
--- a/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveThreadNamingTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveThreadNamingTest.java
@@ -32,6 +32,7 @@ import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
@@ -47,6 +48,8 @@ import static io.aeron.archive.Archive.AERON_ARCHIVE_SHARED_THREAD_NAME;
 import static io.aeron.archive.Archive.AERON_ARCHIVE_SHARED_THREAD_NAME_CLASSIC;
 import static io.aeron.archive.ArchiveSystemTests.CATALOG_CAPACITY;
 import static io.aeron.archive.ArchiveSystemTests.TERM_LENGTH;
+import static io.aeron.test.TestPropertiesUtil.backupAndOverrideSystemProperties;
+import static io.aeron.test.TestPropertiesUtil.restoreSystemProperties;
 import static java.lang.management.ManagementFactory.getThreadMXBean;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
@@ -96,7 +99,9 @@ public class ArchiveThreadNamingTest
         final String threadNaming,
         final String[] expectedThreadNames)
     {
-        System.setProperty(CommonContext.THREAD_NAMING_PROP_NAME, threadNaming);
+        final Properties testProperties = new Properties();
+        testProperties.setProperty(CommonContext.THREAD_NAMING_PROP_NAME, threadNaming);
+        final Properties backup = backupAndOverrideSystemProperties(new Properties(), testProperties);
         try
         {
             final String aeronDirectoryName = CommonContext.generateRandomDirName();
@@ -146,7 +151,7 @@ public class ArchiveThreadNamingTest
         }
         finally
         {
-            System.clearProperty(CommonContext.THREAD_NAMING_PROP_NAME);
+            restoreSystemProperties(backup);
         }
     }
 }

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterThreadNamingTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterThreadNamingTest.java
@@ -42,6 +42,7 @@ import java.lang.management.ThreadMXBean;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.Properties;
 import java.util.stream.Stream;
 
 import static io.aeron.CommonContext.THREAD_NAMING_CLASSIC;
@@ -50,6 +51,8 @@ import static io.aeron.CommonContext.THREAD_NAMING_PROP_NAME;
 import static io.aeron.cluster.ClusterBackup.AERON_CLUSTER_BACKUP_THREAD_NAME;
 import static io.aeron.cluster.ClusterBackup.AERON_CLUSTER_BACKUP_THREAD_NAME_CLASSIC;
 import static io.aeron.cluster.ConsensusModule.AERON_CLUSTER_CONSENSUS_THREAD_NAME;
+import static io.aeron.test.TestPropertiesUtil.backupAndOverrideSystemProperties;
+import static io.aeron.test.TestPropertiesUtil.restoreSystemProperties;
 import static io.aeron.test.cluster.TestCluster.aCluster;
 import static java.lang.management.ManagementFactory.getThreadMXBean;
 
@@ -95,7 +98,9 @@ public class ClusterThreadNamingTest
         final String clusterServiceNameOverride,
         final String[] expectedThreadNames)
     {
-        System.setProperty(THREAD_NAMING_PROP_NAME, threadNamingMode);
+        final Properties testProperties = new Properties();
+        testProperties.setProperty(THREAD_NAMING_PROP_NAME, threadNamingMode);
+        final Properties backup = backupAndOverrideSystemProperties(new Properties(), testProperties);
         try
         {
             try (
@@ -113,7 +118,7 @@ public class ClusterThreadNamingTest
         }
         finally
         {
-            System.clearProperty(THREAD_NAMING_PROP_NAME);
+            restoreSystemProperties(backup);
         }
     }
 
@@ -131,7 +136,9 @@ public class ClusterThreadNamingTest
     void shouldUseCorrectDefaultClusteredServiceThreadNamesPerMode(
         final String threadNamingMode, final String expectedName, @TempDir final Path tmpDir)
     {
-        System.setProperty(THREAD_NAMING_PROP_NAME, threadNamingMode);
+        final Properties testProperties = new Properties();
+        testProperties.setProperty(THREAD_NAMING_PROP_NAME, threadNamingMode);
+        final Properties backup = backupAndOverrideSystemProperties(new Properties(), testProperties);
         try
         {
             final String aeronDirectoryName = tmpDir.resolve("aeron").toString();
@@ -177,7 +184,7 @@ public class ClusterThreadNamingTest
         }
         finally
         {
-            System.clearProperty(THREAD_NAMING_PROP_NAME);
+            restoreSystemProperties(backup);
         }
     }
 

--- a/aeron-system-tests/src/test/java/io/aeron/driver/MediaDriverThreadNamingTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/driver/MediaDriverThreadNamingTest.java
@@ -26,6 +26,7 @@ import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.Properties;
 import java.util.stream.Stream;
 
 import static io.aeron.CommonContext.THREAD_NAMING_CLASSIC;
@@ -40,6 +41,8 @@ import static io.aeron.driver.MediaDriver.AERON_DRIVER_SENDER_THREAD_NAME;
 import static io.aeron.driver.MediaDriver.AERON_DRIVER_SENDER_THREAD_NAME_CLASSIC;
 import static io.aeron.driver.MediaDriver.AERON_DRIVER_SHARED_NETWORK_THREAD_NAME;
 import static io.aeron.driver.MediaDriver.AERON_DRIVER_SHARED_THREAD_NAME;
+import static io.aeron.test.TestPropertiesUtil.backupAndOverrideSystemProperties;
+import static io.aeron.test.TestPropertiesUtil.restoreSystemProperties;
 import static java.lang.management.ManagementFactory.getThreadMXBean;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
@@ -116,7 +119,9 @@ public class MediaDriverThreadNamingTest
         final String[] expectedThreadNames)
     {
         TestMediaDriver.notSupportedOnCMediaDriver("the test uses JMX to check the thread names");
-        System.setProperty(THREAD_NAMING_PROP_NAME, threadNamingMode);
+        final Properties testProperties = new Properties();
+        testProperties.setProperty(THREAD_NAMING_PROP_NAME, threadNamingMode);
+        final Properties backup = backupAndOverrideSystemProperties(new Properties(), testProperties);
         try
         {
             final MediaDriver.Context context = new MediaDriver.Context()
@@ -143,7 +148,7 @@ public class MediaDriverThreadNamingTest
         }
         finally
         {
-            System.clearProperty(THREAD_NAMING_PROP_NAME);
+            restoreSystemProperties(backup);
         }
     }
 }

--- a/aeron-test-support/src/main/java/io/aeron/test/TestPropertiesUtil.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/TestPropertiesUtil.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2014-2026 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aeron.test;
+
+import java.util.Properties;
+
+/**
+ * Utility operations for handling system properties.
+ */
+public final class TestPropertiesUtil
+{
+    private TestPropertiesUtil()
+    {
+    }
+
+    /**
+     * Placeholder for a null value.
+     */
+    public static final String NULL_SENTINEL = "@null";
+
+    /**
+     * Back up the system properties in the supplied newProperties and immediately override
+     * the currently loaded ones.
+     *
+     * @param backup        to store the backed up properties to.
+     * @param newProperties to define which properties to back up and override.
+     * @return the backup properties for a fluent API.
+     */
+    public static Properties backupAndOverrideSystemProperties(final Properties backup, final Properties newProperties)
+    {
+        backupSystemProperties(backup, newProperties);
+        System.getProperties().putAll(newProperties);
+        return backup;
+    }
+
+    /**
+     * Back up the system properties specified in the supplied newProperties collection to the backup properties
+     * collection. Will track <code>null</code> values with the {@link #NULL_SENTINEL}.
+     *
+     * @param backup        To store the backed up properties to.
+     * @param newProperties To define which properties to back up.
+     * @return              the backup properties for a fluent API.
+     */
+    public static Properties backupSystemProperties(final Properties backup, final Properties newProperties)
+    {
+        for (final String key : newProperties.stringPropertyNames())
+        {
+            final String value = System.getProperty(key);
+            if (!backup.containsKey(key))
+            {
+                if (null == value)
+                {
+                    backup.setProperty(key, NULL_SENTINEL);
+                }
+                else
+                {
+                    backup.setProperty(key, System.getProperty(key));
+                }
+            }
+        }
+
+        return backup;
+    }
+
+    /**
+     * Restore the supplied properties back to the system properties.  Will track <code>null</code> values with the
+     * {@link #NULL_SENTINEL}.
+     *
+     * @param backup to restore to system properties.
+     */
+    public static void restoreSystemProperties(final Properties backup)
+    {
+        for (final String key : backup.stringPropertyNames())
+        {
+            final String value = backup.getProperty(key);
+            if (NULL_SENTINEL.equals(value))
+            {
+                System.clearProperty(key);
+            }
+            else
+            {
+                System.setProperty(key, value);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Changes
- Introduce the `TestPropertiesUtil` from aeron-sequencer
- Replace the direct system property overrides in thread naming tests with utility calls 