### PR TITLE
[Driver/C] Change thread names in C driver to follow newly established convention in new thread naming mode.

### DIFF
--- a/aeron-archive/src/test/c/EmbeddedMediaDriver.h
+++ b/aeron-archive/src/test/c/EmbeddedMediaDriver.h
@@ -122,6 +122,7 @@ protected:
         aeron_driver_context_set_dir_delete_on_start(m_context, true);
         aeron_driver_context_set_dir_delete_on_shutdown(m_context, true);
         aeron_driver_context_set_threading_mode(m_context, AERON_THREADING_MODE_SHARED);
+        aeron_driver_context_set_thread_naming(m_context, AERON_THREAD_NAMING_CLASSIC);
         aeron_driver_context_set_shared_idle_strategy(m_context, "sleep-ns");
         aeron_driver_context_set_term_buffer_sparse_file(m_context, true);
         aeron_driver_context_set_term_buffer_length(m_context, 64 * 1024);

--- a/aeron-driver/src/main/c/aeron_driver.c
+++ b/aeron-driver/src/main/c/aeron_driver.c
@@ -977,13 +977,36 @@ int aeron_driver_init(aeron_driver_t **driver, aeron_driver_context_t *context)
         aeron_driver_context_print_configuration(_driver->context);
     }
 
