### PR TITLE
[Archive] Skip non-VALID catalog entries in ArchiveTool dump

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveTool.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveTool.java
@@ -576,15 +576,21 @@ public final class ArchiveTool
             };
 
             catalog.forEach(
-                (recordingDescriptorOffset, headerEncoder, headerDecoder, descriptorEncoder, descriptorDecoder) -> dump(
-                out,
-                archiveDir,
-                catalog,
-                fragmentCountLimit,
-                confirmActionOnFragmentCountLimit,
-                headerDecoder,
-                descriptorDecoder,
-                fragmentHandler));
+                (recordingDescriptorOffset, headerEncoder, headerDecoder, descriptorEncoder, descriptorDecoder) ->
+                {
+                    if (headerDecoder.state() == VALID)
+                    {
+                        dump(
+                            out,
+                            archiveDir,
+                            catalog,
+                            fragmentCountLimit,
+                            confirmActionOnFragmentCountLimit,
+                            headerDecoder,
+                            descriptorDecoder,
+                            fragmentHandler);
+                    }
+                });
         }
     }
 

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveToolTests.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveToolTests.java
@@ -898,6 +898,27 @@ class ArchiveToolTests
         Mockito.verify(out).println("(recordingId=" + recordingId + ") skipping: " + skipState);
     }
 
+    @Test
+    void dumpShouldSkipRecordingsInNonValidStates()
+    {
+        try (ArchiveMarkFile markFile = new ArchiveMarkFile(
+            new File(archiveDir, ArchiveMarkFile.FILENAME), 1024 * 1024, 8096, epochClock, 0))
+        {
+            markFile.signalReady(epochClock.time()); // dump() requires a mark file; this fixture has none
+        }
+        assertFalse(verify(out, archiveDir, emptySet(), null, epochClock, (file) -> false));
+        try (Catalog catalog = openCatalogReadWrite(archiveDir, epochClock, MIN_CAPACITY, null, null))
+        {
+            assertTrue(catalog.changeState(validRecording0, DELETED));
+        }
+
+        dump(out, archiveDir, 1, (fragmentCount) -> false);
+
+        Mockito.verify(out).println("Recording " + validRecording3);
+        Mockito.verify(out, Mockito.never()).println("Recording " + validRecording0);
+        Mockito.verify(out, Mockito.never()).println("Recording " + invalidRecording0);
+    }
+
     @ParameterizedTest
     @ValueSource(longs = {-1000, Long.MAX_VALUE})
     void verifyRecordingShouldThrowExceptionIfRecordingIsUnknown(final long recordingId)


### PR DESCRIPTION
Fixes #2100.

`ArchiveTool dump` handed every catalog entry to a `RecordingReader`, so the first `DELETED`/`INVALID` tombstone (whose segment files are gone) threw `IllegalArgumentException: length must be positive` and aborted the whole run — valid recordings later in the catalog were never reached. Archives that purge recordings (e.g. snapshot rotation via `AeronArchive.purgeRecording`) accumulate such tombstones until an offline `compact`, making `dump` effectively unusable on them.

This applies the same `state() == VALID` guard that `describe` uses to `dump`'s `catalog.forEach`, so non-valid entries are skipped and the remaining recordings are dumped.

Includes a test (`ArchiveToolTests.dumpShouldSkipRecordingsInNonValidStates`) covering both a `DELETED` and an `INVALID` entry; it fails with the reported exception without the fix.

(@bantek899 — saw your comment on the issue offering to pick this up, apologies for the overlap: we hit this in production tooling and had the change ready. Hope you don't mind.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, read-only change to offline archive inspection tooling; behavior aligns with existing `describe` filtering and is covered by a focused unit test.
> 
> **Overview**
> **`ArchiveTool dump`** no longer tries to read segment data for every catalog row. Its `catalog.forEach` callback now matches **`describe`**: it only invokes the per-recording dump when `headerDecoder.state() == VALID`, so tombstoned **`DELETED`** / **`INVALID`** entries (often missing segment files) are ignored instead of aborting the whole command.
> 
> A new test marks a previously valid recording **`DELETED`**, runs `dump`, and asserts output includes a later **`VALID`** recording while omitting the deleted one and catalog **`INVALID`** entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49c417e5af172a4eee041fa3135f4bda029b53ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->