### PR TITLE
Fixes delay in sending the response setup message.

### DIFF
--- a/aeron-driver/src/main/c/aeron_driver_conductor.c
+++ b/aeron-driver/src/main/c/aeron_driver_conductor.c
@@ -4204,6 +4204,7 @@ aeron_driver_conductor_command_state_t aeron_driver_conductor_execute_add_networ
     {
         aeron_publication_image_set_response_session_id(
             async_command->response_publication_image, (int64_t)publication->session_id);
+        aeron_publication_image_request_next_sm_deadline_reset(async_command->response_publication_image);
     }
 
     return AERON_DRIVER_CONDUCTOR_COMMAND_STATE_DONE;

--- a/aeron-driver/src/main/c/aeron_publication_image.c
+++ b/aeron-driver/src/main/c/aeron_publication_image.c
@@ -380,6 +380,7 @@ int aeron_publication_image_create(
     _image->time_of_last_packet_ns = now_ns;
     _image->next_sm_deadline_ns = 0;
     _image->is_sm_enabled = true;
+    _image->is_next_sm_deadline_reset_requested = false;
     _image->conductor_fields.clean_position = initial_position;
     _image->conductor_fields.time_of_last_state_change_ns = now_ns;
 
@@ -756,6 +757,15 @@ int aeron_publication_image_send_pending_status_message(aeron_publication_image_
     int work_count = 0;
     int64_t change_number;
     AERON_GET_ACQUIRE(change_number, image->end_sm_change);
+
+    bool is_next_sm_deadline_reset_requested;
+    AERON_GET_ACQUIRE(is_next_sm_deadline_reset_requested, image->is_next_sm_deadline_reset_requested);
+    if (is_next_sm_deadline_reset_requested)
+    {
+        AERON_SET_RELEASE(image->is_next_sm_deadline_reset_requested, false);
+        image->next_sm_deadline_ns = now_ns - 1;
+    }
+
     const bool has_sm_timed_out = image->is_sm_enabled && image->next_sm_deadline_ns < now_ns;
 
     if (NULL != image->invalidation_reason)
@@ -1227,7 +1237,7 @@ void aeron_publication_image_on_time_event(
                 {
                     AERON_SET_RELEASE(image->is_sending_eos_sm, true);
 
-                    image->next_sm_deadline_ns = now_ns - 1;
+                    aeron_publication_image_request_next_sm_deadline_reset(image);
                 }
 
                 image->conductor_fields.state = AERON_PUBLICATION_IMAGE_STATE_LINGER;
@@ -1315,5 +1325,7 @@ extern bool aeron_publication_image_has_send_response_setup(aeron_publication_im
 
 void aeron_publication_image_set_response_session_id(
     aeron_publication_image_t *image, int64_t response_session_id);
+
+extern void aeron_publication_image_request_next_sm_deadline_reset(aeron_publication_image_t *image);
 
 extern int64_t aeron_publication_image_join_position(aeron_publication_image_t *image);

--- a/aeron-driver/src/main/c/aeron_publication_image.h
+++ b/aeron-driver/src/main/c/aeron_publication_image.h
@@ -144,6 +144,8 @@ typedef struct aeron_publication_image_stct
 
     bool is_sm_enabled;
 
+    volatile bool is_next_sm_deadline_reset_requested;
+
     volatile int64_t response_session_id;
 
     volatile bool is_end_of_stream;
@@ -349,6 +351,22 @@ inline void aeron_publication_image_set_response_session_id(
     aeron_publication_image_t *image, int64_t response_session_id)
 {
     AERON_SET_RELEASE(image->response_session_id, response_session_id);
+}
+
+/*
+ * Request that the status message deadline be expired so frames which ride the status message timer, such as a
+ * Response Setup, are sent on the next receiver duty cycle rather than waiting out the remainder of the current
+ * status message interval.
+ *
+ * The deadline itself is owned by the receiver, so only a request is recorded here and the receiver applies it in
+ * aeron_publication_image_send_pending_status_message(). The release store publishes any writes made before it,
+ * such as the response session id, to the receiver which reads this with acquire semantics.
+ *
+ * May be called from any thread.
+ */
+inline void aeron_publication_image_request_next_sm_deadline_reset(aeron_publication_image_t *image)
+{
+    AERON_SET_RELEASE(image->is_next_sm_deadline_reset_requested, true);
 }
 
 void aeron_publication_image_remove_response_session_id(aeron_publication_image_t *image);

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -2732,6 +2732,7 @@ public final class DriverConductor implements Agent
             if (null != responsePublicationImage)
             {
                 responsePublicationImage.responseSessionId(publication.sessionId());
+                responsePublicationImage.requestNextSmDeadlineReset();
             }
 
             state = State.DONE;

--- a/aeron-driver/src/main/java/io/aeron/driver/PublicationImage.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/PublicationImage.java
@@ -137,6 +137,7 @@ public final class PublicationImage
     private static final VarHandle END_SM_CHANGE_VH;
     private static final VarHandle BEGIN_LOSS_CHANGE_VH;
     private static final VarHandle END_LOSS_CHANGE_VH;
+    private static final VarHandle IS_NEXT_SM_DEADLINE_RESET_REQUESTED_VH;
 
     static
     {
@@ -151,6 +152,8 @@ public final class PublicationImage
                 .findVarHandle(PublicationImage.class, "beginLossChange", long.class);
             END_LOSS_CHANGE_VH = lookup
                 .findVarHandle(PublicationImage.class, "endLossChange", long.class);
+            IS_NEXT_SM_DEADLINE_RESET_REQUESTED_VH = lookup
+                .findVarHandle(PublicationImage.class, "isNextSmDeadlineResetRequested", boolean.class);
         }
         catch (final ReflectiveOperationException ex)
         {
@@ -167,6 +170,8 @@ public final class PublicationImage
     private long lastSmPosition;
     private long lastOverrunThreshold;
     private long nextSmDeadlineNs;
+    @SuppressWarnings("unused") // accessed via IS_NEXT_SM_DEADLINE_RESET_REQUESTED_VH
+    private boolean isNextSmDeadlineResetRequested;
     private final long smTimeoutNs;
     private final long maxReceiverWindowLength;
 
@@ -849,6 +854,13 @@ public final class PublicationImage
     {
         int workCount = 0;
         final long changeNumber = (long)END_SM_CHANGE_VH.getAcquire(this);
+
+        if ((boolean)IS_NEXT_SM_DEADLINE_RESET_REQUESTED_VH.getAcquire(this))
+        {
+            IS_NEXT_SM_DEADLINE_RESET_REQUESTED_VH.setOpaque(this, false);
+            nextSmDeadlineNs = nowNs - 1;
+        }
+
         final boolean hasSmTimedOut = smEnabled && nextSmDeadlineNs - nowNs < 0;
 
         if (null != rejectionReason)
@@ -1026,6 +1038,23 @@ public final class PublicationImage
     }
 
     /**
+     * Request that the status message deadline be expired so frames which ride the status message timer, such as a
+     * Response Setup, are sent on the next {@link Receiver} duty cycle rather than waiting out the remainder of the
+     * current status message interval.
+     * <p>
+     * The deadline itself is owned by the {@link Receiver}, so only a request is recorded here and the
+     * {@link Receiver} applies it in {@link #sendPendingStatusMessage(long)}. The release store publishes any writes
+     * made before it, such as {@link #responseSessionId(Integer)}, to the {@link Receiver} which reads this with
+     * acquire semantics.
+     * <p>
+     * May be called from any thread.
+     */
+    void requestNextSmDeadlineReset()
+    {
+        IS_NEXT_SM_DEADLINE_RESET_REQUESTED_VH.setRelease(this, true);
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override
@@ -1054,7 +1083,7 @@ public final class PublicationImage
                         isRebuilding = false;
                         isSendingEosSm = true;
 
-                        nextSmDeadlineNs = timeNs - 1;
+                        requestNextSmDeadlineReset();
                     }
 
                     conductor.transitionToLinger(this);


### PR DESCRIPTION
What happens is that the conductor sets the responseSessionId on the PublicationImage, but the receiver is the thread that builds and sends the response setup message. And it will only send it after the PublicationImage nextSmDeadlineNs expires. And that could be up to 200ms later.

And this delays finishing the connection up to 200ms.

This change does 2 things:

1) The conductor will ask the PublicationImage for a nextSmDeadline reset
   using the new requestNextSmDeadlineReset method (and its C version
   aeron_publication_image_request_next_sm_deadline_reset)

2) In the old code, there was a race condition and data race on the
   nextSmDeadlineNs. The onTimeEvent is called from the Conductor and was
   writing to this nextSmDeadlineNs directly without furter synchronization;
   this field is a plain field.

   This has now been fixed; so external threads can raise the request for
   resetting the timer by arming the isNextSmDeadlineResetRequested.
   This field is accessed using release/acquire semantics; so that solves the
   data race and race condition. And the receiver thread will eventually
   detect that the timer needs to be reset, and will then reset it. So the
   actual timer field is now only access by the receiver thread exclusively.

This fix will not bring the 200ms down to nearly zero; in my benchmarks it went down from 214 ms → 117 ms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cross-thread synchronization on the hot receiver SM path and response-connection setup; behavior change is localized but timing-sensitive for media driver correctness.
> 
> **Overview**
> **Response Setup** was gated on the receiver’s status-message timer (`nextSmDeadlineNs`), so after the conductor set `responseSessionId` the client could wait up to ~200ms before the setup frame went out.
> 
> The conductor now calls **`requestNextSmDeadlineReset()`** (C: `aeron_publication_image_request_next_sm_deadline_reset`) whenever it assigns a response session id, and uses the same path when forcing EOS SM on publication revoke instead of writing `nextSmDeadlineNs` from the conductor thread.
> 
> A new **`isNextSmDeadlineResetRequested`** flag is set with release semantics from any thread; the receiver clears it and sets `nextSmDeadlineNs = now - 1` in `sendPendingStatusMessage`, so only the receiver mutates the deadline and the prior cross-thread write race is removed. Java and C drivers are aligned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bf35b9c84f3b128ef36812e4869dc9ece747baf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->