### PR TITLE
Add CHANGELOG information regarding thread naming change

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -9,6 +9,14 @@
 ** `aeron_image_controlled_peek` and `aeron_image_set_position`.
 ** `aeron::Image::controlledPeek` and `aeron::Image::position`.
 
+* **[Java]** Introduce more distinct Aeron-specific thread names across all modules,
+configurable via the new `aeron.thread.naming` system property:
++
+--
+** `classic`(default) - use old names (e.g. sender, conductor)
+** `new` - use new standardized names (e.g. aeron-md-snd, aeron-md-rcv)
+--
+
 === Changelog
 
 * **[Client/Java]** Remove `Image#controlledPeek` APIs.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime or API behavior changes in the diff.
> 
> **Overview**
> Documents an upcoming **1.53.0** Java change: more distinct Aeron-specific thread names across modules, controlled by the new `aeron.thread.naming` system property (`classic` keeps legacy names like `sender`/`conductor`; `new` uses names like `aeron-md-snd`/`aeron-md-rcv`).
> 
> No code changes in this PR—**CHANGELOG.adoc** only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d210910231ca017ad7341d9c990ba7dba9738bdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->