### PR TITLE
[Java] Ensure the ClusterTool's consensus module proxy publication has connected before attempting to use it.

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusterToolOperator.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusterToolOperator.java
@@ -596,7 +596,7 @@ public class ClusterToolOperator
             final long correlationId = aeron.nextCorrelationId();
             id.set(correlationId);
 
-            while (!clusterControlAdapter.isBound() && publication.availableWindow() <= 0)
+            while (!clusterControlAdapter.isBound() || publication.availableWindow() <= 0)
             {
                 if (System.currentTimeMillis() > deadlineMs)
                 {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-operator change in ClusterTool readiness logic; reduces flaky timeouts/failed queries without altering cluster consensus behavior.
> 
> **Overview**
> Fixes a race in **`queryClusterMembers`** where ClusterTool could send a **`clusterMembersQuery`** before the **`ConsensusModuleProxy`** publication was ready.
> 
> The pre-send wait loop now keeps spinning until the control subscription is **bound** **and** **`publication.availableWindow() > 0`** (changed **`&&`** to **`||`** in the continue condition so both must be satisfied before exit). That aligns with waiting for the publication to connect, not only for the **`ClusterControlAdapter`** subscription to bind.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5903c43d6bb69c1e0a6f7dd395cd678e167f66c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->