### PR TITLE
Use HTTPS for the Maven Central link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For details of usage, protocol specification, FAQ, etc., please check out the
 [Wiki](https://github.com/aeron-io/aeron/wiki).
 
 For the latest version information and changes, see the [Change Log](https://github.com/aeron-io/aeron/blob/master/CHANGELOG.adoc)
-with Java **downloads** at [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Caeron).
+with Java **downloads** at [Maven Central](https://search.maven.org/#search%7Cga%7C1%7Caeron).
 
 Aeron is owned and operated by Adaptive Financial Consulting. Originally created by Martin Thompson and Todd Montgomery, the Aeron team joined Adaptive in 2022.
 


### PR DESCRIPTION
Update the Maven Central URL in README.md from HTTP to HTTPS.

This avoids insecure navigation and matches the HTTPS links used elsewhere
in the README.

Validation:
- HTTPS URL returned HTTP 200.
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only URL change with no runtime or build impact.
> 
> **Overview**
> Updates the **Maven Central** download link in `README.md` from `http://` to `https://`, aligning it with the other HTTPS links in the document and avoiding insecure redirects when readers click through for Java artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2678a804d51703641ac1aece1d74486e2cbbe141. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->