+    const char *conductor_thread_name;
+    const char *sender_thread_name;
+    const char *receiver_thread_name;
+    const char *shared_network_thread_name;
+    const char *shared_thread_name;
+    if (AERON_THREAD_NAMING_NEW == _driver->context->thread_naming)
+    {
+        conductor_thread_name = AERON_DRIVER_AGENT_ROLE_NAME_CONDUCTOR_NEW;
+        sender_thread_name = AERON_DRIVER_AGENT_ROLE_NAME_SENDER_NEW;
+        receiver_thread_name = AERON_DRIVER_AGENT_ROLE_NAME_RECEIVER_NEW;
+        shared_network_thread_name = AERON_DRIVER_AGENT_ROLE_NAME_SHARED_NETWORK_NEW;
+        shared_thread_name = AERON_DRIVER_AGENT_ROLE_NAME_SHARED_NEW;
+    }
+    else
+    {
+        conductor_thread_name = AERON_DRIVER_AGENT_ROLE_NAME_CONDUCTOR;
+        sender_thread_name = AERON_DRIVER_AGENT_ROLE_NAME_SENDER;
+        receiver_thread_name = AERON_DRIVER_AGENT_ROLE_NAME_RECEIVER;
+        shared_network_thread_name = AERON_DRIVER_AGENT_ROLE_NAME_SHARED_NETWORK;
+        shared_thread_name = AERON_DRIVER_AGENT_ROLE_NAME_SHARED;
+    }
+
+
     switch (_driver->context->threading_mode)
     {
         case AERON_THREADING_MODE_INVOKER:
         case AERON_THREADING_MODE_SHARED:
             if (aeron_agent_init(
                 &_driver->runners[AERON_AGENT_RUNNER_SHARED],
-                AERON_DRIVER_AGENT_ROLE_NAME_SHARED,
+                shared_thread_name,
                 _driver,
                 aeron_driver_shared_on_start,
                 _driver,
@@ -999,7 +1022,7 @@ int aeron_driver_init(aeron_driver_t **driver, aeron_driver_context_t *context)
         case AERON_THREADING_MODE_SHARED_NETWORK:
             if (aeron_agent_init(
                 &_driver->runners[AERON_AGENT_RUNNER_CONDUCTOR],
-                AERON_DRIVER_AGENT_ROLE_NAME_CONDUCTOR,
+                conductor_thread_name,
                 &_driver->conductor,
                 _driver->context->agent_on_start_func,
                 _driver->context->agent_on_start_state,
@@ -1027,7 +1050,7 @@ int aeron_driver_init(aeron_driver_t **driver, aeron_driver_context_t *context)
 
             if (aeron_agent_init(
                 &_driver->runners[AERON_AGENT_RUNNER_SHARED_NETWORK],
-                AERON_DRIVER_AGENT_ROLE_NAME_SHARED_NETWORK,
+                shared_network_thread_name,
                 _driver,
                 _driver->context->agent_on_start_func,
                 _driver->context->agent_on_start_state,
@@ -1044,7 +1067,7 @@ int aeron_driver_init(aeron_driver_t **driver, aeron_driver_context_t *context)
         default:
             if (aeron_agent_init(
                 &_driver->runners[AERON_AGENT_RUNNER_CONDUCTOR],
-                AERON_DRIVER_AGENT_ROLE_NAME_CONDUCTOR,
+                conductor_thread_name,
                 &_driver->conductor,
                 _driver->context->agent_on_start_func,
                 _driver->context->agent_on_start_state,
@@ -1072,7 +1095,7 @@ int aeron_driver_init(aeron_driver_t **driver, aeron_driver_context_t *context)
 
             if (aeron_agent_init(
                 &_driver->runners[AERON_AGENT_RUNNER_SENDER],
-                AERON_DRIVER_AGENT_ROLE_NAME_SENDER,
+                sender_thread_name,
                 &_driver->sender,
                 _driver->context->agent_on_start_func,
                 _driver->context->agent_on_start_state,
@@ -1086,7 +1109,7 @@ int aeron_driver_init(aeron_driver_t **driver, aeron_driver_context_t *context)
 
             if (aeron_agent_init(
                 &_driver->runners[AERON_AGENT_RUNNER_RECEIVER],
-                AERON_DRIVER_AGENT_ROLE_NAME_RECEIVER,
+                receiver_thread_name,
                 &_driver->receiver,
                 _driver->context->agent_on_start_func,
                 _driver->context->agent_on_start_state,

--- a/aeron-driver/src/main/c/aeron_driver_context.c
+++ b/aeron-driver/src/main/c/aeron_driver_context.c
@@ -3397,18 +3397,23 @@ void aeron_set_thread_affinity_on_start(void *state, const char *role_name)
     int result = 0;
     if (0 <= context->conductor_cpu_affinity_no &&
        (0 == strcmp(AERON_DRIVER_AGENT_ROLE_NAME_CONDUCTOR, role_name) ||
-        0 == strcmp(AERON_DRIVER_AGENT_ROLE_NAME_SHARED, role_name)))
+        0 == strcmp(AERON_DRIVER_AGENT_ROLE_NAME_CONDUCTOR_NEW, role_name) ||
+        0 == strcmp(AERON_DRIVER_AGENT_ROLE_NAME_SHARED, role_name) ||
+        0 == strcmp(AERON_DRIVER_AGENT_ROLE_NAME_SHARED_NEW, role_name)))
     {
         result = aeron_thread_set_affinity(role_name, (uint8_t)context->conductor_cpu_affinity_no);
     }
     else if (0 <= context->sender_cpu_affinity_no &&
             (0 == strcmp(AERON_DRIVER_AGENT_ROLE_NAME_SENDER, role_name) ||
-             0 == strcmp(AERON_DRIVER_AGENT_ROLE_NAME_SHARED_NETWORK, role_name)))
+             0 == strcmp(AERON_DRIVER_AGENT_ROLE_NAME_SENDER_NEW, role_name) ||
+             0 == strcmp(AERON_DRIVER_AGENT_ROLE_NAME_SHARED_NETWORK, role_name) ||
+             0 == strcmp(AERON_DRIVER_AGENT_ROLE_NAME_SHARED_NETWORK_NEW, role_name)))
     {
         result = aeron_thread_set_affinity(role_name, (uint8_t)context->sender_cpu_affinity_no);
     }
     else if (0 <= context->receiver_cpu_affinity_no &&
-             0 == strcmp(AERON_DRIVER_AGENT_ROLE_NAME_RECEIVER, role_name))
+             (0 == strcmp(AERON_DRIVER_AGENT_ROLE_NAME_RECEIVER, role_name) ||
+              0 == strcmp(AERON_DRIVER_AGENT_ROLE_NAME_RECEIVER_NEW, role_name)))
     {
         result = aeron_thread_set_affinity(role_name, (uint8_t)context->receiver_cpu_affinity_no);
     }

--- a/aeron-driver/src/main/c/aeron_driver_context.c
+++ b/aeron-driver/src/main/c/aeron_driver_context.c
@@ -73,6 +73,29 @@ aeron_threading_mode_t aeron_config_parse_threading_mode(const char *threading_m
     return result;
 }
 
+aeron_thread_naming_t aeron_config_parse_thread_naming(const char *thread_naming, aeron_thread_naming_t def)
+{
+    aeron_thread_naming_t result = def;
+    if (NULL != thread_naming)
+    {
+        if (strncmp(thread_naming, "classic", sizeof("classic")) == 0)
+        {
+            result = AERON_THREAD_NAMING_CLASSIC;
+        }
+        else if (strncmp(thread_naming, "new", sizeof("new")) == 0)
+        {
+            result = AERON_THREAD_NAMING_NEW;
+        }
+        else
+        {
+            aeron_config_prop_warning(AERON_THREAD_NAMING_ENV_VAR, thread_naming);
+        }
+    }
+
+    return result;
+
+}
+
 aeron_inferable_boolean_t aeron_config_parse_inferable_boolean(
     const char *inferable_boolean, aeron_inferable_boolean_t def)
 {
@@ -149,6 +172,7 @@ static void aeron_driver_untethered_subscription_state_change_null(
 
 #define AERON_DIR_WARN_IF_EXISTS_DEFAULT false
 #define AERON_THREADING_MODE_DEFAULT AERON_THREADING_MODE_DEDICATED
+#define AERON_THREAD_NAMING_DEFAULT AERON_THREAD_NAMING_CLASSIC
 #define AERON_DIR_DELETE_ON_START_DEFAULT false
 #define AERON_DIR_DELETE_ON_SHUTDOWN_DEFAULT false
 #define AERON_CLIENT_LIVENESS_TIMEOUT_NS_DEFAULT (10 * 1000 * 1000 * INT64_C(1000))
@@ -422,6 +446,8 @@ int aeron_driver_context_init(aeron_driver_context_t **context)
 
     _context->threading_mode = aeron_config_parse_threading_mode(
         getenv(AERON_THREADING_MODE_ENV_VAR), AERON_THREADING_MODE_DEFAULT);
+    _context->thread_naming = aeron_config_parse_thread_naming(
+        getenv(AERON_THREAD_NAMING_ENV_VAR), AERON_THREAD_NAMING_DEFAULT);
     _context->receiver_group_consideration = aeron_config_parse_inferable_boolean(
         getenv(AERON_RECEIVER_GROUP_CONSIDERATION_ENV_VAR), AERON_RECEIVER_GROUP_CONSIDERATION_DEFAULT);
     _context->dirs_delete_on_start = AERON_DIR_DELETE_ON_START_DEFAULT;

--- a/aeron-driver/src/main/c/aeron_driver_context.c
+++ b/aeron-driver/src/main/c/aeron_driver_context.c
@@ -1755,6 +1755,18 @@ aeron_threading_mode_t aeron_driver_context_get_threading_mode(aeron_driver_cont
     return NULL != context ? context->threading_mode : AERON_THREADING_MODE_DEFAULT;
 }
 
+int aeron_driver_context_set_thread_naming(aeron_driver_context_t *context, aeron_thread_naming_t naming)
+{
+    AERON_DRIVER_CONTEXT_SET_CHECK_ARG_AND_RETURN(-1, context);
+
+    context->thread_naming = naming;
+    return 0;
+}
+aeron_thread_naming_t aeron_driver_context_get_thread_naming(aeron_driver_context_t *context)
+{
+    return NULL != context ? context->thread_naming : AERON_THREAD_NAMING_DEFAULT;
+}
+
 int aeron_driver_context_set_dir_delete_on_start(aeron_driver_context_t *context, bool value)
 {
     AERON_DRIVER_CONTEXT_SET_CHECK_ARG_AND_RETURN(-1, context);

--- a/aeron-driver/src/main/c/aeron_driver_context.h
+++ b/aeron-driver/src/main/c/aeron_driver_context.h
@@ -41,6 +41,13 @@
 #define AERON_DRIVER_AGENT_ROLE_NAME_SHARED_NETWORK "[sender, receiver]"
 #define AERON_DRIVER_AGENT_ROLE_NAME_SHARED "[conductor, sender, receiver]"
 
+#define AERON_DRIVER_AGENT_ROLE_NAME_CONDUCTOR_NEW "aeron-md-cnd"
+#define AERON_DRIVER_AGENT_ROLE_NAME_RECEIVER_NEW "aeron-md-rcv"
+#define AERON_DRIVER_AGENT_ROLE_NAME_SENDER_NEW "aeron-md-snd"
+#define AERON_DRIVER_AGENT_ROLE_NAME_SHARED_NETWORK_NEW "aeron-md-ntw"
+#define AERON_DRIVER_AGENT_ROLE_NAME_SHARED_NEW "aeron-md-shd"
+
+
 #define AERON_COMMAND_RB_CAPACITY (128 * 1024)
 #define AERON_COMMAND_RB_RESERVE (1024)
 #define AERON_COMMAND_DRAIN_LIMIT (1)
@@ -163,6 +170,7 @@ typedef struct aeron_driver_context_stct
 {
     char aeron_dir[AERON_MAX_PATH];                         /* aeron.dir */
     aeron_threading_mode_t threading_mode;                  /* aeron.threading.mode = DEDICATED */
+    aeron_thread_naming_t thread_naming;                    /* aeron.thread.naming = classic */
     aeron_inferable_boolean_t receiver_group_consideration; /* aeron.receiver.group.consideration = INFER */
     bool dirs_delete_on_start;                              /* aeron.dir.delete.on.start = false */
     bool dirs_delete_on_shutdown;                           /* aeron.dir.delete.on.shutdown = false */

--- a/aeron-driver/src/main/c/aeronmd.c
+++ b/aeron-driver/src/main/c/aeronmd.c
@@ -157,6 +157,8 @@ int main(int argc, char **argv)
         goto cleanup;
     }
 
+    aeron_thread_set_name(driver->runners[AERON_AGENT_RUNNER_CONDUCTOR].role_name);
+
     while (is_running())
     {
         aeron_driver_main_idle_strategy(driver, aeron_driver_main_do_work(driver));

--- a/aeron-driver/src/main/c/aeronmd.h
+++ b/aeron-driver/src/main/c/aeronmd.h
@@ -65,6 +65,14 @@ aeron_threading_mode_t;
 int aeron_driver_context_set_threading_mode(aeron_driver_context_t *context, aeron_threading_mode_t mode);
 aeron_threading_mode_t aeron_driver_context_get_threading_mode(aeron_driver_context_t *context);
 
+#define AERON_THREAD_NAMING_ENV_VAR "AERON_THREAD_NAMING"
+typedef enum aeron_thread_naming_enum
+{
+    AERON_THREAD_NAMING_CLASSIC,
+    AERON_THREAD_NAMING_NEW
+}
+aeron_thread_naming_t;
+
 /**
  * Attempt to delete directories on start if they exist.
  */

--- a/aeron-driver/src/main/c/aeronmd.h
+++ b/aeron-driver/src/main/c/aeronmd.h
@@ -72,6 +72,8 @@ typedef enum aeron_thread_naming_enum
     AERON_THREAD_NAMING_NEW
 }
 aeron_thread_naming_t;
+int aeron_driver_context_set_thread_naming(aeron_driver_context_t *context, aeron_thread_naming_t naming);
+aeron_thread_naming_t aeron_driver_context_get_thread_naming(aeron_driver_context_t *context);
 
 /**
  * Attempt to delete directories on start if they exist.

--- a/aeron-driver/src/test/c/aeronmd_signal_test.cpp
+++ b/aeron-driver/src/test/c/aeronmd_signal_test.cpp
@@ -55,7 +55,7 @@ TEST_F(AeronmdSignalTest, shouldSupportSigTerm)
     aeron_close(aeron);
     aeron_context_close(context);
 
-    FILE *psgrepOutput = popen("/usr/bin/pgrep -xn aeronmd", "r");
+    FILE *psgrepOutput = popen("/usr/bin/pgrep -xn conductor", "r");
 
     char buf[1024] = {};
     if (nullptr == fgets(buf, sizeof(buf) - 1, psgrepOutput))


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Observability and affinity mapping only; default classic behavior is unchanged unless `new` is configured.
> 
> **Overview**
> Adds a **`thread_naming`** driver context option (`classic` default, `new` optional) via **`AERON_THREAD_NAMING`** and **`aeron_driver_context_set_thread_naming`**.
> 
> When set to **new**, agent threads use the **`aeron-md-*`** role names (e.g. `aeron-md-cnd`, `aeron-md-rcv`) instead of the legacy names like `conductor` and `receiver`. **`aeron_driver_init`** selects the name set per threading mode; **CPU affinity** matching in **`aeron_set_thread_affinity_on_start`** accepts both naming schemes.
> 
> **`aeronmd`** explicitly sets the conductor thread name after start. Tests pin embedded drivers to **classic** naming and adjust **pgrep** to look for **`conductor`** rather than **`aeronmd`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baca35a3a5b3a0d13b2e618e8b3e5c3a5c8e7386. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->