### PR TITLE
[Java] Allow contexts to be configured from Properties instance.

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/Archive.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Archive.java
@@ -78,6 +78,7 @@ import java.nio.file.Files;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Objects;
+import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
@@ -97,6 +98,10 @@ import static io.aeron.AeronCounters.ARCHIVE_REPLAY_SESSION_COUNT_TYPE_ID;
 import static io.aeron.AeronCounters.validateCounterTypeId;
 import static io.aeron.CommonContext.ENDPOINT_PARAM_NAME;
 import static io.aeron.CommonContext.fallbackLogger;
+import static io.aeron.PropertiesUtil.getDurationInNanos;
+import static io.aeron.PropertiesUtil.getInteger;
+import static io.aeron.PropertiesUtil.getSizeAsInt;
+import static io.aeron.PropertiesUtil.getSizeAsLong;
 import static io.aeron.archive.Archive.Configuration.ERROR_BUFFER_LENGTH_DEFAULT;
 import static io.aeron.archive.Archive.Configuration.SESSION_LIVENESS_CHECK_INTERVAL_DEFAULT_NS;
 import static io.aeron.archive.Archive.Configuration.SESSION_LIVENESS_CHECK_INTERVAL_PROP_NAME;
@@ -105,14 +110,10 @@ import static io.aeron.exceptions.AeronException.Category.ERROR;
 import static io.aeron.logbuffer.LogBufferDescriptor.TERM_MAX_LENGTH;
 import static io.aeron.logbuffer.LogBufferDescriptor.TERM_MIN_LENGTH;
 import static io.aeron.logbuffer.LogBufferDescriptor.checkTermLength;
-import static java.lang.System.getProperty;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.agrona.BitUtil.CACHE_LINE_LENGTH;
 import static org.agrona.BitUtil.isPowerOfTwo;
 import static org.agrona.BufferUtil.allocateDirectAligned;
-import static org.agrona.SystemUtil.getDurationInNanos;
-import static org.agrona.SystemUtil.getSizeAsInt;
-import static org.agrona.SystemUtil.getSizeAsLong;
 import static org.agrona.SystemUtil.loadPropertiesFiles;
 
 /**
@@ -679,7 +680,18 @@ public final class Archive implements AutoCloseable
          */
         public static String archiveDirName()
         {
-            return System.getProperty(ARCHIVE_DIR_PROP_NAME, ARCHIVE_DIR_DEFAULT);
+            return archiveDirName(System.getProperties());
+        }
+
+        /**
+         * Get the directory name to be used for storing the archive.
+         *
+         * @param properties to read the configuration from.
+         * @return the directory name to be used for storing the archive.
+         */
+        public static String archiveDirName(final Properties properties)
+        {
+            return properties.getProperty(ARCHIVE_DIR_PROP_NAME, ARCHIVE_DIR_DEFAULT);
         }
 
         /**
@@ -689,7 +701,18 @@ public final class Archive implements AutoCloseable
          */
         public static String markFileDir()
         {
-            return System.getProperty(MARK_FILE_DIR_PROP_NAME);
+            return markFileDir(System.getProperties());
+        }
+
+        /**
+         * Get the alternative directory to be used for storing the archive mark file.
+         *
+         * @param properties to read the configuration from.
+         * @return the directory to be used for storing the archive mark file.
+         */
+        public static String markFileDir(final Properties properties)
+        {
+            return properties.getProperty(MARK_FILE_DIR_PROP_NAME);
         }
 
         /**
@@ -699,7 +722,18 @@ public final class Archive implements AutoCloseable
          */
         public static int fileIoMaxLength()
         {
-            return getSizeAsInt(FILE_IO_MAX_LENGTH_PROP_NAME, FILE_IO_MAX_LENGTH_DEFAULT);
+            return fileIoMaxLength(System.getProperties());
+        }
+
+        /**
+         * The maximum length of a file IO operation.
+         *
+         * @param properties to read the configuration from.
+         * @return the maximum length of a file IO operation.
+         */
+        public static int fileIoMaxLength(final Properties properties)
+        {
+            return getSizeAsInt(properties, FILE_IO_MAX_LENGTH_PROP_NAME, FILE_IO_MAX_LENGTH_DEFAULT);
         }
 
         /**
@@ -711,7 +745,20 @@ public final class Archive implements AutoCloseable
          */
         public static int segmentFileLength()
         {
-            return getSizeAsInt(SEGMENT_FILE_LENGTH_PROP_NAME, SEGMENT_FILE_LENGTH_DEFAULT);
+            return segmentFileLength(System.getProperties());
+        }
+
+        /**
+         * The length of file to be used for storing recording segments that must be a power of 2.
+         * <p>
+         * If the {@link Image#termBufferLength()} is greater than this will take priority.
+         *
+         * @param properties to read the configuration from.
+         * @return length of file to be used for storing recording segments.
+         */
+        public static int segmentFileLength(final Properties properties)
+        {
+            return getSizeAsInt(properties, SEGMENT_FILE_LENGTH_PROP_NAME, SEGMENT_FILE_LENGTH_DEFAULT);
         }
 
         /**
@@ -721,7 +768,19 @@ public final class Archive implements AutoCloseable
          */
         public static long lowStorageSpaceThreshold()
         {
-            return getSizeAsLong(LOW_STORAGE_SPACE_THRESHOLD_PROP_NAME, LOW_STORAGE_SPACE_THRESHOLD_DEFAULT);
+            return lowStorageSpaceThreshold(System.getProperties());
+        }
+
+        /**
+         * The low storage space threshold beyond which the archive will reject new requests to record streams.
+         *
+         * @param properties to read the configuration from.
+         * @return threshold beyond which the archive will reject new requests to record streams.
+         */
+        public static long lowStorageSpaceThreshold(final Properties properties)
+        {
+            return getSizeAsLong(
+                properties, LOW_STORAGE_SPACE_THRESHOLD_PROP_NAME, LOW_STORAGE_SPACE_THRESHOLD_DEFAULT);
         }
 
         /**
@@ -737,7 +796,24 @@ public final class Archive implements AutoCloseable
          */
         public static int fileSyncLevel()
         {
-            return Integer.getInteger(FILE_SYNC_LEVEL_PROP_NAME, FILE_SYNC_LEVEL_DEFAULT);
+            return fileSyncLevel(System.getProperties());
+        }
+
+        /**
+         * The level at which files should be sync'ed to disk.
+         * <ul>
+         * <li>0 - normal writes.</li>
+         * <li>1 - sync file data.</li>
+         * <li>2 - sync file data + metadata.</li>
+         * </ul>
+         *
+         * @param properties to read the configuration from.
+         * @return level at which files should be sync'ed to disk.
+         * @see #FILE_SYNC_LEVEL_PROP_NAME
+         */
+        public static int fileSyncLevel(final Properties properties)
+        {
+            return getInteger(properties, FILE_SYNC_LEVEL_PROP_NAME, FILE_SYNC_LEVEL_DEFAULT);
         }
 
         /**
@@ -753,7 +829,24 @@ public final class Archive implements AutoCloseable
          */
         public static int catalogFileSyncLevel()
         {
-            return Integer.getInteger(CATALOG_FILE_SYNC_LEVEL_PROP_NAME, CATALOG_FILE_SYNC_LEVEL_DEFAULT);
+            return catalogFileSyncLevel(System.getProperties());
+        }
+
+        /**
+         * The level at which the catalog file and directory should be sync'ed to disk.
+         * <ul>
+         * <li>0 - normal writes.</li>
+         * <li>1 - sync file data.</li>
+         * <li>2 - sync file data + metadata.</li>
+         * </ul>
+         *
+         * @param properties to read the configuration from.
+         * @return level at which files should be sync'ed to disk.
+         * @see #CATALOG_FILE_SYNC_LEVEL_PROP_NAME
+         */
+        public static int catalogFileSyncLevel(final Properties properties)
+        {
+            return getInteger(properties, CATALOG_FILE_SYNC_LEVEL_PROP_NAME, CATALOG_FILE_SYNC_LEVEL_DEFAULT);
         }
 
         /**
@@ -763,7 +856,18 @@ public final class Archive implements AutoCloseable
          */
         public static ArchiveThreadingMode threadingMode()
         {
-            return ArchiveThreadingMode.valueOf(System.getProperty(THREADING_MODE_PROP_NAME, DEDICATED.name()));
+            return threadingMode(System.getProperties());
+        }
+
+        /**
+         * The threading mode to be employed by the archive.
+         *
+         * @param properties to read the configuration from.
+         * @return the threading mode to be employed by the archive.
+         */
+        public static ArchiveThreadingMode threadingMode(final Properties properties)
+        {
+            return ArchiveThreadingMode.valueOf(properties.getProperty(THREADING_MODE_PROP_NAME, DEDICATED.name()));
         }
 
         /**
@@ -775,9 +879,22 @@ public final class Archive implements AutoCloseable
          */
         public static Supplier<IdleStrategy> idleStrategySupplier(final StatusIndicator controllableStatus)
         {
+            return idleStrategySupplier(System.getProperties(), controllableStatus);
+        }
+
+        /**
+         * Create a supplier of {@link IdleStrategy}s for the {@link #ARCHIVE_IDLE_STRATEGY_PROP_NAME} property.
+         *
+         * @param properties         to read the configuration from.
+         * @param controllableStatus if a {@link org.agrona.concurrent.ControllableIdleStrategy} is required.
+         * @return the new idle strategy {@link Supplier}.
+         */
+        public static Supplier<IdleStrategy> idleStrategySupplier(
+            final Properties properties, final StatusIndicator controllableStatus)
+        {
             return () ->
             {
-                final String name = System.getProperty(ARCHIVE_IDLE_STRATEGY_PROP_NAME, DEFAULT_IDLE_STRATEGY);
+                final String name = properties.getProperty(ARCHIVE_IDLE_STRATEGY_PROP_NAME, DEFAULT_IDLE_STRATEGY);
                 return io.aeron.driver.Configuration.agentIdleStrategy(name, controllableStatus);
             };
         }
@@ -791,7 +908,21 @@ public final class Archive implements AutoCloseable
          */
         public static Supplier<IdleStrategy> recorderIdleStrategySupplier(final StatusIndicator controllableStatus)
         {
-            final String name = System.getProperty(ARCHIVE_RECORDER_IDLE_STRATEGY_PROP_NAME);
+            return recorderIdleStrategySupplier(System.getProperties(), controllableStatus);
+        }
+
+        /**
+         * Create a supplier of {@link IdleStrategy}s for the {@link #ARCHIVE_RECORDER_IDLE_STRATEGY_PROP_NAME}
+         * property.
+         *
+         * @param properties         to read the configuration from.
+         * @param controllableStatus if a {@link org.agrona.concurrent.ControllableIdleStrategy} is required.
+         * @return the new idle strategy {@link Supplier}.
+         */
+        public static Supplier<IdleStrategy> recorderIdleStrategySupplier(
+            final Properties properties, final StatusIndicator controllableStatus)
+        {
+            final String name = properties.getProperty(ARCHIVE_RECORDER_IDLE_STRATEGY_PROP_NAME);
             if (null == name)
             {
                 return null;
@@ -809,7 +940,21 @@ public final class Archive implements AutoCloseable
          */
         public static Supplier<IdleStrategy> replayerIdleStrategySupplier(final StatusIndicator controllableStatus)
         {
-            final String name = System.getProperty(ARCHIVE_REPLAYER_IDLE_STRATEGY_PROP_NAME);
+            return replayerIdleStrategySupplier(System.getProperties(), controllableStatus);
+        }
+
+        /**
+         * Create a supplier of {@link IdleStrategy}s for the {@link #ARCHIVE_REPLAYER_IDLE_STRATEGY_PROP_NAME}
+         * property.
+         *
+         * @param properties         to read the configuration from.
+         * @param controllableStatus if a {@link org.agrona.concurrent.ControllableIdleStrategy} is required.
+         * @return the new idle strategy {@link Supplier}.
+         */
+        public static Supplier<IdleStrategy> replayerIdleStrategySupplier(
+            final Properties properties, final StatusIndicator controllableStatus)
+        {
+            final String name = properties.getProperty(ARCHIVE_REPLAYER_IDLE_STRATEGY_PROP_NAME);
             if (null == name)
             {
                 return null;
@@ -825,7 +970,18 @@ public final class Archive implements AutoCloseable
          */
         public static int maxConcurrentRecordings()
         {
-            return Integer.getInteger(MAX_CONCURRENT_RECORDINGS_PROP_NAME, MAX_CONCURRENT_RECORDINGS_DEFAULT);
+            return maxConcurrentRecordings(System.getProperties());
+        }
+
+        /**
+         * The maximum number of recordings that can operate concurrently after which new requests will be rejected.
+         *
+         * @param properties to read the configuration from.
+         * @return the maximum number of recordings that can operate concurrently.
+         */
+        public static int maxConcurrentRecordings(final Properties properties)
+        {
+            return getInteger(properties, MAX_CONCURRENT_RECORDINGS_PROP_NAME, MAX_CONCURRENT_RECORDINGS_DEFAULT);
         }
 
         /**
@@ -835,7 +991,18 @@ public final class Archive implements AutoCloseable
          */
         public static int maxConcurrentReplays()
         {
-            return Integer.getInteger(MAX_CONCURRENT_REPLAYS_PROP_NAME, MAX_CONCURRENT_REPLAYS_DEFAULT);
+            return maxConcurrentReplays(System.getProperties());
+        }
+
+        /**
+         * The maximum number of replays that can operate concurrently after which new requests will be rejected.
+         *
+         * @param properties to read the configuration from.
+         * @return the maximum number of replays that can operate concurrently.
+         */
+        public static int maxConcurrentReplays(final Properties properties)
+        {
+            return getInteger(properties, MAX_CONCURRENT_REPLAYS_PROP_NAME, MAX_CONCURRENT_REPLAYS_DEFAULT);
         }
 
         /**
@@ -848,7 +1015,21 @@ public final class Archive implements AutoCloseable
         @Deprecated
         public static long maxCatalogEntries()
         {
-            return SystemUtil.getSizeAsLong(MAX_CATALOG_ENTRIES_PROP_NAME, MAX_CATALOG_ENTRIES_DEFAULT);
+            return maxCatalogEntries(System.getProperties());
+        }
+
+        /**
+         * Maximum number of catalog entries to allocate for the catalog file.
+         *
+         * @param properties to read the configuration from.
+         * @return the maximum number of catalog entries to support for the catalog file.
+         * @see #catalogCapacity()
+         * @deprecated Use {@link #catalogCapacity()} instead.
+         */
+        @Deprecated
+        public static long maxCatalogEntries(final Properties properties)
+        {
+            return getSizeAsLong(properties, MAX_CATALOG_ENTRIES_PROP_NAME, MAX_CATALOG_ENTRIES_DEFAULT);
         }
 
         /**
@@ -858,7 +1039,18 @@ public final class Archive implements AutoCloseable
          */
         public static long catalogCapacity()
         {
-            return SystemUtil.getSizeAsLong(CATALOG_CAPACITY_PROP_NAME, CATALOG_CAPACITY_DEFAULT);
+            return catalogCapacity(System.getProperties());
+        }
+
+        /**
+         * Default capacity (size) in bytes for the catalog file.
+         *
+         * @param properties to read the configuration from.
+         * @return default size of the catalog file in bytes.
+         */
+        public static long catalogCapacity(final Properties properties)
+        {
+            return getSizeAsLong(properties, CATALOG_CAPACITY_PROP_NAME, CATALOG_CAPACITY_DEFAULT);
         }
 
         /**
@@ -869,7 +1061,19 @@ public final class Archive implements AutoCloseable
          */
         public static long connectTimeoutNs()
         {
-            return getDurationInNanos(CONNECT_TIMEOUT_PROP_NAME, CONNECT_TIMEOUT_DEFAULT_NS);
+            return connectTimeoutNs(System.getProperties());
+        }
+
+        /**
+         * The timeout in nanoseconds to wait for a connection.
+         *
+         * @param properties to read the configuration from.
+         * @return timeout in nanoseconds to wait for a connection.
+         * @see #CONNECT_TIMEOUT_PROP_NAME
+         */
+        public static long connectTimeoutNs(final Properties properties)
+        {
+            return getDurationInNanos(properties, CONNECT_TIMEOUT_PROP_NAME, CONNECT_TIMEOUT_DEFAULT_NS);
         }
 
         /**
@@ -881,7 +1085,20 @@ public final class Archive implements AutoCloseable
          */
         public static long replayLingerTimeoutNs()
         {
-            return getDurationInNanos(REPLAY_LINGER_TIMEOUT_PROP_NAME, REPLAY_LINGER_TIMEOUT_DEFAULT_NS);
+            return replayLingerTimeoutNs(System.getProperties());
+        }
+
+        /**
+         * The timeout in nanoseconds to for a replay network publication to linger after draining.
+         *
+         * @param properties to read the configuration from.
+         * @return timeout in nanoseconds for a replay network publication to wait in linger.
+         * @see #REPLAY_LINGER_TIMEOUT_PROP_NAME
+         * @see io.aeron.driver.Configuration#PUBLICATION_LINGER_PROP_NAME
+         */
+        public static long replayLingerTimeoutNs(final Properties properties)
+        {
+            return getDurationInNanos(properties, REPLAY_LINGER_TIMEOUT_PROP_NAME, REPLAY_LINGER_TIMEOUT_DEFAULT_NS);
         }
 
         /**
@@ -891,7 +1108,19 @@ public final class Archive implements AutoCloseable
          */
         public static long conductorCycleThresholdNs()
         {
-            return getDurationInNanos(CONDUCTOR_CYCLE_THRESHOLD_PROP_NAME, CONDUCTOR_CYCLE_THRESHOLD_DEFAULT_NS);
+            return conductorCycleThresholdNs(System.getProperties());
+        }
+
+        /**
+         * Get threshold value for the conductor work cycle threshold to track for being exceeded.
+         *
+         * @param properties to read the configuration from.
+         * @return threshold value in nanoseconds.
+         */
+        public static long conductorCycleThresholdNs(final Properties properties)
+        {
+            return getDurationInNanos(
+                properties, CONDUCTOR_CYCLE_THRESHOLD_PROP_NAME, CONDUCTOR_CYCLE_THRESHOLD_DEFAULT_NS);
         }
 
         /**
@@ -901,7 +1130,19 @@ public final class Archive implements AutoCloseable
          */
         public static long recorderCycleThresholdNs()
         {
-            return getDurationInNanos(RECORDER_CYCLE_THRESHOLD_PROP_NAME, RECORDER_CYCLE_THRESHOLD_DEFAULT_NS);
+            return recorderCycleThresholdNs(System.getProperties());
+        }
+
+        /**
+         * Get threshold value for the recorder work cycle threshold to track for being exceeded.
+         *
+         * @param properties to read the configuration from.
+         * @return threshold value in nanoseconds.
+         */
+        public static long recorderCycleThresholdNs(final Properties properties)
+        {
+            return getDurationInNanos(
+                properties, RECORDER_CYCLE_THRESHOLD_PROP_NAME, RECORDER_CYCLE_THRESHOLD_DEFAULT_NS);
         }
 
         /**
@@ -911,7 +1152,19 @@ public final class Archive implements AutoCloseable
          */
         public static long replayerCycleThresholdNs()
         {
-            return getDurationInNanos(REPLAYER_CYCLE_THRESHOLD_PROP_NAME, REPLAYER_CYCLE_THRESHOLD_DEFAULT_NS);
+            return replayerCycleThresholdNs(System.getProperties());
+        }
+
+        /**
+         * Get threshold value for the replayer work cycle threshold to track for being exceeded.
+         *
+         * @param properties to read the configuration from.
+         * @return threshold value in nanoseconds.
+         */
+        public static long replayerCycleThresholdNs(final Properties properties)
+        {
+            return getDurationInNanos(
+                properties, REPLAYER_CYCLE_THRESHOLD_PROP_NAME, REPLAYER_CYCLE_THRESHOLD_DEFAULT_NS);
         }
 
         /**
@@ -922,7 +1175,19 @@ public final class Archive implements AutoCloseable
          */
         public static boolean deleteArchiveOnStart()
         {
-            return "true".equals(getProperty(ARCHIVE_DIR_DELETE_ON_START_PROP_NAME, "false"));
+            return deleteArchiveOnStart(System.getProperties());
+        }
+
+        /**
+         * Whether to delete directory on start or not.
+         *
+         * @param properties to read the configuration from.
+         * @return whether to delete directory on start or not.
+         * @see #ARCHIVE_DIR_DELETE_ON_START_PROP_NAME
+         */
+        public static boolean deleteArchiveOnStart(final Properties properties)
+        {
+            return "true".equals(properties.getProperty(ARCHIVE_DIR_DELETE_ON_START_PROP_NAME, "false"));
         }
 
         /**
@@ -932,7 +1197,18 @@ public final class Archive implements AutoCloseable
          */
         public static String replicationChannel()
         {
-            return System.getProperty(REPLICATION_CHANNEL_PROP_NAME);
+            return replicationChannel(System.getProperties());
+        }
+
+        /**
+         * The system property {@link #REPLICATION_CHANNEL_PROP_NAME} if set, null otherwise.
+         *
+         * @param properties to read the configuration from.
+         * @return system property {@link #REPLICATION_CHANNEL_PROP_NAME} if set.
+         */
+        public static String replicationChannel(final Properties properties)
+        {
+            return properties.getProperty(REPLICATION_CHANNEL_PROP_NAME);
         }
 
         /**
@@ -943,7 +1219,19 @@ public final class Archive implements AutoCloseable
          */
         public static int errorBufferLength()
         {
-            return getSizeAsInt(ERROR_BUFFER_LENGTH_PROP_NAME, ERROR_BUFFER_LENGTH_DEFAULT);
+            return errorBufferLength(System.getProperties());
+        }
+
+        /**
+         * Size in bytes of the error buffer in the mark file.
+         *
+         * @param properties to read the configuration from.
+         * @return length of error buffer in bytes.
+         * @see #ERROR_BUFFER_LENGTH_PROP_NAME
+         */
+        public static int errorBufferLength(final Properties properties)
+        {
+            return getSizeAsInt(properties, ERROR_BUFFER_LENGTH_PROP_NAME, ERROR_BUFFER_LENGTH_DEFAULT);
         }
 
         /**
@@ -955,7 +1243,20 @@ public final class Archive implements AutoCloseable
          */
         public static AuthenticatorSupplier authenticatorSupplier()
         {
-            final String supplierClassName = System.getProperty(
+            return authenticatorSupplier(System.getProperties());
+        }
+
+        /**
+         * The value {@link #AUTHENTICATOR_SUPPLIER_DEFAULT} or system property
+         * {@link #AUTHENTICATOR_SUPPLIER_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #AUTHENTICATOR_SUPPLIER_DEFAULT} or system property
+         * {@link #AUTHENTICATOR_SUPPLIER_PROP_NAME} if set.
+         */
+        public static AuthenticatorSupplier authenticatorSupplier(final Properties properties)
+        {
+            final String supplierClassName = properties.getProperty(
                 AUTHENTICATOR_SUPPLIER_PROP_NAME, AUTHENTICATOR_SUPPLIER_DEFAULT);
 
             AuthenticatorSupplier supplier = null;
@@ -981,7 +1282,21 @@ public final class Archive implements AutoCloseable
          */
         public static AuthorisationServiceSupplier authorisationServiceSupplier()
         {
-            final String supplierClassName = System.getProperty(AUTHORISATION_SERVICE_SUPPLIER_PROP_NAME);
+            return authorisationServiceSupplier(System.getProperties());
+        }
+
+        /**
+         * The {@link AuthorisationServiceSupplier} specified in the
+         * {@link #AUTHORISATION_SERVICE_SUPPLIER_PROP_NAME} system property or the
+         * {@link #DEFAULT_AUTHORISATION_SERVICE_SUPPLIER}.
+         *
+         * @param properties to read the configuration from.
+         * @return system property {@link #AUTHORISATION_SERVICE_SUPPLIER_PROP_NAME} if set or
+         * {@link #DEFAULT_AUTHORISATION_SERVICE_SUPPLIER} otherwise.
+         */
+        public static AuthorisationServiceSupplier authorisationServiceSupplier(final Properties properties)
+        {
+            final String supplierClassName = properties.getProperty(AUTHORISATION_SERVICE_SUPPLIER_PROP_NAME);
             if (Strings.isEmpty(supplierClassName))
             {
                 return DEFAULT_AUTHORISATION_SERVICE_SUPPLIER;
@@ -992,7 +1307,8 @@ public final class Archive implements AutoCloseable
             }
             else if (AuthorisationService.ALLOW_ALL_NAME.equals(supplierClassName))
             {
-                fallbackLogger().println("Warning: Cluster authorisation service set to allow all requests");
+                fallbackLogger(properties).println(
+                    "Warning: Cluster authorisation service set to allow all requests");
                 return () -> AuthorisationService.ALLOW_ALL;
             }
 
@@ -1016,7 +1332,20 @@ public final class Archive implements AutoCloseable
          */
         public static String recordChecksum()
         {
-            return getProperty(RECORD_CHECKSUM_PROP_NAME);
+            return recordChecksum(System.getProperties());
+        }
+
+        /**
+         * Fully qualified class name of the {@link io.aeron.archive.checksum.Checksum} implementation to use during
+         * recording to compute checksums. Non-empty value means that checksum is enabled for recording.
+         *
+         * @param properties to read the configuration from.
+         * @return class that implements {@link io.aeron.archive.checksum.Checksum} interface
+         * @see Configuration#RECORD_CHECKSUM_PROP_NAME
+         */
+        public static String recordChecksum(final Properties properties)
+        {
+            return properties.getProperty(RECORD_CHECKSUM_PROP_NAME);
         }
 
         /**
@@ -1028,7 +1357,20 @@ public final class Archive implements AutoCloseable
          */
         public static String replayChecksum()
         {
-            return getProperty(REPLAY_CHECKSUM_PROP_NAME);
+            return replayChecksum(System.getProperties());
+        }
+
+        /**
+         * Fully qualified class name of the {@link io.aeron.archive.checksum.Checksum} implementation to use during
+         * replay for the checksum. Non-empty value means that checksum is enabled for replay.
+         *
+         * @param properties to read the configuration from.
+         * @return class that implements {@link io.aeron.archive.checksum.Checksum} interface
+         * @see Configuration#REPLAY_CHECKSUM_PROP_NAME
+         */
+        public static String replayChecksum(final Properties properties)
+        {
+            return properties.getProperty(REPLAY_CHECKSUM_PROP_NAME);
         }
 
         /**
@@ -1039,7 +1381,19 @@ public final class Archive implements AutoCloseable
          */
         public static boolean controlChannelEnabled()
         {
-            return "true".equals(System.getProperty(CONTROL_CHANNEL_ENABLED_PROP_NAME, "true"));
+            return controlChannelEnabled(System.getProperties());
+        }
+
+        /**
+         * Should the network (UDP) control channel be enabled.
+         *
+         * @param properties to read the configuration from.
+         * @return {@code true} if the network control channel to be enabled.
+         * @see #CONTROL_CHANNEL_ENABLED_PROP_NAME
+         */
+        public static boolean controlChannelEnabled(final Properties properties)
+        {
+            return "true".equals(properties.getProperty(CONTROL_CHANNEL_ENABLED_PROP_NAME, "true"));
         }
 
         /**
@@ -1050,7 +1404,19 @@ public final class Archive implements AutoCloseable
          */
         public static long archiveId()
         {
-            final String prop = getProperty(Configuration.ARCHIVE_ID_PROP_NAME);
+            return archiveId(System.getProperties());
+        }
+
+        /**
+         * Return configured id for the Archive.
+         *
+         * @param properties to read the configuration from.
+         * @return id for the Archive or {@link Aeron#NULL_VALUE}.
+         * @see #ARCHIVE_ID_PROP_NAME
+         */
+        public static long archiveId(final Properties properties)
+        {
+            final String prop = properties.getProperty(Configuration.ARCHIVE_ID_PROP_NAME);
             if (!Strings.isEmpty(prop))
             {
                 return AsciiEncoding.parseLongAscii(prop, 0, prop.length());
@@ -1081,14 +1447,15 @@ public final class Archive implements AutoCloseable
             }
         }
 
+        private final Properties properties;
         private volatile boolean isConcluded;
-        private boolean deleteArchiveOnStart = Configuration.deleteArchiveOnStart();
-        private boolean ownsAeronClient = false;
-        private String aeronDirectoryName = CommonContext.getAeronDirectoryName();
+        private boolean deleteArchiveOnStart;
+        private boolean ownsAeronClient;
+        private String aeronDirectoryName;
         private Aeron aeron;
         private File archiveDir;
         private File markFileDir;
-        private String archiveDirectoryName = Configuration.archiveDirName();
+        private String archiveDirectoryName;
         private FileChannel archiveDirChannel;
         private FileStore archiveFileStore;
         private Catalog catalog;
@@ -1096,36 +1463,35 @@ public final class Archive implements AutoCloseable
         private AeronArchive.Context archiveClientContext;
         private AgentInvoker mediaDriverAgentInvoker;
 
-        private boolean controlChannelEnabled = Configuration.controlChannelEnabled();
-        private String controlChannel = AeronArchive.Configuration.controlChannel();
-        private int controlStreamId = AeronArchive.Configuration.controlStreamId();
-        private String localControlChannel = AeronArchive.Configuration.localControlChannel();
-        private int localControlStreamId = AeronArchive.Configuration.localControlStreamId();
-        private boolean controlTermBufferSparse = AeronArchive.Configuration.controlTermBufferSparse();
-        private int controlTermBufferLength = AeronArchive.Configuration.controlTermBufferLength();
-        private int controlMtuLength = AeronArchive.Configuration.controlMtuLength();
-        private String recordingEventsChannel = AeronArchive.Configuration.recordingEventsChannel();
-        private int recordingEventsStreamId = AeronArchive.Configuration.recordingEventsStreamId();
-        private boolean recordingEventsEnabled = AeronArchive.Configuration.recordingEventsEnabled();
-        private String replicationChannel = Configuration.replicationChannel();
+        private boolean controlChannelEnabled;
+        private String controlChannel;
+        private int controlStreamId;
+        private String localControlChannel;
+        private int localControlStreamId;
+        private boolean controlTermBufferSparse;
+        private int controlTermBufferLength;
+        private int controlMtuLength;
+        private String recordingEventsChannel;
+        private int recordingEventsStreamId;
+        private boolean recordingEventsEnabled;
+        private String replicationChannel;
 
-        private long connectTimeoutNs = Configuration.connectTimeoutNs();
-        private long sessionLivenessCheckIntervalNs =
-            getDurationInNanos(SESSION_LIVENESS_CHECK_INTERVAL_PROP_NAME, SESSION_LIVENESS_CHECK_INTERVAL_DEFAULT_NS);
-        private long replayLingerTimeoutNs = Configuration.replayLingerTimeoutNs();
-        private long conductorCycleThresholdNs = Configuration.conductorCycleThresholdNs();
-        private long recorderCycleThresholdNs = Configuration.recorderCycleThresholdNs();
-        private long replayerCycleThresholdNs = Configuration.replayerCycleThresholdNs();
-        private long catalogCapacity = Configuration.catalogCapacity();
-        private long lowStorageSpaceThreshold = Configuration.lowStorageSpaceThreshold();
-        private int segmentFileLength = Configuration.segmentFileLength();
-        private int fileSyncLevel = Configuration.fileSyncLevel();
-        private int catalogFileSyncLevel = Configuration.catalogFileSyncLevel();
-        private int maxConcurrentRecordings = Configuration.maxConcurrentRecordings();
-        private int maxConcurrentReplays = Configuration.maxConcurrentReplays();
-        private int fileIoMaxLength = Configuration.fileIoMaxLength();
-        private long archiveId = Configuration.archiveId();
-        private ArchiveThreadingMode threadingMode = Configuration.threadingMode();
+        private long connectTimeoutNs;
+        private long sessionLivenessCheckIntervalNs;
+        private long replayLingerTimeoutNs;
+        private long conductorCycleThresholdNs;
+        private long recorderCycleThresholdNs;
+        private long replayerCycleThresholdNs;
+        private long catalogCapacity;
+        private long lowStorageSpaceThreshold;
+        private int segmentFileLength;
+        private int fileSyncLevel;
+        private int catalogFileSyncLevel;
+        private int maxConcurrentRecordings;
+        private int maxConcurrentReplays;
+        private int fileIoMaxLength;
+        private long archiveId;
+        private ArchiveThreadingMode threadingMode;
         private ThreadFactory threadFactory;
         private ThreadFactory recorderThreadFactory;
         private ThreadFactory replayerThreadFactory;
@@ -1141,7 +1507,7 @@ public final class Archive implements AutoCloseable
         private Counter controlSessionsCounter;
         private Counter recordingSessionCounter;
         private Counter replaySessionCounter;
-        private int errorBufferLength = Configuration.errorBufferLength();
+        private int errorBufferLength;
         private ErrorHandler errorHandler;
         private AtomicCounter errorCounter;
         private CountedErrorHandler countedErrorHandler;
@@ -1162,13 +1528,76 @@ public final class Archive implements AutoCloseable
         private Counter totalReadBytesCounter;
         private Counter totalReadTimeCounter;
         private Counter maxReadTimeCounter;
-        private String secureRandomAlgorithm = CommonContext.getSecureRandomAlgorithm();
+        private String secureRandomAlgorithm;
 
         /**
          * Construct a Context using default values and loading from system properties.
          */
         public Context()
         {
+            this(System.getProperties());
+        }
+
+        /**
+         * Construct a Context using default values loaded from the supplied properties.
+         *
+         * @param properties to load the configuration from.
+         */
+        public Context(final Properties properties)
+        {
+            this.properties = properties;
+            applyDefaults(properties);
+        }
+
+        /**
+         * The properties this context was constructed from, to be propagated to any context it
+         * creates.
+         *
+         * @return the properties this context was constructed from.
+         */
+        public Properties properties()
+        {
+            return properties;
+        }
+
+        private void applyDefaults(final Properties properties)
+        {
+            deleteArchiveOnStart = Configuration.deleteArchiveOnStart(properties);
+            ownsAeronClient = false;
+            aeronDirectoryName = CommonContext.getAeronDirectoryName(properties);
+            archiveDirectoryName = Configuration.archiveDirName(properties);
+            controlChannelEnabled = Configuration.controlChannelEnabled(properties);
+            controlChannel = AeronArchive.Configuration.controlChannel(properties);
+            controlStreamId = AeronArchive.Configuration.controlStreamId(properties);
+            localControlChannel = AeronArchive.Configuration.localControlChannel(properties);
+            localControlStreamId = AeronArchive.Configuration.localControlStreamId(properties);
+            controlTermBufferSparse = AeronArchive.Configuration.controlTermBufferSparse(properties);
+            controlTermBufferLength = AeronArchive.Configuration.controlTermBufferLength(properties);
+            controlMtuLength = AeronArchive.Configuration.controlMtuLength(properties);
+            recordingEventsChannel = AeronArchive.Configuration.recordingEventsChannel(properties);
+            recordingEventsStreamId = AeronArchive.Configuration.recordingEventsStreamId(properties);
+            recordingEventsEnabled = AeronArchive.Configuration.recordingEventsEnabled(properties);
+            replicationChannel = Configuration.replicationChannel(properties);
+
+            connectTimeoutNs = Configuration.connectTimeoutNs(properties);
+            sessionLivenessCheckIntervalNs = getDurationInNanos(
+                properties, SESSION_LIVENESS_CHECK_INTERVAL_PROP_NAME, SESSION_LIVENESS_CHECK_INTERVAL_DEFAULT_NS);
+            replayLingerTimeoutNs = Configuration.replayLingerTimeoutNs(properties);
+            conductorCycleThresholdNs = Configuration.conductorCycleThresholdNs(properties);
+            recorderCycleThresholdNs = Configuration.recorderCycleThresholdNs(properties);
+            replayerCycleThresholdNs = Configuration.replayerCycleThresholdNs(properties);
+            catalogCapacity = Configuration.catalogCapacity(properties);
+            lowStorageSpaceThreshold = Configuration.lowStorageSpaceThreshold(properties);
+            segmentFileLength = Configuration.segmentFileLength(properties);
+            fileSyncLevel = Configuration.fileSyncLevel(properties);
+            catalogFileSyncLevel = Configuration.catalogFileSyncLevel(properties);
+            maxConcurrentRecordings = Configuration.maxConcurrentRecordings(properties);
+            maxConcurrentReplays = Configuration.maxConcurrentReplays(properties);
+            fileIoMaxLength = Configuration.fileIoMaxLength(properties);
+            archiveId = Configuration.archiveId(properties);
+            threadingMode = Configuration.threadingMode(properties);
+            errorBufferLength = Configuration.errorBufferLength(properties);
+            secureRandomAlgorithm = CommonContext.getSecureRandomAlgorithm(properties);
         }
 
         /**
@@ -1241,14 +1670,14 @@ public final class Archive implements AutoCloseable
             {
                 throw new ConfigurationException(
                     "Archive.Context.recordingEventsChannel must be set if " +
-                    "Archive.Context.recordingEventsEnabled is true");
+                        "Archive.Context.recordingEventsEnabled is true");
             }
 
             if (null != mediaDriverAgentInvoker && ArchiveThreadingMode.INVOKER != threadingMode)
             {
                 throw new ConfigurationException(
                     "Archive.Context.threadingMode(ArchiveThreadingMode.INVOKER) must be set if " +
-                    "Archive.Context.mediaDriverAgentInvoker is set");
+                        "Archive.Context.mediaDriverAgentInvoker is set");
             }
 
             if (null == archiveDir)
@@ -1258,7 +1687,7 @@ public final class Archive implements AutoCloseable
 
             if (null == markFileDir)
             {
-                final String markFileDirPath = Configuration.markFileDir();
+                final String markFileDirPath = Configuration.markFileDir(properties);
                 markFileDir = !Strings.isEmpty(markFileDirPath) ? new File(markFileDirPath) : archiveDir;
             }
 
@@ -1329,6 +1758,7 @@ public final class Archive implements AutoCloseable
                 ArchiveMarkFile.LINK_FILENAME);
 
             errorHandler = CommonContext.setupErrorHandler(
+                properties,
                 errorHandler, new DistinctErrorLog(markFile.errorBuffer(), epochClock, US_ASCII));
 
             final ExpandableArrayBuffer tempBuffer = new ExpandableArrayBuffer();
@@ -1339,7 +1769,7 @@ public final class Archive implements AutoCloseable
                 ownsAeronClient = true;
 
                 aeron = Aeron.connect(
-                    new Aeron.Context()
+                    new Aeron.Context(properties)
                         .aeronDirectoryName(aeronDirectoryName)
                         .epochClock(epochClock)
                         .nanoClock(nanoClock)
@@ -1396,7 +1826,7 @@ public final class Archive implements AutoCloseable
 
             if (null == idleStrategySupplier)
             {
-                idleStrategySupplier = Configuration.idleStrategySupplier(null);
+                idleStrategySupplier = Configuration.idleStrategySupplier(properties, null);
             }
 
             if (null == conductorDutyCycleTracker)
@@ -1422,7 +1852,7 @@ public final class Archive implements AutoCloseable
             {
                 if (null == recorderIdleStrategySupplier)
                 {
-                    recorderIdleStrategySupplier = Configuration.recorderIdleStrategySupplier(null);
+                    recorderIdleStrategySupplier = Configuration.recorderIdleStrategySupplier(properties, null);
                     if (null == recorderIdleStrategySupplier)
                     {
                         recorderIdleStrategySupplier = idleStrategySupplier;
@@ -1431,7 +1861,7 @@ public final class Archive implements AutoCloseable
 
                 if (null == replayerIdleStrategySupplier)
                 {
-                    replayerIdleStrategySupplier = Configuration.replayerIdleStrategySupplier(null);
+                    replayerIdleStrategySupplier = Configuration.replayerIdleStrategySupplier(properties, null);
                     if (null == replayerIdleStrategySupplier)
                     {
                         replayerIdleStrategySupplier = idleStrategySupplier;
@@ -1488,12 +1918,12 @@ public final class Archive implements AutoCloseable
 
             if (null == authenticatorSupplier)
             {
-                authenticatorSupplier = Configuration.authenticatorSupplier();
+                authenticatorSupplier = Configuration.authenticatorSupplier(properties);
             }
 
             if (null == authorisationServiceSupplier)
             {
-                authorisationServiceSupplier = Configuration.authorisationServiceSupplier();
+                authorisationServiceSupplier = Configuration.authorisationServiceSupplier(properties);
             }
 
             concludeRecordChecksum();
@@ -1513,7 +1943,7 @@ public final class Archive implements AutoCloseable
 
             if (null == archiveClientContext)
             {
-                archiveClientContext = new AeronArchive.Context();
+                archiveClientContext = new AeronArchive.Context(properties);
             }
 
             if (null == archiveClientContext.controlResponseChannel())
@@ -1664,7 +2094,7 @@ public final class Archive implements AutoCloseable
 
             markFile.signalReady(epochClock.time());
 
-            if (CommonContext.shouldPrintConfigurationOnStart())
+            if (CommonContext.shouldPrintConfigurationOnStart(properties))
             {
                 System.out.println(this);
             }
@@ -3665,7 +4095,7 @@ public final class Archive implements AutoCloseable
         {
             if (null == recordChecksum)
             {
-                final String checksumClass = Configuration.recordChecksum();
+                final String checksumClass = Configuration.recordChecksum(properties);
                 if (!Strings.isEmpty(checksumClass))
                 {
                     recordChecksum = Checksums.newInstance(checksumClass);
@@ -3677,7 +4107,7 @@ public final class Archive implements AutoCloseable
         {
             if (null == replayChecksum)
             {
-                final String checksumClass = Configuration.replayChecksum();
+                final String checksumClass = Configuration.replayChecksum(properties);
                 if (!Strings.isEmpty(checksumClass))
                 {
                     replayChecksum = Checksums.newInstance(checksumClass);

--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveConductor.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveConductor.java
@@ -2670,7 +2670,7 @@ abstract class ArchiveConductor
     {
         //noinspection Java8CollectionRemoveIf
         for (Long2ObjectHashMap<SessionForReplay>.ValueIterator it = controlSessionByReplayToken.values().iterator();
-            it.hasNext();)
+             it.hasNext(); )
         {
             final SessionForReplay sessionForReplay = it.next();
             if (sessionForReplay.controlSession.sessionId() == sessionId)
@@ -2684,7 +2684,7 @@ abstract class ArchiveConductor
     {
         //noinspection Java8CollectionRemoveIf
         for (Long2ObjectHashMap<SessionForReplay>.ValueIterator it = controlSessionByReplayToken.values().iterator();
-            it.hasNext();)
+             it.hasNext(); )
         {
             final SessionForReplay sessionForReplay = it.next();
             if (sessionForReplay.deadlineNs <= nowNs)
@@ -2707,7 +2707,7 @@ abstract class ArchiveConductor
 
         Recorder(final CountedErrorHandler errorHandler, final Archive.Context context)
         {
-            super(threadName(
+            super(threadName(context.properties(),
                 AERON_ARCHIVE_RECORDER_THREAD_NAME, AERON_ARCHIVE_RECORDER_THREAD_NAME_CLASSIC), errorHandler);
             totalWriteBytesCounter = context.totalWriteBytesCounter();
             totalWriteTimeCounter = context.totalWriteTimeCounter();
@@ -2754,7 +2754,7 @@ abstract class ArchiveConductor
 
         Replayer(final CountedErrorHandler errorHandler, final Archive.Context context)
         {
-            super(threadName(
+            super(threadName(context.properties(),
                 AERON_ARCHIVE_REPLAYER_THREAD_NAME, AERON_ARCHIVE_REPLAYER_THREAD_NAME_CLASSIC), errorHandler);
             totalReadBytesCounter = context.totalReadBytesCounter();
             totalReadTimeCounter = context.totalReadTimeCounter();

--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveMarkFile.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveMarkFile.java
@@ -102,7 +102,8 @@ public class ArchiveMarkFile implements AutoCloseable
             alignedTotalFileLength(ctx),
             ctx.errorBufferLength(),
             ctx.epochClock(),
-            LIVENESS_TIMEOUT_MS);
+            LIVENESS_TIMEOUT_MS,
+            CommonContext.fallbackLogger(ctx.properties()));
 
         encode(ctx);
     }
@@ -113,6 +114,17 @@ public class ArchiveMarkFile implements AutoCloseable
         final int errorBufferLength,
         final EpochClock epochClock,
         final long timeoutMs)
+    {
+        this(file, totalFileLength, errorBufferLength, epochClock, timeoutMs, CommonContext.fallbackLogger());
+    }
+
+    ArchiveMarkFile(
+        final File file,
+        final int totalFileLength,
+        final int errorBufferLength,
+        final EpochClock epochClock,
+        final long timeoutMs,
+        final PrintStream fallbackLogger)
     {
         final MessageHeaderDecoder messageHeaderDecoder = new MessageHeaderDecoder();
 
@@ -148,7 +160,7 @@ public class ArchiveMarkFile implements AutoCloseable
                 final UnsafeBuffer existingErrorBuffer = new UnsafeBuffer(
                     existingBuffer, headerDecoder.headerLength(), existingErrorBufferLength);
 
-                saveExistingErrors(file, existingErrorBuffer, CommonContext.fallbackLogger());
+                saveExistingErrors(file, existingErrorBuffer, fallbackLogger);
                 existingErrorBuffer.setMemory(0, existingErrorBufferLength, (byte)0);
             }
 
@@ -452,12 +464,12 @@ public class ArchiveMarkFile implements AutoCloseable
     {
         final int headerLength =
             HEADER_OFFSET +
-            MarkFileHeaderEncoder.BLOCK_LENGTH +
-            (4 * VarAsciiEncodingEncoder.lengthEncodingLength()) +
-            (null != ctx.controlChannel() ? ctx.controlChannel().length() : 0) +
-            ctx.localControlChannel().length() +
-            (null != ctx.recordingEventsChannel() ? ctx.recordingEventsChannel().length() : 0) +
-            ctx.aeronDirectoryName().length();
+                MarkFileHeaderEncoder.BLOCK_LENGTH +
+                (4 * VarAsciiEncodingEncoder.lengthEncodingLength()) +
+                (null != ctx.controlChannel() ? ctx.controlChannel().length() : 0) +
+                ctx.localControlChannel().length() +
+                (null != ctx.recordingEventsChannel() ? ctx.recordingEventsChannel().length() : 0) +
+                ctx.aeronDirectoryName().length();
 
         if (headerLength > HEADER_LENGTH)
         {
@@ -510,7 +522,7 @@ public class ArchiveMarkFile implements AutoCloseable
         {
             throw new IllegalArgumentException(
                 "mark file (" + markFile.getAbsolutePath() + ") major version " + SemanticVersion.major(version) +
-                " does not match software: " + MAJOR_VERSION);
+                    " does not match software: " + MAJOR_VERSION);
         }
     }
 

--- a/aeron-archive/src/main/java/io/aeron/archive/DedicatedModeArchiveConductor.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/DedicatedModeArchiveConductor.java
@@ -17,7 +17,11 @@ package io.aeron.archive;
 
 import io.aeron.driver.DutyCycleTracker;
 import org.agrona.CloseHelper;
-import org.agrona.concurrent.*;
+import org.agrona.concurrent.AgentRunner;
+import org.agrona.concurrent.AgentTerminationException;
+import org.agrona.concurrent.CountedErrorHandler;
+import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
+import org.agrona.concurrent.NanoClock;
 import org.agrona.concurrent.status.AtomicCounter;
 
 import java.util.concurrent.CountDownLatch;
@@ -36,7 +40,8 @@ final class DedicatedModeArchiveConductor extends ArchiveConductor
 
     DedicatedModeArchiveConductor(final Archive.Context ctx)
     {
-        super(ctx, threadName(AERON_ARCHIVE_CONDUCTOR_THREAD_NAME, AERON_ARCHIVE_CONDUCTOR_THREAD_NAME_CLASSIC));
+        super(ctx, threadName(
+            ctx.properties(), AERON_ARCHIVE_CONDUCTOR_THREAD_NAME, AERON_ARCHIVE_CONDUCTOR_THREAD_NAME_CLASSIC));
         closeQueue = new ManyToOneConcurrentLinkedQueue<>();
     }
 

--- a/aeron-archive/src/main/java/io/aeron/archive/SharedModeArchiveConductor.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/SharedModeArchiveConductor.java
@@ -30,7 +30,8 @@ final class SharedModeArchiveConductor extends ArchiveConductor
 
     SharedModeArchiveConductor(final Archive.Context ctx)
     {
-        super(ctx, threadName(AERON_ARCHIVE_SHARED_THREAD_NAME, AERON_ARCHIVE_SHARED_THREAD_NAME_CLASSIC));
+        super(ctx, threadName(
+            ctx.properties(), AERON_ARCHIVE_SHARED_THREAD_NAME, AERON_ARCHIVE_SHARED_THREAD_NAME_CLASSIC));
     }
 
     public void onStart()

--- a/aeron-archive/src/main/java/io/aeron/archive/client/AeronArchive.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/client/AeronArchive.java
@@ -55,6 +55,7 @@ import org.agrona.concurrent.NoOpLock;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -69,13 +70,14 @@ import static io.aeron.CommonContext.SPARSE_PARAM_NAME;
 import static io.aeron.CommonContext.TERM_LENGTH_PARAM_NAME;
 import static io.aeron.CommonContext.checkDebugTimeout;
 import static io.aeron.CommonContext.getAeronDirectoryName;
+import static io.aeron.PropertiesUtil.getDurationInNanos;
+import static io.aeron.PropertiesUtil.getInteger;
+import static io.aeron.PropertiesUtil.getProperty;
+import static io.aeron.PropertiesUtil.getSizeAsInt;
 import static io.aeron.driver.Configuration.IDLE_MAX_PARK_NS;
 import static io.aeron.driver.Configuration.IDLE_MAX_SPINS;
 import static io.aeron.driver.Configuration.IDLE_MAX_YIELDS;
 import static io.aeron.driver.Configuration.IDLE_MIN_PARK_NS;
-import static org.agrona.SystemUtil.getDurationInNanos;
-import static org.agrona.SystemUtil.getProperty;
-import static org.agrona.SystemUtil.getSizeAsInt;
 
 /**
  * Client for interacting with a local or remote Aeron Archive which records and replays message streams from storage.
@@ -2349,7 +2351,7 @@ public final class AeronArchive implements AutoCloseable
         {
             throw new TimeoutException(
                 errorMessage + " - correlationId=" + correlationId + " messageTimeout=" +
-                SystemUtil.formatDuration(messageTimeoutNs));
+                    SystemUtil.formatDuration(messageTimeoutNs));
         }
 
         if (Thread.currentThread().isInterrupted())
@@ -2398,9 +2400,9 @@ public final class AeronArchive implements AutoCloseable
             state(State.DISCONNECTED);
             throw new ArchiveException(
                 "response channel from archive is not connected, " +
-                "channel=" + subscription.channel() +
-                ", streamId=" + subscription.streamId() +
-                ", imageCount=" + subscription.imageCount());
+                    "channel=" + subscription.channel() +
+                    ", streamId=" + subscription.streamId() +
+                    ", imageCount=" + subscription.imageCount());
         }
     }
 
@@ -2846,7 +2848,19 @@ public final class AeronArchive implements AutoCloseable
          */
         public static long messageTimeoutNs()
         {
-            return getDurationInNanos(MESSAGE_TIMEOUT_PROP_NAME, MESSAGE_TIMEOUT_DEFAULT_NS);
+            return messageTimeoutNs(System.getProperties());
+        }
+
+        /**
+         * The timeout in nanoseconds to wait for a message.
+         *
+         * @param properties to read the configuration from.
+         * @return timeout in nanoseconds to wait for a message.
+         * @see #MESSAGE_TIMEOUT_PROP_NAME
+         */
+        public static long messageTimeoutNs(final Properties properties)
+        {
+            return getDurationInNanos(properties, MESSAGE_TIMEOUT_PROP_NAME, MESSAGE_TIMEOUT_DEFAULT_NS);
         }
 
         /**
@@ -2857,7 +2871,19 @@ public final class AeronArchive implements AutoCloseable
          */
         public static int messageRetryAttempts()
         {
-            return Integer.getInteger(MESSAGE_RETRY_ATTEMPTS_PROP_NAME, MESSAGE_RETRY_ATTEMPTS_DEFAULT);
+            return messageRetryAttempts(System.getProperties());
+        }
+
+        /**
+         * The number of retry attempts to be made when offering messages to the archive.
+         *
+         * @param properties to read the configuration from.
+         * @return the number of retry attempts.
+         * @see #MESSAGE_RETRY_ATTEMPTS_PROP_NAME
+         */
+        public static int messageRetryAttempts(final Properties properties)
+        {
+            return getInteger(properties, MESSAGE_RETRY_ATTEMPTS_PROP_NAME, MESSAGE_RETRY_ATTEMPTS_DEFAULT);
         }
 
         /**
@@ -2868,7 +2894,19 @@ public final class AeronArchive implements AutoCloseable
          */
         public static boolean controlTermBufferSparse()
         {
-            final String propValue = System.getProperty(
+            return controlTermBufferSparse(System.getProperties());
+        }
+
+        /**
+         * Should term buffer files be sparse for control request and response streams.
+         *
+         * @param properties to read the configuration from.
+         * @return {@code true} if term buffer files should be sparse for control request and response streams.
+         * @see #CONTROL_TERM_BUFFER_SPARSE_PROP_NAME
+         */
+        public static boolean controlTermBufferSparse(final Properties properties)
+        {
+            final String propValue = properties.getProperty(
                 CONTROL_TERM_BUFFER_SPARSE_PROP_NAME, Boolean.toString(CONTROL_TERM_BUFFER_SPARSE_DEFAULT));
             return "true".equals(propValue);
         }
@@ -2881,7 +2919,19 @@ public final class AeronArchive implements AutoCloseable
          */
         public static int controlTermBufferLength()
         {
-            return getSizeAsInt(CONTROL_TERM_BUFFER_LENGTH_PROP_NAME, CONTROL_TERM_BUFFER_LENGTH_DEFAULT);
+            return controlTermBufferLength(System.getProperties());
+        }
+
+        /**
+         * Term buffer length to be used for control request and response streams.
+         *
+         * @param properties to read the configuration from.
+         * @return term buffer length to be used for control request and response streams.
+         * @see #CONTROL_TERM_BUFFER_LENGTH_PROP_NAME
+         */
+        public static int controlTermBufferLength(final Properties properties)
+        {
+            return getSizeAsInt(properties, CONTROL_TERM_BUFFER_LENGTH_PROP_NAME, CONTROL_TERM_BUFFER_LENGTH_DEFAULT);
         }
 
         /**
@@ -2892,7 +2942,19 @@ public final class AeronArchive implements AutoCloseable
          */
         public static int controlMtuLength()
         {
-            return getSizeAsInt(CONTROL_MTU_LENGTH_PROP_NAME, CONTROL_MTU_LENGTH_DEFAULT);
+            return controlMtuLength(System.getProperties());
+        }
+
+        /**
+         * MTU length to be used for control request and response streams.
+         *
+         * @param properties to read the configuration from.
+         * @return MTU length to be used for control request and response streams.
+         * @see #CONTROL_MTU_LENGTH_PROP_NAME
+         */
+        public static int controlMtuLength(final Properties properties)
+        {
+            return getSizeAsInt(properties, CONTROL_MTU_LENGTH_PROP_NAME, CONTROL_MTU_LENGTH_DEFAULT);
         }
 
         /**
@@ -2902,7 +2964,18 @@ public final class AeronArchive implements AutoCloseable
          */
         public static String controlChannel()
         {
-            return System.getProperty(CONTROL_CHANNEL_PROP_NAME);
+            return controlChannel(System.getProperties());
+        }
+
+        /**
+         * The value of system property {@link #CONTROL_CHANNEL_PROP_NAME} if set, null otherwise.
+         *
+         * @param properties to read the configuration from.
+         * @return system property {@link #CONTROL_CHANNEL_PROP_NAME} if set.
+         */
+        public static String controlChannel(final Properties properties)
+        {
+            return properties.getProperty(CONTROL_CHANNEL_PROP_NAME);
         }
 
         /**
@@ -2914,7 +2987,20 @@ public final class AeronArchive implements AutoCloseable
          */
         public static int controlStreamId()
         {
-            return Integer.getInteger(CONTROL_STREAM_ID_PROP_NAME, CONTROL_STREAM_ID_DEFAULT);
+            return controlStreamId(System.getProperties());
+        }
+
+        /**
+         * The value {@link #CONTROL_STREAM_ID_DEFAULT} or system property
+         * {@link #CONTROL_STREAM_ID_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #CONTROL_STREAM_ID_DEFAULT} or system property
+         * {@link #CONTROL_STREAM_ID_PROP_NAME} if set.
+         */
+        public static int controlStreamId(final Properties properties)
+        {
+            return getInteger(properties, CONTROL_STREAM_ID_PROP_NAME, CONTROL_STREAM_ID_DEFAULT);
         }
 
         /**
@@ -2926,7 +3012,20 @@ public final class AeronArchive implements AutoCloseable
          */
         public static String localControlChannel()
         {
-            return System.getProperty(LOCAL_CONTROL_CHANNEL_PROP_NAME, LOCAL_CONTROL_CHANNEL_DEFAULT);
+            return localControlChannel(System.getProperties());
+        }
+
+        /**
+         * The value {@link #LOCAL_CONTROL_CHANNEL_DEFAULT} or system property
+         * {@link #LOCAL_CONTROL_CHANNEL_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #LOCAL_CONTROL_CHANNEL_DEFAULT} or system property
+         * {@link #LOCAL_CONTROL_CHANNEL_PROP_NAME} if set.
+         */
+        public static String localControlChannel(final Properties properties)
+        {
+            return properties.getProperty(LOCAL_CONTROL_CHANNEL_PROP_NAME, LOCAL_CONTROL_CHANNEL_DEFAULT);
         }
 
         /**
@@ -2938,7 +3037,20 @@ public final class AeronArchive implements AutoCloseable
          */
         public static int localControlStreamId()
         {
-            return Integer.getInteger(LOCAL_CONTROL_STREAM_ID_PROP_NAME, LOCAL_CONTROL_STREAM_ID_DEFAULT);
+            return localControlStreamId(System.getProperties());
+        }
+
+        /**
+         * The value {@link #LOCAL_CONTROL_STREAM_ID_DEFAULT} or system property
+         * {@link #LOCAL_CONTROL_STREAM_ID_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #LOCAL_CONTROL_STREAM_ID_DEFAULT} or system property
+         * {@link #LOCAL_CONTROL_STREAM_ID_PROP_NAME} if set.
+         */
+        public static int localControlStreamId(final Properties properties)
+        {
+            return getInteger(properties, LOCAL_CONTROL_STREAM_ID_PROP_NAME, LOCAL_CONTROL_STREAM_ID_DEFAULT);
         }
 
         /**
@@ -2948,7 +3060,18 @@ public final class AeronArchive implements AutoCloseable
          */
         public static String controlResponseChannel()
         {
-            return System.getProperty(CONTROL_RESPONSE_CHANNEL_PROP_NAME);
+            return controlResponseChannel(System.getProperties());
+        }
+
+        /**
+         * The value of system property {@link #CONTROL_RESPONSE_CHANNEL_PROP_NAME} if set, null otherwise.
+         *
+         * @param properties to read the configuration from.
+         * @return of system property {@link #CONTROL_RESPONSE_CHANNEL_PROP_NAME} if set.
+         */
+        public static String controlResponseChannel(final Properties properties)
+        {
+            return properties.getProperty(CONTROL_RESPONSE_CHANNEL_PROP_NAME);
         }
 
         /**
@@ -2960,7 +3083,20 @@ public final class AeronArchive implements AutoCloseable
          */
         public static int controlResponseStreamId()
         {
-            return Integer.getInteger(CONTROL_RESPONSE_STREAM_ID_PROP_NAME, CONTROL_RESPONSE_STREAM_ID_DEFAULT);
+            return controlResponseStreamId(System.getProperties());
+        }
+
+        /**
+         * The value {@link #CONTROL_RESPONSE_STREAM_ID_DEFAULT} or system property
+         * {@link #CONTROL_RESPONSE_STREAM_ID_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #CONTROL_RESPONSE_STREAM_ID_DEFAULT} or system property
+         * {@link #CONTROL_RESPONSE_STREAM_ID_PROP_NAME} if set.
+         */
+        public static int controlResponseStreamId(final Properties properties)
+        {
+            return getInteger(properties, CONTROL_RESPONSE_STREAM_ID_PROP_NAME, CONTROL_RESPONSE_STREAM_ID_DEFAULT);
         }
 
         /**
@@ -2970,7 +3106,18 @@ public final class AeronArchive implements AutoCloseable
          */
         public static String recordingEventsChannel()
         {
-            return System.getProperty(RECORDING_EVENTS_CHANNEL_PROP_NAME);
+            return recordingEventsChannel(System.getProperties());
+        }
+
+        /**
+         * The value of system property {@link #RECORDING_EVENTS_CHANNEL_PROP_NAME} if set, null otherwise.
+         *
+         * @param properties to read the configuration from.
+         * @return system property {@link #RECORDING_EVENTS_CHANNEL_PROP_NAME} if set.
+         */
+        public static String recordingEventsChannel(final Properties properties)
+        {
+            return properties.getProperty(RECORDING_EVENTS_CHANNEL_PROP_NAME);
         }
 
         /**
@@ -2982,7 +3129,20 @@ public final class AeronArchive implements AutoCloseable
          */
         public static int recordingEventsStreamId()
         {
-            return Integer.getInteger(RECORDING_EVENTS_STREAM_ID_PROP_NAME, RECORDING_EVENTS_STREAM_ID_DEFAULT);
+            return recordingEventsStreamId(System.getProperties());
+        }
+
+        /**
+         * The value {@link #RECORDING_EVENTS_STREAM_ID_DEFAULT} or system property
+         * {@link #RECORDING_EVENTS_STREAM_ID_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #RECORDING_EVENTS_STREAM_ID_DEFAULT} or system property
+         * {@link #RECORDING_EVENTS_STREAM_ID_PROP_NAME} if set.
+         */
+        public static int recordingEventsStreamId(final Properties properties)
+        {
+            return getInteger(properties, RECORDING_EVENTS_STREAM_ID_PROP_NAME, RECORDING_EVENTS_STREAM_ID_DEFAULT);
         }
 
         /**
@@ -2993,7 +3153,19 @@ public final class AeronArchive implements AutoCloseable
          */
         public static boolean recordingEventsEnabled()
         {
-            final String propValue = System.getProperty(
+            return recordingEventsEnabled(System.getProperties());
+        }
+
+        /**
+         * Should the recording events stream be enabled.
+         *
+         * @param properties to read the configuration from.
+         * @return {@code true} if the recording events stream be enabled.
+         * @see #RECORDING_EVENTS_ENABLED_PROP_NAME
+         */
+        public static boolean recordingEventsEnabled(final Properties properties)
+        {
+            final String propValue = properties.getProperty(
                 RECORDING_EVENTS_ENABLED_PROP_NAME, Boolean.toString(RECORDING_EVENTS_ENABLED_DEFAULT));
             return "true".equals(propValue);
         }
@@ -3007,7 +3179,20 @@ public final class AeronArchive implements AutoCloseable
          */
         public static String clientName()
         {
-            return getProperty(CLIENT_NAME_PROP_NAME, "");
+            return clientName(System.getProperties());
+        }
+
+        /**
+         * Get the configured client name.
+         *
+         * @param properties to read the configuration from.
+         * @return specified client name or empty string if not set.
+         * @see #CLIENT_NAME_PROP_NAME
+         * @since 1.49.0
+         */
+        public static String clientName(final Properties properties)
+        {
+            return getProperty(properties, CLIENT_NAME_PROP_NAME, "");
         }
     }
 
@@ -3033,34 +3218,77 @@ public final class AeronArchive implements AutoCloseable
             }
         }
 
+        private final Properties properties;
         private volatile boolean isConcluded;
-        private long messageTimeoutNs = Configuration.messageTimeoutNs();
-        private int messageRetryAttempts = Configuration.messageRetryAttempts();
-        private String clientName = AeronArchive.Configuration.clientName();
-        private String recordingEventsChannel = AeronArchive.Configuration.recordingEventsChannel();
-        private int recordingEventsStreamId = AeronArchive.Configuration.recordingEventsStreamId();
-        private String controlRequestChannel = Configuration.controlChannel();
-        private int controlRequestStreamId = Configuration.controlStreamId();
-        private String controlResponseChannel = Configuration.controlResponseChannel();
-        private int controlResponseStreamId = Configuration.controlResponseStreamId();
-        private boolean controlTermBufferSparse = Configuration.controlTermBufferSparse();
-        private int controlTermBufferLength = Configuration.controlTermBufferLength();
-        private int controlMtuLength = Configuration.controlMtuLength();
+        private long messageTimeoutNs;
+        private int messageRetryAttempts;
+        private String clientName;
+        private String recordingEventsChannel;
+        private int recordingEventsStreamId;
+        private String controlRequestChannel;
+        private int controlRequestStreamId;
+        private String controlResponseChannel;
+        private int controlResponseStreamId;
+        private boolean controlTermBufferSparse;
+        private int controlTermBufferLength;
+        private int controlMtuLength;
         private IdleStrategy idleStrategy;
         private Lock lock;
-        private String aeronDirectoryName = getAeronDirectoryName();
+        private String aeronDirectoryName;
         private Aeron aeron;
         private ErrorHandler errorHandler;
         private CredentialsSupplier credentialsSupplier;
-        private RecordingSignalConsumer recordingSignalConsumer = Configuration.NO_OP_RECORDING_SIGNAL_CONSUMER;
+        private RecordingSignalConsumer recordingSignalConsumer;
         private AgentInvoker agentInvoker;
-        private boolean ownsAeronClient = false;
+        private boolean ownsAeronClient;
 
         /**
          * Construct a Context using default values and loading from system properties.
          */
         public Context()
         {
+            this(System.getProperties());
+        }
+
+        /**
+         * Construct a Context using default values loaded from the supplied properties.
+         *
+         * @param properties to load the configuration from.
+         */
+        public Context(final Properties properties)
+        {
+            this.properties = properties;
+            applyDefaults(properties);
+        }
+
+        /**
+         * The properties this context was constructed from, to be propagated to any context it
+         * creates.
+         *
+         * @return the properties this context was constructed from.
+         */
+        public Properties properties()
+        {
+            return properties;
+        }
+
+        private void applyDefaults(final Properties properties)
+        {
+            messageTimeoutNs = Configuration.messageTimeoutNs(properties);
+            messageRetryAttempts = Configuration.messageRetryAttempts(properties);
+            clientName = AeronArchive.Configuration.clientName(properties);
+            recordingEventsChannel = AeronArchive.Configuration.recordingEventsChannel(properties);
+            recordingEventsStreamId = AeronArchive.Configuration.recordingEventsStreamId(properties);
+            controlRequestChannel = Configuration.controlChannel(properties);
+            controlRequestStreamId = Configuration.controlStreamId(properties);
+            controlResponseChannel = Configuration.controlResponseChannel(properties);
+            controlResponseStreamId = Configuration.controlResponseStreamId(properties);
+            controlTermBufferSparse = Configuration.controlTermBufferSparse(properties);
+            controlTermBufferLength = Configuration.controlTermBufferLength(properties);
+            controlMtuLength = Configuration.controlMtuLength(properties);
+            aeronDirectoryName = getAeronDirectoryName(properties);
+            recordingSignalConsumer = Configuration.NO_OP_RECORDING_SIGNAL_CONSUMER;
+            ownsAeronClient = false;
         }
 
         /**
@@ -3115,7 +3343,7 @@ public final class AeronArchive implements AutoCloseable
             if (null == aeron)
             {
                 aeron = Aeron.connect(
-                    new Aeron.Context()
+                    new Aeron.Context(properties)
                         .aeronDirectoryName(aeronDirectoryName)
                         .clientName(clientName.isEmpty() ? "archive-client" : clientName)
                         .errorHandler(errorHandler)
@@ -3183,7 +3411,7 @@ public final class AeronArchive implements AutoCloseable
         @Config
         public long messageTimeoutNs()
         {
-            return checkDebugTimeout(messageTimeoutNs, TimeUnit.NANOSECONDS);
+            return checkDebugTimeout(properties, messageTimeoutNs, TimeUnit.NANOSECONDS);
         }
 
         /**
@@ -3977,11 +4205,11 @@ public final class AeronArchive implements AutoCloseable
             {
                 throw new TimeoutException(
                     "Archive connect timeout: step=" + state +
-                    " publication=" +
-                    (null != archiveProxy ? archiveProxy.publication() : ctx.controlRequestChannel()) +
-                    " subscription=" +
-                    (null != controlResponsePoller ? controlResponsePoller.subscription() :
-                        ctx.controlResponseChannel()));
+                        " publication=" +
+                        (null != archiveProxy ? archiveProxy.publication() : ctx.controlRequestChannel()) +
+                        " subscription=" +
+                        (null != controlResponsePoller ? controlResponsePoller.subscription() :
+                            ctx.controlResponseChannel()));
             }
 
             if (Thread.currentThread().isInterrupted())

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveContextPropertiesTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveContextPropertiesTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2014-2025 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.archive;
+
+import io.aeron.CommonContext;
+import io.aeron.archive.client.AeronArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import static io.aeron.CommonContext.AERON_DIR_PROP_NAME;
+import static io.aeron.archive.Archive.Configuration.ARCHIVE_DIR_PROP_NAME;
+import static io.aeron.archive.Archive.Configuration.ARCHIVE_ID_PROP_NAME;
+import static io.aeron.archive.Archive.Configuration.MAX_CONCURRENT_RECORDINGS_PROP_NAME;
+import static io.aeron.archive.Archive.Configuration.SEGMENT_FILE_LENGTH_PROP_NAME;
+import static io.aeron.archive.Archive.Configuration.THREADING_MODE_PROP_NAME;
+import static io.aeron.archive.client.AeronArchive.Configuration.CONTROL_CHANNEL_PROP_NAME;
+import static io.aeron.archive.client.AeronArchive.Configuration.MESSAGE_TIMEOUT_PROP_NAME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class ArchiveContextPropertiesTest
+{
+    @AfterEach
+    void tearDown()
+    {
+        System.clearProperty(ARCHIVE_DIR_PROP_NAME);
+        System.clearProperty(SEGMENT_FILE_LENGTH_PROP_NAME);
+    }
+
+    @Test
+    void suppliedPropertiesConfigureTheArchiveContext()
+    {
+        final Properties properties = new Properties();
+        properties.setProperty(AERON_DIR_PROP_NAME, "/tmp/aeron-a");
+        properties.setProperty(ARCHIVE_DIR_PROP_NAME, "/tmp/archive-a");
+        properties.setProperty(SEGMENT_FILE_LENGTH_PROP_NAME, "256k");
+        properties.setProperty(MAX_CONCURRENT_RECORDINGS_PROP_NAME, "7");
+        properties.setProperty(ARCHIVE_ID_PROP_NAME, "42");
+        properties.setProperty(THREADING_MODE_PROP_NAME, ArchiveThreadingMode.SHARED.name());
+
+        final Archive.Context context = new Archive.Context(properties);
+
+        assertSame(properties, context.properties());
+        assertEquals("/tmp/aeron-a", context.aeronDirectoryName());
+        assertEquals("/tmp/archive-a", context.archiveDirectoryName());
+        assertEquals(256 * 1024, context.segmentFileLength());
+        assertEquals(7, context.maxConcurrentRecordings());
+        assertEquals(42, context.archiveId());
+        assertEquals(ArchiveThreadingMode.SHARED, context.threadingMode());
+    }
+
+    @Test
+    void twoArchiveContextsFromDifferentPropertiesAreIndependent()
+    {
+        final Properties a = new Properties();
+        a.setProperty(ARCHIVE_DIR_PROP_NAME, "/tmp/archive-a");
+        a.setProperty(SEGMENT_FILE_LENGTH_PROP_NAME, "128k");
+
+        final Properties b = new Properties();
+        b.setProperty(ARCHIVE_DIR_PROP_NAME, "/tmp/archive-b");
+        b.setProperty(SEGMENT_FILE_LENGTH_PROP_NAME, "256k");
+
+        final Archive.Context contextA = new Archive.Context(a);
+        final Archive.Context contextB = new Archive.Context(b);
+
+        assertEquals("/tmp/archive-a", contextA.archiveDirectoryName());
+        assertEquals("/tmp/archive-b", contextB.archiveDirectoryName());
+        assertEquals(128 * 1024, contextA.segmentFileLength());
+        assertEquals(256 * 1024, contextB.segmentFileLength());
+        assertNotEquals(contextA.archiveDirectoryName(), contextB.archiveDirectoryName());
+    }
+
+    @Test
+    void suppliedPropertiesShadowSystemPropertiesAndAreNotWrittenBackToThem()
+    {
+        System.setProperty(SEGMENT_FILE_LENGTH_PROP_NAME, "64k");
+
+        final Properties properties = new Properties();
+        properties.setProperty(SEGMENT_FILE_LENGTH_PROP_NAME, "512k");
+
+        assertEquals(512 * 1024, new Archive.Context(properties).segmentFileLength());
+        assertEquals(64 * 1024, new Archive.Context().segmentFileLength());
+        assertEquals("64k", System.getProperty(SEGMENT_FILE_LENGTH_PROP_NAME));
+    }
+
+    @Test
+    void emptyPropertiesYieldTheDocumentedDefaults()
+    {
+        final Archive.Context context = new Archive.Context(new Properties());
+
+        assertEquals(Archive.Configuration.SEGMENT_FILE_LENGTH_DEFAULT, context.segmentFileLength());
+        assertEquals(Archive.Configuration.MAX_CONCURRENT_RECORDINGS_DEFAULT, context.maxConcurrentRecordings());
+        assertEquals(CommonContext.AERON_DIR_PROP_DEFAULT, context.aeronDirectoryName());
+    }
+
+    @Test
+    void suppliedPropertiesConfigureTheAeronArchiveClientContext()
+    {
+        final Properties properties = new Properties();
+        properties.setProperty(AERON_DIR_PROP_NAME, "/tmp/aeron-a");
+        properties.setProperty(CONTROL_CHANNEL_PROP_NAME, "aeron:udp?endpoint=localhost:9999");
+        properties.setProperty(MESSAGE_TIMEOUT_PROP_NAME, "3s");
+
+        final AeronArchive.Context context = new AeronArchive.Context(properties);
+
+        assertSame(properties, context.properties());
+        assertEquals("/tmp/aeron-a", context.aeronDirectoryName());
+        assertEquals("aeron:udp?endpoint=localhost:9999", context.controlRequestChannel());
+        assertEquals(TimeUnit.SECONDS.toNanos(3), context.messageTimeoutNs());
+    }
+
+    @Test
+    void archiveContextPropagatesItsPropertiesToTheArchiveClientContextItCreates()
+    {
+        final Properties properties = new Properties();
+        properties.setProperty(CONTROL_CHANNEL_PROP_NAME, "aeron:udp?endpoint=localhost:8888");
+
+        final Archive.Context context = new Archive.Context(properties);
+        context.archiveClientContext(new AeronArchive.Context(context.properties()));
+
+        assertSame(properties, context.archiveClientContext().properties());
+        assertEquals("aeron:udp?endpoint=localhost:8888", context.archiveClientContext().controlRequestChannel());
+    }
+}

--- a/aeron-client/src/main/java/io/aeron/Aeron.java
+++ b/aeron-client/src/main/java/io/aeron/Aeron.java
@@ -54,14 +54,15 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.nio.ByteBuffer;
 import java.util.Objects;
+import java.util.Properties;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static io.aeron.Aeron.Configuration.MAX_CLIENT_NAME_LENGTH;
-import static org.agrona.SystemUtil.getDurationInNanos;
-import static org.agrona.SystemUtil.getProperty;
+import static io.aeron.PropertiesUtil.getDurationInNanos;
+import static io.aeron.PropertiesUtil.getProperty;
 
 /**
  * Aeron entry point for communicating to the Media Driver for creating {@link Publication}s and {@link Subscription}s.
@@ -1033,7 +1034,19 @@ public final class Aeron implements AutoCloseable
         @Config
         public static long idleSleepDurationNs()
         {
-            return getDurationInNanos(IDLE_SLEEP_DURATION_PROP_NAME, IDLE_SLEEP_DEFAULT_NS);
+            return idleSleepDurationNs(System.getProperties());
+        }
+
+        /**
+         * Duration in nanoseconds for which the client conductor will sleep between work cycles when idle.
+         *
+         * @param properties to read the configuration from.
+         * @return duration in nanoseconds to wait when idle in client conductor.
+         * @see #IDLE_SLEEP_DURATION_PROP_NAME
+         */
+        public static long idleSleepDurationNs(final Properties properties)
+        {
+            return getDurationInNanos(properties, IDLE_SLEEP_DURATION_PROP_NAME, IDLE_SLEEP_DEFAULT_NS);
         }
 
         /**
@@ -1046,7 +1059,21 @@ public final class Aeron implements AutoCloseable
         @Config
         public static long resourceLingerDurationNs()
         {
-            return getDurationInNanos(RESOURCE_LINGER_DURATION_PROP_NAME, RESOURCE_LINGER_DURATION_DEFAULT_NS);
+            return resourceLingerDurationNs(System.getProperties());
+        }
+
+        /**
+         * Duration to wait while lingering an entity such as an {@link Image} before deleting underlying resources
+         * such as memory mapped files.
+         *
+         * @param properties to read the configuration from.
+         * @return duration in nanoseconds to wait before deleting an expired resource.
+         * @see #RESOURCE_LINGER_DURATION_PROP_NAME
+         */
+        public static long resourceLingerDurationNs(final Properties properties)
+        {
+            return getDurationInNanos(
+                properties, RESOURCE_LINGER_DURATION_PROP_NAME, RESOURCE_LINGER_DURATION_DEFAULT_NS);
         }
 
         /**
@@ -1059,7 +1086,20 @@ public final class Aeron implements AutoCloseable
         @Config
         public static long closeLingerDurationNs()
         {
-            return getDurationInNanos(CLOSE_LINGER_DURATION_PROP_NAME, CLOSE_LINGER_DURATION_DEFAULT_NS);
+            return closeLingerDurationNs(System.getProperties());
+        }
+
+        /**
+         * Duration to wait while lingering an entity such as an {@link Image} before deleting underlying resources
+         * such as memory mapped files.
+         *
+         * @param properties to read the configuration from.
+         * @return duration in nanoseconds to wait before deleting an expired resource.
+         * @see #RESOURCE_LINGER_DURATION_PROP_NAME
+         */
+        public static long closeLingerDurationNs(final Properties properties)
+        {
+            return getDurationInNanos(properties, CLOSE_LINGER_DURATION_PROP_NAME, CLOSE_LINGER_DURATION_DEFAULT_NS);
         }
 
         /**
@@ -1071,7 +1111,19 @@ public final class Aeron implements AutoCloseable
         @Config
         public static boolean preTouchMappedMemory()
         {
-            final String value = System.getProperty(PRE_TOUCH_MAPPED_MEMORY_PROP_NAME);
+            return preTouchMappedMemory(System.getProperties());
+        }
+
+        /**
+         * Should memory-mapped files be pre-touched so that they are already faulted into a process.
+         *
+         * @param properties to read the configuration from.
+         * @return true if memory mappings should be pre-touched, otherwise false.
+         * @see #PRE_TOUCH_MAPPED_MEMORY_PROP_NAME
+         */
+        public static boolean preTouchMappedMemory(final Properties properties)
+        {
+            final String value = properties.getProperty(PRE_TOUCH_MAPPED_MEMORY_PROP_NAME);
             if (null != value)
             {
                 return Boolean.parseBoolean(value);
@@ -1089,7 +1141,19 @@ public final class Aeron implements AutoCloseable
         @Config
         public static String clientName()
         {
-            return getProperty(CLIENT_NAME_PROP_NAME, "");
+            return clientName(System.getProperties());
+        }
+
+        /**
+         * Get the configured client name.
+         *
+         * @param properties to read the configuration from.
+         * @return specified client name or empty string if not set.
+         * @see #CLIENT_NAME_PROP_NAME
+         */
+        public static String clientName(final Properties properties)
+        {
+            return getProperty(properties, CLIENT_NAME_PROP_NAME, "");
         }
 
         /**
@@ -1114,9 +1178,9 @@ public final class Aeron implements AutoCloseable
     public static final class Context extends CommonContext
     {
         private long clientId;
-        private String clientName = Configuration.clientName();
-        private boolean useConductorAgentInvoker = false;
-        private boolean preTouchMappedMemory = Configuration.preTouchMappedMemory();
+        private String clientName;
+        private boolean useConductorAgentInvoker;
+        private boolean preTouchMappedMemory;
         private AgentInvoker driverAgentInvoker;
         private Lock clientLock;
         private EpochClock epochClock;
@@ -1135,22 +1199,43 @@ public final class Aeron implements AutoCloseable
         private UnavailableImageHandler unavailableImageHandler;
         private AvailableCounterHandler availableCounterHandler;
         private UnavailableCounterHandler unavailableCounterHandler;
-        private PublicationErrorFrameHandler publicationErrorFrameHandler = PublicationErrorFrameHandler.NO_OP;
+        private PublicationErrorFrameHandler publicationErrorFrameHandler;
         private Runnable closeHandler;
-        private long keepAliveIntervalNs = Configuration.KEEPALIVE_INTERVAL_NS;
+        private long keepAliveIntervalNs;
         private long interServiceTimeoutNs;
-        private long idleSleepDurationNs = Configuration.idleSleepDurationNs();
-        private long resourceLingerDurationNs = Configuration.resourceLingerDurationNs();
-        private long closeLingerDurationNs = Configuration.closeLingerDurationNs();
+        private long idleSleepDurationNs;
+        private long resourceLingerDurationNs;
+        private long closeLingerDurationNs;
         private int filePageSize;
 
-        private ThreadFactory threadFactory = Thread::new;
+        private ThreadFactory threadFactory;
 
         /**
          * Construct a Context using default values and loading from system properties.
          */
         public Context()
         {
+            this(System.getProperties());
+        }
+
+        /**
+         * Construct a Context using default values loaded from the supplied properties.
+         *
+         * @param properties to load the configuration from.
+         */
+        public Context(final Properties properties)
+        {
+            super(properties);
+
+            clientName = Configuration.clientName(properties);
+            useConductorAgentInvoker = false;
+            preTouchMappedMemory = Configuration.preTouchMappedMemory(properties);
+            publicationErrorFrameHandler = PublicationErrorFrameHandler.NO_OP;
+            keepAliveIntervalNs = Configuration.KEEPALIVE_INTERVAL_NS;
+            idleSleepDurationNs = Configuration.idleSleepDurationNs(properties);
+            resourceLingerDurationNs = Configuration.resourceLingerDurationNs(properties);
+            closeLingerDurationNs = Configuration.closeLingerDurationNs(properties);
+            threadFactory = Thread::new;
         }
 
         /**
@@ -1183,14 +1268,14 @@ public final class Aeron implements AutoCloseable
             {
                 throw new ConfigurationException(
                     "Must use Aeron.Context.useConductorAgentInvoker(true) when Aeron.Context.clientLock(...) " +
-                    "is using a NoOpLock");
+                        "is using a NoOpLock");
             }
 
             if (null != driverAgentInvoker && !useConductorAgentInvoker)
             {
                 throw new ConfigurationException(
                     "Must use Aeron.Context.useConductorAgentInvoker(true) when Aeron.Context.driverAgentInvoker() " +
-                    "is set");
+                        "is set");
             }
 
             if (clientName.length() > MAX_CLIENT_NAME_LENGTH)
@@ -1821,7 +1906,7 @@ public final class Aeron implements AutoCloseable
          */
         public long interServiceTimeoutNs()
         {
-            return CommonContext.checkDebugTimeout(interServiceTimeoutNs, TimeUnit.NANOSECONDS);
+            return CommonContext.checkDebugTimeout(properties(), interServiceTimeoutNs, TimeUnit.NANOSECONDS);
         }
 
         /**

--- a/aeron-client/src/main/java/io/aeron/CommonContext.java
+++ b/aeron-client/src/main/java/io/aeron/CommonContext.java
@@ -59,6 +59,7 @@ import java.nio.file.NoSuchFileException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Map;
+import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -68,8 +69,9 @@ import static io.aeron.CncFileDescriptor.CNC_FILE;
 import static io.aeron.CncFileDescriptor.TO_DRIVER_BUFFER_LENGTH_FIELD_OFFSET;
 import static io.aeron.CncFileDescriptor.cncVersionOffset;
 import static io.aeron.CncFileDescriptor.createToDriverBuffer;
+import static io.aeron.PropertiesUtil.getBoolean;
+import static io.aeron.PropertiesUtil.getLong;
 import static java.lang.Long.getLong;
-import static java.lang.System.getProperty;
 import static java.nio.channels.FileChannel.MapMode.READ_WRITE;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.file.StandardOpenOption.READ;
@@ -550,13 +552,26 @@ public class CommonContext implements Cloneable
     /**
      * Choose a thread/role name depending on the configured naming scheme.
      *
-     * @param newName the new, prefixed name.
-     * @param classicName  the old name.
+     * @param newName     the new, prefixed name.
+     * @param classicName the old name.
      * @return the name to use for the current naming scheme.
      */
     public static String threadName(final String newName, final String classicName)
     {
-        final String mode = System.getProperty(THREAD_NAMING_PROP_NAME, THREAD_NAMING_DEFAULT);
+        return threadName(System.getProperties(), newName, classicName);
+    }
+
+    /**
+     * Get the name to use for a thread based on the configured naming scheme.
+     *
+     * @param properties  to read the configuration from.
+     * @param newName     the new, prefixed name.
+     * @param classicName the old name.
+     * @return the name to use for the current naming scheme.
+     */
+    public static String threadName(final Properties properties, final String newName, final String classicName)
+    {
+        final String mode = properties.getProperty(THREAD_NAMING_PROP_NAME, THREAD_NAMING_DEFAULT);
         return switch (mode)
         {
             case THREAD_NAMING_CLASSIC -> classicName;
@@ -588,7 +603,19 @@ public class CommonContext implements Cloneable
      */
     public static boolean shouldPrintConfigurationOnStart()
     {
-        return "true".equals(getProperty(PRINT_CONFIGURATION_ON_START_PROP_NAME));
+        return shouldPrintConfigurationOnStart(System.getProperties());
+    }
+
+    /**
+     * Should a component's configuration be printed on start.
+     *
+     * @param properties to read the configuration from.
+     * @return {@code true} if the configuration should be printed on start.
+     * @see #PRINT_CONFIGURATION_ON_START_PROP_NAME
+     */
+    public static boolean shouldPrintConfigurationOnStart(final Properties properties)
+    {
+        return "true".equals(properties.getProperty(PRINT_CONFIGURATION_ON_START_PROP_NAME));
     }
 
     /**
@@ -600,7 +627,20 @@ public class CommonContext implements Cloneable
      */
     public static String getSecureRandomAlgorithm()
     {
-        return System.getProperty(SECURE_RANDOM_ALGORITHM_PROP_NAME, SECURE_RANDOM_ALGORITHM_DEFAULT);
+        return getSecureRandomAlgorithm(System.getProperties());
+    }
+
+    /**
+     * Get the configured value for the secure random algorithm, falling back to the default if not supplied.
+     *
+     * @param properties to read the configuration from.
+     * @return the secure random algorithm
+     * @see #SECURE_RANDOM_ALGORITHM_PROP_NAME
+     * @see #SECURE_RANDOM_ALGORITHM_DEFAULT
+     */
+    public static String getSecureRandomAlgorithm(final Properties properties)
+    {
+        return properties.getProperty(SECURE_RANDOM_ALGORITHM_PROP_NAME, SECURE_RANDOM_ALGORITHM_DEFAULT);
     }
 
     /**
@@ -611,7 +651,18 @@ public class CommonContext implements Cloneable
     @Config
     public static PrintStream fallbackLogger()
     {
-        final String fallbackLoggerName = getProperty(FALLBACK_LOGGER_PROP_NAME, "stderr");
+        return fallbackLogger(System.getProperties());
+    }
+
+    /**
+     * Get the current fallback logger based on the supplied properties.
+     *
+     * @param properties to read the configuration from.
+     * @return the configured PrintStream.
+     */
+    public static PrintStream fallbackLogger(final Properties properties)
+    {
+        final String fallbackLoggerName = properties.getProperty(FALLBACK_LOGGER_PROP_NAME, "stderr");
         return switch (fallbackLoggerName)
         {
             case "stdout" -> System.out;
@@ -644,13 +695,14 @@ public class CommonContext implements Cloneable
     }
 
     private volatile boolean isConcluded;
-    private long driverTimeoutMs = DRIVER_TIMEOUT_MS;
-    private String aeronDirectoryName = getAeronDirectoryName();
+    private final Properties properties;
+    private long driverTimeoutMs;
+    private String aeronDirectoryName;
     private File aeronDirectory;
     private File cncFile;
     private UnsafeBuffer countersMetaDataBuffer;
     private UnsafeBuffer countersValuesBuffer;
-    private boolean enableExperimentalFeatures = Boolean.getBoolean(ENABLE_EXPERIMENTAL_FEATURES_PROP_NAME);
+    private boolean enableExperimentalFeatures;
 
     static
     {
@@ -678,6 +730,32 @@ public class CommonContext implements Cloneable
      */
     public CommonContext()
     {
+        this(System.getProperties());
+    }
+
+    /**
+     * Construct a CommonContext using default values loaded from the supplied properties. This allows several
+     * independently configured Aeron stacks to coexist in a single JVM.
+     *
+     * @param properties to load the configuration from.
+     */
+    public CommonContext(final Properties properties)
+    {
+        this.properties = properties;
+
+        driverTimeoutMs = getLong(properties, DRIVER_TIMEOUT_PROP_NAME, DEFAULT_DRIVER_TIMEOUT_MS);
+        aeronDirectoryName = getAeronDirectoryName(properties);
+        enableExperimentalFeatures = getBoolean(properties, ENABLE_EXPERIMENTAL_FEATURES_PROP_NAME);
+    }
+
+    /**
+     * The properties this context was constructed from, to be propagated to any context it creates.
+     *
+     * @return the properties this context was constructed from.
+     */
+    public Properties properties()
+    {
+        return properties;
     }
 
     /**
@@ -706,7 +784,19 @@ public class CommonContext implements Cloneable
     @Config(id = "AERON_DIR")
     public static String getAeronDirectoryName()
     {
-        return getProperty(AERON_DIR_PROP_NAME, AERON_DIR_PROP_DEFAULT);
+        return getAeronDirectoryName(System.getProperties());
+    }
+
+    /**
+     * Get the default directory name to be used if {@link #aeronDirectoryName(String)} is not set. This will take
+     * the {@link #AERON_DIR_PROP_NAME} if set and if not then {@link #AERON_DIR_PROP_DEFAULT}.
+     *
+     * @param properties to read the configuration from.
+     * @return the default directory name to be used if {@link #aeronDirectoryName(String)} is not set.
+     */
+    public static String getAeronDirectoryName(final Properties properties)
+    {
+        return properties.getProperty(AERON_DIR_PROP_NAME, AERON_DIR_PROP_DEFAULT);
     }
 
     /**
@@ -814,7 +904,18 @@ public class CommonContext implements Cloneable
      */
     public static File newDefaultCncFile()
     {
-        return new File(getProperty(AERON_DIR_PROP_NAME, AERON_DIR_PROP_DEFAULT), CncFileDescriptor.CNC_FILE);
+        return newDefaultCncFile(System.getProperties());
+    }
+
+    /**
+     * Create a new command and control file in the administration directory.
+     *
+     * @param properties to read the configuration from.
+     * @return The newly created File.
+     */
+    public static File newDefaultCncFile(final Properties properties)
+    {
+        return new File(getAeronDirectoryName(properties), CncFileDescriptor.CNC_FILE);
     }
 
     /**
@@ -903,7 +1004,7 @@ public class CommonContext implements Cloneable
     @Config(id = "DRIVER_TIMEOUT")
     public long driverTimeoutMs()
     {
-        return checkDebugTimeout(driverTimeoutMs, TimeUnit.MILLISECONDS);
+        return checkDebugTimeout(properties, driverTimeoutMs, TimeUnit.MILLISECONDS);
     }
 
     /**
@@ -945,7 +1046,22 @@ public class CommonContext implements Cloneable
      */
     public static long checkDebugTimeout(final long timeout, final TimeUnit timeUnit)
     {
-        return checkDebugTimeout(timeout, timeUnit, 1.0);
+        return checkDebugTimeout(System.getProperties(), timeout, timeUnit, 1.0);
+    }
+
+    /**
+     * Override the supplied timeout with the debug value if it has been set, and we are in debug mode.
+     *
+     * @param properties to read the configuration from.
+     * @param timeout    The timeout value currently in use.
+     * @param timeUnit   The units of the timeout value. Debug timeout is specified in ns, so will be converted to
+     *                   this unit.
+     * @return The debug timeout if specified, and we are being debugged or the supplied value if not. Will be in
+     * timeUnit units.
+     */
+    public static long checkDebugTimeout(final Properties properties, final long timeout, final TimeUnit timeUnit)
+    {
+        return checkDebugTimeout(properties, timeout, timeUnit, 1.0);
     }
 
     /**
@@ -961,7 +1077,25 @@ public class CommonContext implements Cloneable
      */
     public static long checkDebugTimeout(final long timeout, final TimeUnit timeUnit, final double factor)
     {
-        final String debugTimeoutString = getProperty(DEBUG_TIMEOUT_PROP_NAME);
+        return checkDebugTimeout(System.getProperties(), timeout, timeUnit, factor);
+    }
+
+    /**
+     * Override the supplied timeout with the debug value if it has been set, and we are in debug mode.
+     *
+     * @param properties to read the configuration from.
+     * @param timeout    The timeout value currently in use.
+     * @param timeUnit   The units of the timeout value. Debug timeout is specified in ns, so will be converted to
+     *                   this unit.
+     * @param factor     to multiply the debug timeout by. Required when some timeouts need to be larger than others
+     *                   in order to pass validation. E.g. clientLiveness and publicationUnblock.
+     * @return The debug timeout if specified, and we are being debugged or the supplied value if not. Will be in
+     * timeUnit units.
+     */
+    public static long checkDebugTimeout(
+        final Properties properties, final long timeout, final TimeUnit timeUnit, final double factor)
+    {
+        final String debugTimeoutString = properties.getProperty(DEBUG_TIMEOUT_PROP_NAME);
         if (null == debugTimeoutString || !SystemUtil.isDebuggerAttached())
         {
             return timeout;
@@ -1326,6 +1460,20 @@ public class CommonContext implements Cloneable
     }
 
     /**
+     * Wrap a user ErrorHandler so that error will continue to write to the errorLog.
+     *
+     * @param properties       to resolve the fallback logger from.
+     * @param userErrorHandler the user specified ErrorHandler, can be null.
+     * @param errorLog         the configured errorLog, either the default or user supplied.
+     * @return an error handler that will delegate to both the userErrorHandler and the errorLog.
+     */
+    public static ErrorHandler setupErrorHandler(
+        final Properties properties, final ErrorHandler userErrorHandler, final DistinctErrorLog errorLog)
+    {
+        return setupErrorHandler(userErrorHandler, errorLog, fallbackLogger(properties));
+    }
+
+    /**
      * Connect to the media driver and extract file page size from the C'n'C file.
      *
      * @param aeronDirectory where driver is running.
@@ -1365,7 +1513,7 @@ public class CommonContext implements Cloneable
         {
             final int correlationIdOffset =
                 metadata.getInt(TO_DRIVER_BUFFER_LENGTH_FIELD_OFFSET) - RingBufferDescriptor.TRAILER_LENGTH +
-                RingBufferDescriptor.CORRELATION_COUNTER_OFFSET;
+                    RingBufferDescriptor.CORRELATION_COUNTER_OFFSET;
             final UnsafeBuffer toDriverBuffer = createToDriverBuffer(metadata.byteBuffer(), metadata);
             return toDriverBuffer.getAndAddLong(correlationIdOffset, 1);
         }

--- a/aeron-client/src/main/java/io/aeron/PropertiesUtil.java
+++ b/aeron-client/src/main/java/io/aeron/PropertiesUtil.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2014-2025 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron;
+
+import org.agrona.SystemUtil;
+
+import java.util.Properties;
+
+/**
+ * Utilities for reading typed values from supplied {@link Properties} instance.
+ *
+ * @see SystemUtil
+ */
+public final class PropertiesUtil
+{
+    private PropertiesUtil()
+    {
+    }
+
+    /**
+     * Get the value of a property with the exception that if the value is {@link SystemUtil#NULL_PROPERTY_VALUE} then
+     * return {@code null}.
+     *
+     * @param properties   to look up the value in.
+     * @param propertyName to get the value for.
+     * @return the value of the property with the exception that if the value is
+     * {@link SystemUtil#NULL_PROPERTY_VALUE} then return {@code null}.
+     * @see SystemUtil#getProperty(String)
+     */
+    public static String getProperty(final Properties properties, final String propertyName)
+    {
+        final String propertyValue = properties.getProperty(propertyName);
+
+        return SystemUtil.NULL_PROPERTY_VALUE.equals(propertyValue) ? null : propertyValue;
+    }
+
+    /**
+     * Get the value of a property with the exception that if the value is {@link SystemUtil#NULL_PROPERTY_VALUE} then
+     * return {@code null}, otherwise if the value is not set then return the default value.
+     *
+     * @param properties   to look up the value in.
+     * @param propertyName to get the value for.
+     * @param defaultValue to use if the property is not set.
+     * @return the value of the property with the exception that if the value is
+     * {@link SystemUtil#NULL_PROPERTY_VALUE} then return {@code null}, otherwise if the value is not set then return
+     * the default value.
+     * @see SystemUtil#getProperty(String, String)
+     */
+    public static String getProperty(
+        final Properties properties, final String propertyName, final String defaultValue)
+    {
+        final String propertyValue = properties.getProperty(propertyName);
+        if (SystemUtil.NULL_PROPERTY_VALUE.equals(propertyValue))
+        {
+            return null;
+        }
+
+        return null == propertyValue ? defaultValue : propertyValue;
+    }
+
+    /**
+     * Get a boolean value from a property. The result is {@code true} if and only if the value is equal, ignoring
+     * case, to the string {@code "true"}.
+     *
+     * @param properties   to look up the value in.
+     * @param propertyName to get the value for.
+     * @return the boolean value.
+     * @see Boolean#getBoolean(String)
+     */
+    public static boolean getBoolean(final Properties properties, final String propertyName)
+    {
+        return Boolean.parseBoolean(properties.getProperty(propertyName));
+    }
+
+    /**
+     * Get an int value from a property. The value is decoded as per {@link Integer#decode(String)} so hexadecimal,
+     * octal, and decimal representations are all supported. The default value is used if the property is not present
+     * or cannot be decoded.
+     *
+     * @param properties   to look up the value in.
+     * @param propertyName to get the value for.
+     * @param defaultValue to be used if the property is not present or cannot be decoded.
+     * @return the int value.
+     * @see Integer#getInteger(String, int)
+     */
+    public static int getInteger(final Properties properties, final String propertyName, final int defaultValue)
+    {
+        final String propertyValue = properties.getProperty(propertyName);
+        if (null != propertyValue)
+        {
+            try
+            {
+                return Integer.decode(propertyValue);
+            }
+            catch (final NumberFormatException ignore)
+            {
+                // fall through to the default value, as per Integer.getInteger(String, int)
+            }
+        }
+
+        return defaultValue;
+    }
+
+    /**
+     * Get a long value from a property. The value is decoded as per {@link Long#decode(String)} so hexadecimal,
+     * octal, and decimal representations are all supported. The default value is used if the property is not present
+     * or cannot be decoded.
+     *
+     * @param properties   to look up the value in.
+     * @param propertyName to get the value for.
+     * @param defaultValue to be used if the property is not present or cannot be decoded.
+     * @return the long value.
+     * @see Long#getLong(String, long)
+     */
+    public static long getLong(final Properties properties, final String propertyName, final long defaultValue)
+    {
+        final String propertyValue = properties.getProperty(propertyName);
+        if (null != propertyValue)
+        {
+            try
+            {
+                return Long.decode(propertyValue);
+            }
+            catch (final NumberFormatException ignore)
+            {
+                // fall through to the default value, as per Long.getLong(String, long)
+            }
+        }
+
+        return defaultValue;
+    }
+
+    /**
+     * Get a long value from a property, allowing a {@code null} default value to represent an unset property. The
+     * value is decoded as per {@link Long#decode(String)} so hexadecimal, octal, and decimal representations are all
+     * supported. The default value is used if the property is not present or cannot be decoded.
+     *
+     * @param properties   to look up the value in.
+     * @param propertyName to get the value for.
+     * @param defaultValue to be used if the property is not present or cannot be decoded, may be {@code null}.
+     * @return the {@link Long} value which may be {@code null}.
+     * @see Long#getLong(String, Long)
+     */
+    public static Long getLong(final Properties properties, final String propertyName, final Long defaultValue)
+    {
+        final String propertyValue = properties.getProperty(propertyName);
+        if (null != propertyValue)
+        {
+            try
+            {
+                return Long.decode(propertyValue);
+            }
+            catch (final NumberFormatException ignore)
+            {
+                // fall through to the default value, as per Long.getLong(String, Long)
+            }
+        }
+
+        return defaultValue;
+    }
+
+    /**
+     * Get a size value as an int from a property. Supports a 'g', 'm', and 'k' suffix to indicate gigabytes,
+     * megabytes, or kilobytes respectively.
+     *
+     * @param properties   to look up the value in.
+     * @param propertyName to look up.
+     * @param defaultValue to be applied if the property is not set.
+     * @return the int value.
+     * @throws NumberFormatException if the value is out of range or mal-formatted.
+     * @see SystemUtil#getSizeAsInt(String, int)
+     */
+    public static int getSizeAsInt(final Properties properties, final String propertyName, final int defaultValue)
+    {
+        final String propertyValue = properties.getProperty(propertyName);
+        if (null != propertyValue)
+        {
+            final long value = SystemUtil.parseSize(propertyName, propertyValue);
+            if (value < 0 || value > Integer.MAX_VALUE)
+            {
+                throw new NumberFormatException(
+                    propertyName + " must positive and less than Integer.MAX_VALUE: " + value);
+            }
+
+            return (int)value;
+        }
+
+        return defaultValue;
+    }
+
+    /**
+     * Get a size value as a long from a property. Supports a 'g', 'm', and 'k' suffix to indicate gigabytes,
+     * megabytes, or kilobytes respectively.
+     *
+     * @param properties   to look up the value in.
+     * @param propertyName to look up.
+     * @param defaultValue to be applied if the property is not set.
+     * @return the long value.
+     * @throws NumberFormatException if the value is out of range or mal-formatted.
+     * @see SystemUtil#getSizeAsLong(String, long)
+     */
+    public static long getSizeAsLong(final Properties properties, final String propertyName, final long defaultValue)
+    {
+        final String propertyValue = properties.getProperty(propertyName);
+        if (null != propertyValue)
+        {
+            return SystemUtil.parseSize(propertyName, propertyValue);
+        }
+
+        return defaultValue;
+    }
+
+    /**
+     * Get a time duration in nanoseconds from a property with an optional suffix of 's', 'ms', 'us', or 'ns' to
+     * indicate seconds, milliseconds, microseconds, or nanoseconds respectively.
+     * <p>
+     * If the resulting duration is greater than {@link Long#MAX_VALUE} then {@link Long#MAX_VALUE} is used.
+     *
+     * @param properties   to look up the value in.
+     * @param propertyName associated with the duration value.
+     * @param defaultValue to be used if the property is not present.
+     * @return the long value.
+     * @throws NumberFormatException if the value is negative or malformed.
+     * @see SystemUtil#getDurationInNanos(String, long)
+     */
+    public static long getDurationInNanos(
+        final Properties properties, final String propertyName, final long defaultValue)
+    {
+        final String propertyValue = properties.getProperty(propertyName);
+        if (null != propertyValue)
+        {
+            return SystemUtil.parseDuration(propertyName, propertyValue);
+        }
+
+        return defaultValue;
+    }
+}

--- a/aeron-client/src/test/java/io/aeron/PropertiesUtilTest.java
+++ b/aeron-client/src/test/java/io/aeron/PropertiesUtilTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2014-2025 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron;
+
+import org.agrona.SystemUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Properties;
+
+import static io.aeron.PropertiesUtil.getBoolean;
+import static io.aeron.PropertiesUtil.getDurationInNanos;
+import static io.aeron.PropertiesUtil.getInteger;
+import static io.aeron.PropertiesUtil.getLong;
+import static io.aeron.PropertiesUtil.getProperty;
+import static io.aeron.PropertiesUtil.getSizeAsInt;
+import static io.aeron.PropertiesUtil.getSizeAsLong;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PropertiesUtilTest
+{
+    private static final String NAME = "io.aeron.test.properties.util";
+
+    private final Properties properties = new Properties();
+
+    @AfterEach
+    void tearDown()
+    {
+        System.clearProperty(NAME);
+    }
+
+    @Test
+    void getPropertyReturnsNullWhenUnset()
+    {
+        assertNull(getProperty(properties, NAME));
+        assertEquals("fallback", getProperty(properties, NAME, "fallback"));
+    }
+
+    @Test
+    void getPropertyTreatsNullSentinelAsNull()
+    {
+        properties.setProperty(NAME, SystemUtil.NULL_PROPERTY_VALUE);
+
+        assertNull(getProperty(properties, NAME));
+        assertNull(getProperty(properties, NAME, "fallback"));
+    }
+
+    @Test
+    void getBooleanMatchesBooleanGetBoolean()
+    {
+        assertFalse(getBoolean(properties, NAME));
+
+        properties.setProperty(NAME, "TrUe");
+        assertTrue(getBoolean(properties, NAME));
+
+        properties.setProperty(NAME, "yes");
+        assertFalse(getBoolean(properties, NAME));
+    }
+
+    @Test
+    void getIntegerDecodesAndFallsBackLikeIntegerGetInteger()
+    {
+        assertEquals(42, getInteger(properties, NAME, 42));
+
+        properties.setProperty(NAME, "0x10");
+        assertEquals(16, getInteger(properties, NAME, 42));
+
+        properties.setProperty(NAME, "not a number");
+        assertEquals(42, getInteger(properties, NAME, 42));
+
+        System.setProperty(NAME, "7");
+        assertEquals(Integer.getInteger(NAME, 42), getInteger(System.getProperties(), NAME, 42));
+    }
+
+    @Test
+    void getLongDecodesAndFallsBackLikeLongGetLong()
+    {
+        assertEquals(42L, getLong(properties, NAME, 42L));
+        assertNull(getLong(properties, NAME, (Long)null));
+
+        properties.setProperty(NAME, "0x10");
+        assertEquals(16L, getLong(properties, NAME, 42L));
+
+        properties.setProperty(NAME, "not a number");
+        assertEquals(42L, getLong(properties, NAME, 42L));
+
+        System.setProperty(NAME, "7");
+        assertEquals(Long.getLong(NAME, 42L), getLong(System.getProperties(), NAME, 42L));
+    }
+
+    @Test
+    void getSizeMatchesSystemUtil()
+    {
+        assertEquals(64, getSizeAsInt(properties, NAME, 64));
+        assertEquals(64L, getSizeAsLong(properties, NAME, 64L));
+
+        properties.setProperty(NAME, "1m");
+        System.setProperty(NAME, "1m");
+
+        assertEquals(SystemUtil.getSizeAsInt(NAME, 64), getSizeAsInt(properties, NAME, 64));
+        assertEquals(SystemUtil.getSizeAsLong(NAME, 64L), getSizeAsLong(properties, NAME, 64L));
+    }
+
+    @Test
+    void getSizeAsIntRejectsValuesLargerThanIntegerMaxValue()
+    {
+        properties.setProperty(NAME, "4g");
+
+        assertThrows(NumberFormatException.class, () -> getSizeAsInt(properties, NAME, 64));
+    }
+
+    @Test
+    void getDurationInNanosMatchesSystemUtil()
+    {
+        assertEquals(64L, getDurationInNanos(properties, NAME, 64L));
+
+        properties.setProperty(NAME, "500ms");
+        System.setProperty(NAME, "500ms");
+
+        assertEquals(SystemUtil.getDurationInNanos(NAME, 64L), getDurationInNanos(properties, NAME, 64L));
+    }
+
+    @Test
+    void suppliedPropertiesAreIndependentOfSystemProperties()
+    {
+        System.setProperty(NAME, "1000");
+        properties.setProperty(NAME, "2000");
+
+        assertEquals(2000, getInteger(properties, NAME, 0));
+        assertEquals(1000, getInteger(System.getProperties(), NAME, 0));
+        assertEquals(0, getInteger(new Properties(), NAME, 0));
+    }
+}

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackup.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackup.java
@@ -57,6 +57,7 @@ import java.io.File;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.util.Arrays;
+import java.util.Properties;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
@@ -64,11 +65,10 @@ import java.util.function.Supplier;
 import static io.aeron.AeronCounters.CLUSTER_BACKUP_SNAPSHOT_RETRIEVE_COUNT_TYPE_ID;
 import static io.aeron.CommonContext.ENDPOINT_PARAM_NAME;
 import static io.aeron.CommonContext.driverFilePageSize;
+import static io.aeron.PropertiesUtil.getDurationInNanos;
 import static io.aeron.cluster.ConsensusModule.Configuration.SERVICE_ID;
 import static io.aeron.cluster.service.ClusteredServiceContainer.Configuration.LIVENESS_TIMEOUT_MS;
-import static java.lang.System.getProperty;
 import static java.nio.charset.StandardCharsets.US_ASCII;
-import static org.agrona.SystemUtil.getDurationInNanos;
 
 /**
  * Backup component which can run remote from a cluster which polls for snapshots and replicates the log.
@@ -416,14 +416,27 @@ public final class ClusterBackup implements AutoCloseable
          */
         public static String catchupEndpoint()
         {
-            String configuredCatchupEndpoint = System.getProperty(CLUSTER_BACKUP_CATCHUP_ENDPOINT_PROP_NAME);
+            return catchupEndpoint(System.getProperties());
+        }
 
-            if (null == configuredCatchupEndpoint && null != ConsensusModule.Configuration.clusterMembers())
+        /**
+         * The value of system property {@link #CLUSTER_BACKUP_CATCHUP_ENDPOINT_PROP_NAME} if set, otherwise it will
+         * try to derive the catchup endpoint from {@link ConsensusModule.Configuration#clusterMembers()} and
+         * {@link ConsensusModule.Configuration#clusterMemberId()}. Failing that null will be returned.
+         *
+         * @param properties to read the configuration from.
+         * @return system property {@link #CLUSTER_BACKUP_CATCHUP_ENDPOINT_PROP_NAME}, the derived value, or null.
+         */
+        public static String catchupEndpoint(final Properties properties)
+        {
+            String configuredCatchupEndpoint = properties.getProperty(CLUSTER_BACKUP_CATCHUP_ENDPOINT_PROP_NAME);
+
+            if (null == configuredCatchupEndpoint && null != ConsensusModule.Configuration.clusterMembers(properties))
             {
                 final ClusterMember member = ClusterMember.determineMember(
-                    ClusterMember.parse(ConsensusModule.Configuration.clusterMembers()),
-                    ConsensusModule.Configuration.clusterMemberId(),
-                    ConsensusModule.Configuration.memberEndpoints());
+                    ClusterMember.parse(ConsensusModule.Configuration.clusterMembers(properties)),
+                    ConsensusModule.Configuration.clusterMemberId(properties),
+                    ConsensusModule.Configuration.memberEndpoints(properties));
 
                 configuredCatchupEndpoint = member.catchupEndpoint();
             }
@@ -440,7 +453,21 @@ public final class ClusterBackup implements AutoCloseable
          */
         public static String catchupChannel()
         {
-            return System.getProperty(CLUSTER_BACKUP_CATCHUP_CHANNEL_PROP_NAME, CLUSTER_BACKUP_CATCHUP_CHANNEL_DEFAULT);
+            return catchupChannel(System.getProperties());
+        }
+
+        /**
+         * The value {@link #CLUSTER_BACKUP_CATCHUP_CHANNEL_DEFAULT} or system property
+         * {@link #CLUSTER_BACKUP_CATCHUP_CHANNEL_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #CLUSTER_BACKUP_CATCHUP_CHANNEL_DEFAULT} or system property
+         * {@link #CLUSTER_BACKUP_CATCHUP_CHANNEL_PROP_NAME} if set.
+         */
+        public static String catchupChannel(final Properties properties)
+        {
+            return properties.getProperty(
+                CLUSTER_BACKUP_CATCHUP_CHANNEL_PROP_NAME, CLUSTER_BACKUP_CATCHUP_CHANNEL_DEFAULT);
         }
 
         /**
@@ -453,17 +480,31 @@ public final class ClusterBackup implements AutoCloseable
          */
         public static String consensusChannel()
         {
-            String consensusChannel = ConsensusModule.Configuration.consensusChannel();
+            return consensusChannel(System.getProperties());
+        }
 
-            if (null != consensusChannel && null != ConsensusModule.Configuration.clusterMembers())
+        /**
+         * The value of system property {@link ConsensusModule.Configuration#consensusChannel()} if set. If that channel
+         * does not have an endpoint set, then this will try to derive one using
+         * {@link ConsensusModule.Configuration#clusterMembers()} and
+         * {@link ConsensusModule.Configuration#clusterMemberId()}.
+         *
+         * @param properties to read the configuration from.
+         * @return system property {@link #CLUSTER_BACKUP_CATCHUP_CHANNEL_PROP_NAME}, the derived value, or null.
+         */
+        public static String consensusChannel(final Properties properties)
+        {
+            String consensusChannel = ConsensusModule.Configuration.consensusChannel(properties);
+
+            if (null != consensusChannel && null != ConsensusModule.Configuration.clusterMembers(properties))
             {
                 final ChannelUri consensusUri = ChannelUri.parse(consensusChannel);
                 if (!consensusUri.containsKey(ENDPOINT_PARAM_NAME))
                 {
                     final ClusterMember member = ClusterMember.determineMember(
-                        ClusterMember.parse(ConsensusModule.Configuration.clusterMembers()),
-                        ConsensusModule.Configuration.clusterMemberId(),
-                        ConsensusModule.Configuration.memberEndpoints());
+                        ClusterMember.parse(ConsensusModule.Configuration.clusterMembers(properties)),
+                        ConsensusModule.Configuration.clusterMemberId(properties),
+                        ConsensusModule.Configuration.memberEndpoints(properties));
 
                     consensusUri.put(ENDPOINT_PARAM_NAME, member.consensusEndpoint());
                     consensusChannel = consensusUri.toString();
@@ -481,7 +522,20 @@ public final class ClusterBackup implements AutoCloseable
          */
         public static long clusterBackupIntervalNs()
         {
-            return getDurationInNanos(CLUSTER_BACKUP_INTERVAL_PROP_NAME, CLUSTER_BACKUP_INTERVAL_DEFAULT_NS);
+            return clusterBackupIntervalNs(System.getProperties());
+        }
+
+        /**
+         * Interval at which a cluster backup will send backup queries.
+         *
+         * @param properties to read the configuration from.
+         * @return Interval at which a cluster backup will send backup queries.
+         * @see #CLUSTER_BACKUP_INTERVAL_PROP_NAME
+         */
+        public static long clusterBackupIntervalNs(final Properties properties)
+        {
+            return getDurationInNanos(
+                properties, CLUSTER_BACKUP_INTERVAL_PROP_NAME, CLUSTER_BACKUP_INTERVAL_DEFAULT_NS);
         }
 
         /**
@@ -492,8 +546,20 @@ public final class ClusterBackup implements AutoCloseable
          */
         public static long clusterBackupResponseTimeoutNs()
         {
+            return clusterBackupResponseTimeoutNs(System.getProperties());
+        }
+
+        /**
+         * Timeout within which a cluster backup will expect a response from a backup query.
+         *
+         * @param properties to read the configuration from.
+         * @return timeout within which a cluster backup will expect a response from a backup query.
+         * @see #CLUSTER_BACKUP_RESPONSE_TIMEOUT_PROP_NAME
+         */
+        public static long clusterBackupResponseTimeoutNs(final Properties properties)
+        {
             return getDurationInNanos(
-                CLUSTER_BACKUP_RESPONSE_TIMEOUT_PROP_NAME, CLUSTER_BACKUP_RESPONSE_TIMEOUT_DEFAULT_NS);
+                properties, CLUSTER_BACKUP_RESPONSE_TIMEOUT_PROP_NAME, CLUSTER_BACKUP_RESPONSE_TIMEOUT_DEFAULT_NS);
         }
 
         /**
@@ -504,8 +570,20 @@ public final class ClusterBackup implements AutoCloseable
          */
         public static long clusterBackupProgressTimeoutNs()
         {
+            return clusterBackupProgressTimeoutNs(System.getProperties());
+        }
+
+        /**
+         * Timeout within which a cluster backup will expect progress.
+         *
+         * @param properties to read the configuration from.
+         * @return timeout within which a cluster backup will expect progress.
+         * @see #CLUSTER_BACKUP_PROGRESS_TIMEOUT_PROP_NAME
+         */
+        public static long clusterBackupProgressTimeoutNs(final Properties properties)
+        {
             return getDurationInNanos(
-                CLUSTER_BACKUP_PROGRESS_TIMEOUT_PROP_NAME, CLUSTER_BACKUP_PROGRESS_TIMEOUT_DEFAULT_NS);
+                properties, CLUSTER_BACKUP_PROGRESS_TIMEOUT_PROP_NAME, CLUSTER_BACKUP_PROGRESS_TIMEOUT_DEFAULT_NS);
         }
 
         /**
@@ -516,8 +594,20 @@ public final class ClusterBackup implements AutoCloseable
          */
         public static long clusterBackupCoolDownIntervalNs()
         {
+            return clusterBackupCoolDownIntervalNs(System.getProperties());
+        }
+
+        /**
+         * Interval at which the cluster backup is re-initialised after an exception has been thrown.
+         *
+         * @param properties to read the configuration from.
+         * @return interval at which the cluster backup is re-initialised after an exception has been thrown.
+         * @see #CLUSTER_BACKUP_COOL_DOWN_INTERVAL_PROP_NAME
+         */
+        public static long clusterBackupCoolDownIntervalNs(final Properties properties)
+        {
             return getDurationInNanos(
-                CLUSTER_BACKUP_COOL_DOWN_INTERVAL_PROP_NAME, CLUSTER_BACKUP_COOL_DOWN_INTERVAL_DEFAULT_NS);
+                properties, CLUSTER_BACKUP_COOL_DOWN_INTERVAL_PROP_NAME, CLUSTER_BACKUP_COOL_DOWN_INTERVAL_DEFAULT_NS);
         }
 
         /**
@@ -529,7 +619,20 @@ public final class ClusterBackup implements AutoCloseable
          */
         public static String clusterBackupSourceType()
         {
-            return System.getProperty(CLUSTER_BACKUP_SOURCE_TYPE_PROP_NAME, CLUSTER_BACKUP_SOURCE_TYPE_DEFAULT);
+            return clusterBackupSourceType(System.getProperties());
+        }
+
+        /**
+         * Returns the string representation of the {@link SourceType} that this backup instance will use depending on
+         * the value of the {@link #CLUSTER_BACKUP_CATCHUP_CHANNEL_PROP_NAME} system property if set or
+         * {@link #CLUSTER_BACKUP_SOURCE_TYPE_DEFAULT} if not.
+         *
+         * @param properties to read the configuration from.
+         * @return the configured source type.
+         */
+        public static String clusterBackupSourceType(final Properties properties)
+        {
+            return properties.getProperty(CLUSTER_BACKUP_SOURCE_TYPE_PROP_NAME, CLUSTER_BACKUP_SOURCE_TYPE_DEFAULT);
         }
 
         /**
@@ -568,7 +671,19 @@ public final class ClusterBackup implements AutoCloseable
          */
         public static ReplayStart clusterInitialReplayStart()
         {
-            final String propertyValue = getProperty(CLUSTER_INITIAL_REPLAY_START_PROP_NAME);
+            return clusterInitialReplayStart(System.getProperties());
+        }
+
+        /**
+         * Get the initial value for the cluster relay start.
+         *
+         * @param properties to read the configuration from.
+         * @return enum to determine where to start replaying the log from.
+         * @see #CLUSTER_INITIAL_REPLAY_START_PROP_NAME
+         */
+        public static ReplayStart clusterInitialReplayStart(final Properties properties)
+        {
+            final String propertyValue = properties.getProperty(CLUSTER_INITIAL_REPLAY_START_PROP_NAME);
             if (null == propertyValue)
             {
                 return CLUSTER_INITIAL_REPLAY_START_DEFAULT;
@@ -597,33 +712,34 @@ public final class ClusterBackup implements AutoCloseable
             }
         }
 
+        private final Properties properties;
         private volatile boolean isConcluded;
-        private boolean ownsAeronClient = false;
-        private String aeronDirectoryName = CommonContext.getAeronDirectoryName();
+        private boolean ownsAeronClient;
+        private String aeronDirectoryName;
         private Aeron aeron;
 
-        private int clusterId = ClusteredServiceContainer.Configuration.clusterId();
-        private String consensusChannel = Configuration.consensusChannel();
-        private int consensusStreamId = ConsensusModule.Configuration.consensusStreamId();
-        private int consensusModuleSnapshotStreamId = ConsensusModule.Configuration.snapshotStreamId();
-        private int serviceSnapshotStreamId = ClusteredServiceContainer.Configuration.snapshotStreamId();
-        private int logStreamId = ConsensusModule.Configuration.logStreamId();
-        private String catchupEndpoint = Configuration.catchupEndpoint();
-        private String catchupChannel = Configuration.catchupChannel();
+        private int clusterId;
+        private String consensusChannel;
+        private int consensusStreamId;
+        private int consensusModuleSnapshotStreamId;
+        private int serviceSnapshotStreamId;
+        private int logStreamId;
+        private String catchupEndpoint;
+        private String catchupChannel;
 
-        private long clusterBackupIntervalNs = Configuration.clusterBackupIntervalNs();
-        private long clusterBackupResponseTimeoutNs = Configuration.clusterBackupResponseTimeoutNs();
-        private long clusterBackupProgressTimeoutNs = Configuration.clusterBackupProgressTimeoutNs();
-        private long clusterBackupCoolDownIntervalNs = Configuration.clusterBackupCoolDownIntervalNs();
-        private int errorBufferLength = ConsensusModule.Configuration.errorBufferLength();
+        private long clusterBackupIntervalNs;
+        private long clusterBackupResponseTimeoutNs;
+        private long clusterBackupProgressTimeoutNs;
+        private long clusterBackupCoolDownIntervalNs;
+        private int errorBufferLength;
 
-        private boolean deleteDirOnStart = false;
-        private boolean useAgentInvoker = false;
-        private String clusterDirectoryName = ClusteredServiceContainer.Configuration.clusterDirName();
+        private boolean deleteDirOnStart;
+        private boolean useAgentInvoker;
+        private String clusterDirectoryName;
         private File clusterDir;
         private File markFileDir;
         private ClusterMarkFile markFile;
-        private String clusterConsensusEndpoints = ConsensusModule.Configuration.clusterConsensusEndpoints();
+        private String clusterConsensusEndpoints;
         private ThreadFactory threadFactory;
         private EpochClock epochClock;
         private Supplier<IdleStrategy> idleStrategySupplier;
@@ -642,16 +758,68 @@ public final class ClusterBackup implements AutoCloseable
         private Runnable terminationHook;
         private ClusterBackupEventsListener eventsListener;
         private CredentialsSupplier credentialsSupplier;
-        private String sourceType = Configuration.clusterBackupSourceType();
-        private long replicationProgressTimeoutNs = ConsensusModule.Configuration.replicationProgressTimeoutNs();
-        private long replicationProgressIntervalNs = ConsensusModule.Configuration.replicationProgressIntervalNs();
-        private Configuration.ReplayStart initialReplayStart = Configuration.clusterInitialReplayStart();
+        private String sourceType;
+        private long replicationProgressTimeoutNs;
+        private long replicationProgressIntervalNs;
+        private Configuration.ReplayStart initialReplayStart;
 
         /**
          * Construct a Context using default values and loading from system properties.
          */
         public Context()
         {
+            this(System.getProperties());
+        }
+
+        /**
+         * Construct a Context using default values loaded from the supplied properties.
+         *
+         * @param properties to load the configuration from.
+         */
+        public Context(final Properties properties)
+        {
+            this.properties = properties;
+            applyDefaults(properties);
+        }
+
+        /**
+         * The properties this context was constructed from, to be propagated to any context it
+         * creates.
+         *
+         * @return the properties this context was constructed from.
+         */
+        public Properties properties()
+        {
+            return properties;
+        }
+
+        private void applyDefaults(final Properties properties)
+        {
+            ownsAeronClient = false;
+            aeronDirectoryName = CommonContext.getAeronDirectoryName(properties);
+            clusterId = ClusteredServiceContainer.Configuration.clusterId(properties);
+            consensusChannel = Configuration.consensusChannel(properties);
+            consensusStreamId = ConsensusModule.Configuration.consensusStreamId(properties);
+            consensusModuleSnapshotStreamId = ConsensusModule.Configuration.snapshotStreamId(properties);
+            serviceSnapshotStreamId = ClusteredServiceContainer.Configuration.snapshotStreamId(properties);
+            logStreamId = ConsensusModule.Configuration.logStreamId(properties);
+            catchupEndpoint = Configuration.catchupEndpoint(properties);
+            catchupChannel = Configuration.catchupChannel(properties);
+
+            clusterBackupIntervalNs = Configuration.clusterBackupIntervalNs(properties);
+            clusterBackupResponseTimeoutNs = Configuration.clusterBackupResponseTimeoutNs(properties);
+            clusterBackupProgressTimeoutNs = Configuration.clusterBackupProgressTimeoutNs(properties);
+            clusterBackupCoolDownIntervalNs = Configuration.clusterBackupCoolDownIntervalNs(properties);
+            errorBufferLength = ConsensusModule.Configuration.errorBufferLength(properties);
+
+            deleteDirOnStart = false;
+            useAgentInvoker = false;
+            clusterDirectoryName = ClusteredServiceContainer.Configuration.clusterDirName(properties);
+            clusterConsensusEndpoints = ConsensusModule.Configuration.clusterConsensusEndpoints(properties);
+            sourceType = Configuration.clusterBackupSourceType(properties);
+            replicationProgressTimeoutNs = ConsensusModule.Configuration.replicationProgressTimeoutNs(properties);
+            replicationProgressIntervalNs = ConsensusModule.Configuration.replicationProgressIntervalNs(properties);
+            initialReplayStart = Configuration.clusterInitialReplayStart(properties);
         }
 
         /**
@@ -710,7 +878,7 @@ public final class ClusterBackup implements AutoCloseable
 
             if (null == markFileDir)
             {
-                final String dir = ClusteredServiceContainer.Configuration.markFileDir();
+                final String dir = ClusteredServiceContainer.Configuration.markFileDir(properties);
                 markFileDir = Strings.isEmpty(dir) ? clusterDir : new File(dir);
             }
 
@@ -739,7 +907,8 @@ public final class ClusterBackup implements AutoCloseable
                     errorBufferLength,
                     epochClock,
                     LIVENESS_TIMEOUT_MS,
-                    filePageSize);
+                    filePageSize,
+                    CommonContext.fallbackLogger(properties));
             }
 
             MarkFile.ensureMarkFileLink(
@@ -752,7 +921,7 @@ public final class ClusterBackup implements AutoCloseable
                 errorLog = new DistinctErrorLog(markFile.errorBuffer(), epochClock, US_ASCII);
             }
 
-            errorHandler = CommonContext.setupErrorHandler(errorHandler, errorLog);
+            errorHandler = CommonContext.setupErrorHandler(properties, errorHandler, errorLog);
 
             final String clientName = "cluster-backup clusterId=" + clusterId;
             if (null == aeron)
@@ -760,7 +929,7 @@ public final class ClusterBackup implements AutoCloseable
                 ownsAeronClient = true;
 
                 aeron = Aeron.connect(
-                    new Aeron.Context()
+                    new Aeron.Context(properties)
                         .aeronDirectoryName(aeronDirectoryName)
                         .errorHandler(errorHandler)
                         .epochClock(epochClock)
@@ -842,15 +1011,15 @@ public final class ClusterBackup implements AutoCloseable
 
             if (null == idleStrategySupplier)
             {
-                idleStrategySupplier = ClusteredServiceContainer.Configuration.idleStrategySupplier(null);
+                idleStrategySupplier = ClusteredServiceContainer.Configuration.idleStrategySupplier(properties, null);
             }
 
             if (null == archiveContext)
             {
-                archiveContext = new AeronArchive.Context()
-                    .controlRequestChannel(AeronArchive.Configuration.localControlChannel())
-                    .controlResponseChannel(AeronArchive.Configuration.localControlChannel())
-                    .controlRequestStreamId(AeronArchive.Configuration.localControlStreamId());
+                archiveContext = new AeronArchive.Context(properties)
+                    .controlRequestChannel(AeronArchive.Configuration.localControlChannel(properties))
+                    .controlResponseChannel(AeronArchive.Configuration.localControlChannel(properties))
+                    .controlRequestStreamId(AeronArchive.Configuration.localControlStreamId(properties));
             }
 
             archiveContext
@@ -872,7 +1041,7 @@ public final class ClusterBackup implements AutoCloseable
 
             if (null == clusterArchiveContext)
             {
-                clusterArchiveContext = new AeronArchive.Context();
+                clusterArchiveContext = new AeronArchive.Context(properties);
             }
 
             clusterArchiveContext
@@ -899,7 +1068,7 @@ public final class ClusterBackup implements AutoCloseable
             {
                 throw new ConfigurationException(
                     "ClusterBackup.Context.sourceType=" + sourceType + " is not valid. Must be one of: " +
-                    Arrays.toString(SourceType.values()));
+                        Arrays.toString(SourceType.values()));
             }
 
             concludeMarkFile();
@@ -2030,12 +2199,12 @@ public final class ClusterBackup implements AutoCloseable
 
             markFile.encoder()
                 .archiveStreamId(archiveContext.controlRequestStreamId())
-                .serviceStreamId(ClusteredServiceContainer.Configuration.serviceStreamId())
-                .consensusModuleStreamId(ClusteredServiceContainer.Configuration.consensusModuleStreamId())
-                .ingressStreamId(AeronCluster.Configuration.ingressStreamId())
+                .serviceStreamId(ClusteredServiceContainer.Configuration.serviceStreamId(properties))
+                .consensusModuleStreamId(ClusteredServiceContainer.Configuration.consensusModuleStreamId(properties))
+                .ingressStreamId(AeronCluster.Configuration.ingressStreamId(properties))
                 .memberId(-1)
                 .serviceId(SERVICE_ID)
-                .clusterId(ClusteredServiceContainer.Configuration.clusterId())
+                .clusterId(ClusteredServiceContainer.Configuration.clusterId(properties))
                 .aeronDirectory(aeron.context().aeronDirectoryName())
                 .controlChannel(null)
                 .ingressChannel(null)

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackupAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackupAgent.java
@@ -57,7 +57,13 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static io.aeron.Aeron.NULL_VALUE;
-import static io.aeron.CommonContext.*;
+import static io.aeron.CommonContext.CONTROL_MODE_RESPONSE;
+import static io.aeron.CommonContext.ENDPOINT_PARAM_NAME;
+import static io.aeron.CommonContext.MDC_CONTROL_MODE_PARAM_NAME;
+import static io.aeron.CommonContext.MDC_CONTROL_PARAM_NAME;
+import static io.aeron.CommonContext.SESSION_ID_PARAM_NAME;
+import static io.aeron.CommonContext.TAGS_PARAM_NAME;
+import static io.aeron.CommonContext.threadName;
 import static io.aeron.archive.client.AeronArchive.NULL_LENGTH;
 import static io.aeron.archive.client.AeronArchive.NULL_POSITION;
 import static io.aeron.archive.client.AeronArchive.NULL_TIMESTAMP;
@@ -176,7 +182,8 @@ public final class ClusterBackupAgent implements Agent
         liveLogPositionCounter = ctx.liveLogPositionCounter();
         nextQueryDeadlineMsCounter = ctx.nextQueryDeadlineMsCounter();
         logSourceValidator = new LogSourceValidator(ctx.sourceType());
-        roleName = threadName(AERON_CLUSTER_BACKUP_THREAD_NAME, AERON_CLUSTER_BACKUP_THREAD_NAME_CLASSIC);
+        roleName = threadName(
+            ctx.properties(), AERON_CLUSTER_BACKUP_THREAD_NAME, AERON_CLUSTER_BACKUP_THREAD_NAME_CLASSIC);
     }
 
     /**

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
@@ -80,6 +80,7 @@ import java.io.UncheckedIOException;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.nio.charset.StandardCharsets;
+import java.util.Properties;
 import java.util.Random;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
@@ -102,6 +103,10 @@ import static io.aeron.CommonContext.UDP_CHANNEL;
 import static io.aeron.CommonContext.driverFilePageSize;
 import static io.aeron.CommonContext.fallbackLogger;
 import static io.aeron.CommonContext.threadName;
+import static io.aeron.PropertiesUtil.getBoolean;
+import static io.aeron.PropertiesUtil.getDurationInNanos;
+import static io.aeron.PropertiesUtil.getInteger;
+import static io.aeron.PropertiesUtil.getSizeAsInt;
 import static io.aeron.cluster.ConsensusModule.Configuration.CLUSTER_CLIENT_TIMEOUT_COUNT_TYPE_ID;
 import static io.aeron.cluster.ConsensusModule.Configuration.CLUSTER_CLOCK_PROP_NAME;
 import static io.aeron.cluster.ConsensusModule.Configuration.CLUSTER_NODE_ROLE_TYPE_ID;
@@ -110,13 +115,11 @@ import static io.aeron.cluster.ConsensusModule.Configuration.CONSENSUS_MODULE_ER
 import static io.aeron.cluster.ConsensusModule.Configuration.CONSENSUS_MODULE_STATE_TYPE_ID;
 import static io.aeron.cluster.ConsensusModule.Configuration.CONTROL_TOGGLE_TYPE_ID;
 import static io.aeron.cluster.ConsensusModule.Configuration.ELECTION_STATE_TYPE_ID;
-import static io.aeron.cluster.service.ClusteredServiceContainer.Configuration.MAX_SERVICE_COUNT;
 import static io.aeron.cluster.ConsensusModule.Configuration.SERVICE_ID;
 import static io.aeron.cluster.ConsensusModule.Configuration.SNAPSHOT_COUNTER_TYPE_ID;
+import static io.aeron.cluster.service.ClusteredServiceContainer.Configuration.MAX_SERVICE_COUNT;
 import static java.lang.Boolean.parseBoolean;
 import static org.agrona.BitUtil.findNextPositivePowerOfTwo;
-import static org.agrona.SystemUtil.getDurationInNanos;
-import static org.agrona.SystemUtil.getSizeAsInt;
 import static org.agrona.SystemUtil.loadPropertiesFiles;
 
 /**
@@ -1021,7 +1024,21 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static int ingressFragmentLimit()
         {
-            return Integer.getInteger(CLUSTER_INGRESS_FRAGMENT_LIMIT_PROP_NAME, CLUSTER_INGRESS_FRAGMENT_LIMIT_DEFAULT);
+            return ingressFragmentLimit(System.getProperties());
+        }
+
+        /**
+         * The value {@link #CLUSTER_INGRESS_FRAGMENT_LIMIT_DEFAULT} or system property
+         * {@link #CLUSTER_INGRESS_FRAGMENT_LIMIT_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #CLUSTER_INGRESS_FRAGMENT_LIMIT_DEFAULT} or system property
+         * {@link #CLUSTER_INGRESS_FRAGMENT_LIMIT_PROP_NAME} if set.
+         */
+        public static int ingressFragmentLimit(final Properties properties)
+        {
+            return getInteger(
+                properties, CLUSTER_INGRESS_FRAGMENT_LIMIT_PROP_NAME, CLUSTER_INGRESS_FRAGMENT_LIMIT_DEFAULT);
         }
 
         /**
@@ -1033,7 +1050,20 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static boolean isIpcIngressAllowed()
         {
-            return "true".equalsIgnoreCase(System.getProperty(
+            return isIpcIngressAllowed(System.getProperties());
+        }
+
+        /**
+         * The value {@link #CLUSTER_INGRESS_IPC_ALLOWED_DEFAULT} or system property
+         * {@link #CLUSTER_INGRESS_IPC_ALLOWED_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #CLUSTER_INGRESS_IPC_ALLOWED_DEFAULT} or system property
+         * {@link #CLUSTER_INGRESS_IPC_ALLOWED_PROP_NAME} if set.
+         */
+        public static boolean isIpcIngressAllowed(final Properties properties)
+        {
+            return "true".equalsIgnoreCase(properties.getProperty(
                 CLUSTER_INGRESS_IPC_ALLOWED_PROP_NAME, CLUSTER_INGRESS_IPC_ALLOWED_DEFAULT));
         }
 
@@ -1046,7 +1076,20 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static int clusterMemberId()
         {
-            return Integer.getInteger(CLUSTER_MEMBER_ID_PROP_NAME, CLUSTER_MEMBER_ID_DEFAULT);
+            return clusterMemberId(System.getProperties());
+        }
+
+        /**
+         * The value {@link #CLUSTER_MEMBER_ID_DEFAULT} or system property
+         * {@link #CLUSTER_MEMBER_ID_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #CLUSTER_MEMBER_ID_DEFAULT} or system property
+         * {@link #CLUSTER_MEMBER_ID_PROP_NAME} if set.
+         */
+        public static int clusterMemberId(final Properties properties)
+        {
+            return getInteger(properties, CLUSTER_MEMBER_ID_PROP_NAME, CLUSTER_MEMBER_ID_DEFAULT);
         }
 
         /**
@@ -1060,7 +1103,22 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static int appointedLeaderId()
         {
-            return Integer.getInteger(APPOINTED_LEADER_ID_PROP_NAME, APPOINTED_LEADER_ID_DEFAULT);
+            return appointedLeaderId(System.getProperties());
+        }
+
+        /**
+         * The value {@link #APPOINTED_LEADER_ID_DEFAULT} or system property
+         * {@link #APPOINTED_LEADER_ID_PROP_NAME} if set.
+         * <p>
+         * This feature is for testing and not recommended for production usage.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #APPOINTED_LEADER_ID_DEFAULT} or system property
+         * {@link #APPOINTED_LEADER_ID_PROP_NAME} if set.
+         */
+        public static int appointedLeaderId(final Properties properties)
+        {
+            return getInteger(properties, APPOINTED_LEADER_ID_PROP_NAME, APPOINTED_LEADER_ID_DEFAULT);
         }
 
         /**
@@ -1070,7 +1128,18 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static String clusterMembers()
         {
-            return System.getProperty(CLUSTER_MEMBERS_PROP_NAME);
+            return clusterMembers(System.getProperties());
+        }
+
+        /**
+         * The value of system property {@link #CLUSTER_MEMBERS_PROP_NAME} if set, null otherwise.
+         *
+         * @param properties to read the configuration from.
+         * @return of system property {@link #CLUSTER_MEMBERS_PROP_NAME} if set.
+         */
+        public static String clusterMembers(final Properties properties)
+        {
+            return properties.getProperty(CLUSTER_MEMBERS_PROP_NAME);
         }
 
         /**
@@ -1082,7 +1151,20 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static String clusterConsensusEndpoints()
         {
-            return System.getProperty(CLUSTER_CONSENSUS_ENDPOINTS_PROP_NAME, CLUSTER_CONSENSUS_ENDPOINTS_DEFAULT);
+            return clusterConsensusEndpoints(System.getProperties());
+        }
+
+        /**
+         * The value {@link #CLUSTER_CONSENSUS_ENDPOINTS_DEFAULT} or system property
+         * {@link #CLUSTER_CONSENSUS_ENDPOINTS_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #CLUSTER_CONSENSUS_ENDPOINTS_DEFAULT} or system property
+         * {@link #CLUSTER_CONSENSUS_ENDPOINTS_PROP_NAME} it set.
+         */
+        public static String clusterConsensusEndpoints(final Properties properties)
+        {
+            return properties.getProperty(CLUSTER_CONSENSUS_ENDPOINTS_PROP_NAME, CLUSTER_CONSENSUS_ENDPOINTS_DEFAULT);
         }
 
         /**
@@ -1092,7 +1174,18 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static String logChannel()
         {
-            return System.getProperty(LOG_CHANNEL_PROP_NAME, LOG_CHANNEL_DEFAULT);
+            return logChannel(System.getProperties());
+        }
+
+        /**
+         * The value {@link #LOG_CHANNEL_DEFAULT} or system property {@link #LOG_CHANNEL_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #LOG_CHANNEL_DEFAULT} or system property {@link #LOG_CHANNEL_PROP_NAME} if set.
+         */
+        public static String logChannel(final Properties properties)
+        {
+            return properties.getProperty(LOG_CHANNEL_PROP_NAME, LOG_CHANNEL_DEFAULT);
         }
 
         /**
@@ -1102,7 +1195,18 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static int logStreamId()
         {
-            return Integer.getInteger(LOG_STREAM_ID_PROP_NAME, LOG_STREAM_ID_DEFAULT);
+            return logStreamId(System.getProperties());
+        }
+
+        /**
+         * The value {@link #LOG_STREAM_ID_DEFAULT} or system property {@link #LOG_STREAM_ID_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #LOG_STREAM_ID_DEFAULT} or system property {@link #LOG_STREAM_ID_PROP_NAME} if set.
+         */
+        public static int logStreamId(final Properties properties)
+        {
+            return getInteger(properties, LOG_STREAM_ID_PROP_NAME, LOG_STREAM_ID_DEFAULT);
         }
 
         /**
@@ -1112,7 +1216,18 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static String memberEndpoints()
         {
-            return System.getProperty(MEMBER_ENDPOINTS_PROP_NAME, MEMBER_ENDPOINTS_DEFAULT);
+            return memberEndpoints(System.getProperties());
+        }
+
+        /**
+         * The value {@link #MEMBER_ENDPOINTS_DEFAULT} or system property {@link #MEMBER_ENDPOINTS_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #MEMBER_ENDPOINTS_DEFAULT} or system property {@link #MEMBER_ENDPOINTS_PROP_NAME} if set.
+         */
+        public static String memberEndpoints(final Properties properties)
+        {
+            return properties.getProperty(MEMBER_ENDPOINTS_PROP_NAME, MEMBER_ENDPOINTS_DEFAULT);
         }
 
         /**
@@ -1124,7 +1239,20 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static String snapshotChannel()
         {
-            return System.getProperty(
+            return snapshotChannel(System.getProperties());
+        }
+
+        /**
+         * The value {@link #SNAPSHOT_CHANNEL_DEFAULT} or system property
+         * {@link io.aeron.cluster.service.ClusteredServiceContainer.Configuration#SNAPSHOT_CHANNEL_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #SNAPSHOT_CHANNEL_DEFAULT} or system property
+         * {@link io.aeron.cluster.service.ClusteredServiceContainer.Configuration#SNAPSHOT_CHANNEL_PROP_NAME} if set.
+         */
+        public static String snapshotChannel(final Properties properties)
+        {
+            return properties.getProperty(
                 ClusteredServiceContainer.Configuration.SNAPSHOT_CHANNEL_PROP_NAME, SNAPSHOT_CHANNEL_DEFAULT);
         }
 
@@ -1137,8 +1265,23 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static int snapshotStreamId()
         {
-            return Integer.getInteger(
-                ClusteredServiceContainer.Configuration.SNAPSHOT_STREAM_ID_PROP_NAME, SNAPSHOT_STREAM_ID_DEFAULT);
+            return snapshotStreamId(System.getProperties());
+        }
+
+        /**
+         * The value {@link #SNAPSHOT_STREAM_ID_DEFAULT} or system property
+         * {@link io.aeron.cluster.service.ClusteredServiceContainer.Configuration#SNAPSHOT_STREAM_ID_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #SNAPSHOT_STREAM_ID_DEFAULT} or system property
+         * {@link io.aeron.cluster.service.ClusteredServiceContainer.Configuration#SNAPSHOT_STREAM_ID_PROP_NAME} if set.
+         */
+        public static int snapshotStreamId(final Properties properties)
+        {
+            return getInteger(
+                properties,
+                ClusteredServiceContainer.Configuration.SNAPSHOT_STREAM_ID_PROP_NAME,
+                SNAPSHOT_STREAM_ID_DEFAULT);
         }
 
         /**
@@ -1150,7 +1293,20 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static int serviceCount()
         {
-            return Integer.getInteger(SERVICE_COUNT_PROP_NAME, SERVICE_COUNT_DEFAULT);
+            return serviceCount(System.getProperties());
+        }
+
+        /**
+         * The value {@link #SERVICE_COUNT_DEFAULT} or system property
+         * {@link #SERVICE_COUNT_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #SERVICE_COUNT_DEFAULT} or system property
+         * {@link #SERVICE_COUNT_PROP_NAME} if set.
+         */
+        public static int serviceCount(final Properties properties)
+        {
+            return getInteger(properties, SERVICE_COUNT_PROP_NAME, SERVICE_COUNT_DEFAULT);
         }
 
         /**
@@ -1162,7 +1318,20 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static int maxConcurrentSessions()
         {
-            return Integer.getInteger(MAX_CONCURRENT_SESSIONS_PROP_NAME, MAX_CONCURRENT_SESSIONS_DEFAULT);
+            return maxConcurrentSessions(System.getProperties());
+        }
+
+        /**
+         * The value {@link #MAX_CONCURRENT_SESSIONS_DEFAULT} or system property
+         * {@link #MAX_CONCURRENT_SESSIONS_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #MAX_CONCURRENT_SESSIONS_DEFAULT} or system property
+         * {@link #MAX_CONCURRENT_SESSIONS_PROP_NAME} if set.
+         */
+        public static int maxConcurrentSessions(final Properties properties)
+        {
+            return getInteger(properties, MAX_CONCURRENT_SESSIONS_PROP_NAME, MAX_CONCURRENT_SESSIONS_DEFAULT);
         }
 
         /**
@@ -1173,7 +1342,19 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static long sessionTimeoutNs()
         {
-            return getDurationInNanos(SESSION_TIMEOUT_PROP_NAME, SESSION_TIMEOUT_DEFAULT_NS);
+            return sessionTimeoutNs(System.getProperties());
+        }
+
+        /**
+         * Timeout for a session if no activity is observed.
+         *
+         * @param properties to read the configuration from.
+         * @return timeout in nanoseconds to wait for activity
+         * @see #SESSION_TIMEOUT_PROP_NAME
+         */
+        public static long sessionTimeoutNs(final Properties properties)
+        {
+            return getDurationInNanos(properties, SESSION_TIMEOUT_PROP_NAME, SESSION_TIMEOUT_DEFAULT_NS);
         }
 
         /**
@@ -1184,7 +1365,20 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static long leaderHeartbeatTimeoutNs()
         {
-            return getDurationInNanos(LEADER_HEARTBEAT_TIMEOUT_PROP_NAME, LEADER_HEARTBEAT_TIMEOUT_DEFAULT_NS);
+            return leaderHeartbeatTimeoutNs(System.getProperties());
+        }
+
+        /**
+         * Timeout for a leader if no heartbeat is received by another member.
+         *
+         * @param properties to read the configuration from.
+         * @return timeout in nanoseconds to wait for heartbeat from a leader.
+         * @see #LEADER_HEARTBEAT_TIMEOUT_PROP_NAME
+         */
+        public static long leaderHeartbeatTimeoutNs(final Properties properties)
+        {
+            return getDurationInNanos(
+                properties, LEADER_HEARTBEAT_TIMEOUT_PROP_NAME, LEADER_HEARTBEAT_TIMEOUT_DEFAULT_NS);
         }
 
         /**
@@ -1195,7 +1389,20 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static long leaderHeartbeatIntervalNs()
         {
-            return getDurationInNanos(LEADER_HEARTBEAT_INTERVAL_PROP_NAME, LEADER_HEARTBEAT_INTERVAL_DEFAULT_NS);
+            return leaderHeartbeatIntervalNs(System.getProperties());
+        }
+
+        /**
+         * Interval at which a leader will send a heartbeat if the log is not progressing.
+         *
+         * @param properties to read the configuration from.
+         * @return timeout in nanoseconds to for leader heartbeats when no log being appended.
+         * @see #LEADER_HEARTBEAT_INTERVAL_PROP_NAME
+         */
+        public static long leaderHeartbeatIntervalNs(final Properties properties)
+        {
+            return getDurationInNanos(
+                properties, LEADER_HEARTBEAT_INTERVAL_PROP_NAME, LEADER_HEARTBEAT_INTERVAL_DEFAULT_NS);
         }
 
         /**
@@ -1206,7 +1413,20 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static long startupCanvassTimeoutNs()
         {
-            return getDurationInNanos(STARTUP_CANVASS_TIMEOUT_PROP_NAME, STARTUP_CANVASS_TIMEOUT_DEFAULT_NS);
+            return startupCanvassTimeoutNs(System.getProperties());
+        }
+
+        /**
+         * Timeout waiting to canvass the status of cluster members before voting if a majority have been heard from.
+         *
+         * @param properties to read the configuration from.
+         * @return timeout in nanoseconds to wait for the status of other cluster members before voting.
+         * @see #STARTUP_CANVASS_TIMEOUT_PROP_NAME
+         */
+        public static long startupCanvassTimeoutNs(final Properties properties)
+        {
+            return getDurationInNanos(
+                properties, STARTUP_CANVASS_TIMEOUT_PROP_NAME, STARTUP_CANVASS_TIMEOUT_DEFAULT_NS);
         }
 
         /**
@@ -1217,7 +1437,19 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static long electionTimeoutNs()
         {
-            return getDurationInNanos(ELECTION_TIMEOUT_PROP_NAME, ELECTION_TIMEOUT_DEFAULT_NS);
+            return electionTimeoutNs(System.getProperties());
+        }
+
+        /**
+         * Timeout waiting for votes to become leader in an election.
+         *
+         * @param properties to read the configuration from.
+         * @return timeout in nanoseconds to wait for votes to become leader in an election.
+         * @see #ELECTION_TIMEOUT_PROP_NAME
+         */
+        public static long electionTimeoutNs(final Properties properties)
+        {
+            return getDurationInNanos(properties, ELECTION_TIMEOUT_PROP_NAME, ELECTION_TIMEOUT_DEFAULT_NS);
         }
 
         /**
@@ -1228,7 +1460,20 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static long electionStatusIntervalNs()
         {
-            return getDurationInNanos(ELECTION_STATUS_INTERVAL_PROP_NAME, ELECTION_STATUS_INTERVAL_DEFAULT_NS);
+            return electionStatusIntervalNs(System.getProperties());
+        }
+
+        /**
+         * Interval at which a member will send out status messages during the election phases.
+         *
+         * @param properties to read the configuration from.
+         * @return interval at which a member will send out status messages during the election phases.
+         * @see #ELECTION_STATUS_INTERVAL_PROP_NAME
+         */
+        public static long electionStatusIntervalNs(final Properties properties)
+        {
+            return getDurationInNanos(
+                properties, ELECTION_STATUS_INTERVAL_PROP_NAME, ELECTION_STATUS_INTERVAL_DEFAULT_NS);
         }
 
         /**
@@ -1239,7 +1484,19 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static long terminationTimeoutNs()
         {
-            return getDurationInNanos(TERMINATION_TIMEOUT_PROP_NAME, TERMINATION_TIMEOUT_DEFAULT_NS);
+            return terminationTimeoutNs(System.getProperties());
+        }
+
+        /**
+         * Timeout waiting for follower termination by leader.
+         *
+         * @param properties to read the configuration from.
+         * @return timeout in nanoseconds to wait followers to terminate.
+         * @see #TERMINATION_TIMEOUT_PROP_NAME
+         */
+        public static long terminationTimeoutNs(final Properties properties)
+        {
+            return getDurationInNanos(properties, TERMINATION_TIMEOUT_PROP_NAME, TERMINATION_TIMEOUT_DEFAULT_NS);
         }
 
         /**
@@ -1249,7 +1506,18 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static long cycleThresholdNs()
         {
-            return getDurationInNanos(CYCLE_THRESHOLD_PROP_NAME, CYCLE_THRESHOLD_DEFAULT_NS);
+            return cycleThresholdNs(System.getProperties());
+        }
+
+        /**
+         * Get threshold value for the consensus module agent work cycle threshold to track for being exceeded.
+         *
+         * @param properties to read the configuration from.
+         * @return threshold value in nanoseconds.
+         */
+        public static long cycleThresholdNs(final Properties properties)
+        {
+            return getDurationInNanos(properties, CYCLE_THRESHOLD_PROP_NAME, CYCLE_THRESHOLD_DEFAULT_NS);
         }
 
         /**
@@ -1260,8 +1528,20 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static long totalSnapshotDurationThresholdNs()
         {
+            return totalSnapshotDurationThresholdNs(System.getProperties());
+        }
+
+        /**
+         * Get threshold value, which is used for monitoring total snapshot duration breaches of its predefined
+         * threshold.
+         *
+         * @param properties to read the configuration from.
+         * @return threshold value in nanoseconds.
+         */
+        public static long totalSnapshotDurationThresholdNs(final Properties properties)
+        {
             return getDurationInNanos(
-                TOTAL_SNAPSHOT_DURATION_THRESHOLD_PROP_NAME, TOTAL_SNAPSHOT_DURATION_THRESHOLD_DEFAULT_NS);
+                properties, TOTAL_SNAPSHOT_DURATION_THRESHOLD_PROP_NAME, TOTAL_SNAPSHOT_DURATION_THRESHOLD_DEFAULT_NS);
         }
 
         /**
@@ -1272,8 +1552,20 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static long standbySnapshotNotificationProcessingDelayNs()
         {
+            return standbySnapshotNotificationProcessingDelayNs(System.getProperties());
+        }
+
+        /**
+         * Get the delay before recording a standby snapshot notification.
+         * The delay starts after the commit position passes the snapshot's log position.
+         *
+         * @param properties to read the configuration from.
+         * @return the delay, in nanoseconds.
+         */
+        public static long standbySnapshotNotificationProcessingDelayNs(final Properties properties)
+        {
             return getDurationInNanos(
-                STANDBY_SNAPSHOT_NOTIFICATION_PROCESSING_DELAY_PROP_NAME,
+                properties, STANDBY_SNAPSHOT_NOTIFICATION_PROCESSING_DELAY_PROP_NAME,
                 STANDBY_SNAPSHOT_NOTIFICATION_PROCESSING_DELAY_DEFAULT_NS);
         }
 
@@ -1285,7 +1577,19 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static int errorBufferLength()
         {
-            return getSizeAsInt(ERROR_BUFFER_LENGTH_PROP_NAME, ERROR_BUFFER_LENGTH_DEFAULT);
+            return errorBufferLength(System.getProperties());
+        }
+
+        /**
+         * Size in bytes of the error buffer in the mark file.
+         *
+         * @param properties to read the configuration from.
+         * @return length of error buffer in bytes.
+         * @see #ERROR_BUFFER_LENGTH_PROP_NAME
+         */
+        public static int errorBufferLength(final Properties properties)
+        {
+            return getSizeAsInt(properties, ERROR_BUFFER_LENGTH_PROP_NAME, ERROR_BUFFER_LENGTH_DEFAULT);
         }
 
         /**
@@ -1297,7 +1601,20 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static AuthenticatorSupplier authenticatorSupplier()
         {
-            final String supplierClassName = System.getProperty(AUTHENTICATOR_SUPPLIER_PROP_NAME);
+            return authenticatorSupplier(System.getProperties());
+        }
+
+        /**
+         * The value {@link DefaultAuthenticatorSupplier#INSTANCE} or system property
+         * {@link #AUTHENTICATOR_SUPPLIER_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link DefaultAuthenticatorSupplier#INSTANCE} or system property
+         * {@link #AUTHENTICATOR_SUPPLIER_PROP_NAME} if set.
+         */
+        public static AuthenticatorSupplier authenticatorSupplier(final Properties properties)
+        {
+            final String supplierClassName = properties.getProperty(AUTHENTICATOR_SUPPLIER_PROP_NAME);
             if (Strings.isEmpty(supplierClassName))
             {
                 return DefaultAuthenticatorSupplier.INSTANCE;
@@ -1326,7 +1643,21 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static AuthorisationServiceSupplier authorisationServiceSupplier()
         {
-            final String supplierClassName = System.getProperty(AUTHORISATION_SERVICE_SUPPLIER_PROP_NAME);
+            return authorisationServiceSupplier(System.getProperties());
+        }
+
+        /**
+         * The {@link AuthorisationServiceSupplier} specified in the
+         * {@link #AUTHORISATION_SERVICE_SUPPLIER_PROP_NAME} system property or the
+         * {@link #DEFAULT_AUTHORISATION_SERVICE_SUPPLIER}.
+         *
+         * @param properties to read the configuration from.
+         * @return system property {@link #AUTHORISATION_SERVICE_SUPPLIER_PROP_NAME} if set or
+         * {@link #DEFAULT_AUTHORISATION_SERVICE_SUPPLIER} otherwise.
+         */
+        public static AuthorisationServiceSupplier authorisationServiceSupplier(final Properties properties)
+        {
+            final String supplierClassName = properties.getProperty(AUTHORISATION_SERVICE_SUPPLIER_PROP_NAME);
             if (Strings.isEmpty(supplierClassName))
             {
                 return DEFAULT_AUTHORISATION_SERVICE_SUPPLIER;
@@ -1337,7 +1668,8 @@ public final class ConsensusModule implements AutoCloseable
             }
             else if (AuthorisationService.ALLOW_ALL_NAME.equals(supplierClassName))
             {
-                fallbackLogger().println("Warning: Cluster authorisation service set to allow all requests");
+                fallbackLogger(properties).println(
+                    "Warning: Cluster authorisation service set to allow all requests");
                 return () -> AuthorisationService.ALLOW_ALL;
             }
 
@@ -1361,7 +1693,20 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static String consensusChannel()
         {
-            return System.getProperty(CONSENSUS_CHANNEL_PROP_NAME, CONSENSUS_CHANNEL_DEFAULT);
+            return consensusChannel(System.getProperties());
+        }
+
+        /**
+         * The value {@link #CONSENSUS_CHANNEL_DEFAULT} or system property
+         * {@link #CONSENSUS_CHANNEL_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #CONSENSUS_CHANNEL_DEFAULT} or system property
+         * {@link #CONSENSUS_CHANNEL_PROP_NAME} if set.
+         */
+        public static String consensusChannel(final Properties properties)
+        {
+            return properties.getProperty(CONSENSUS_CHANNEL_PROP_NAME, CONSENSUS_CHANNEL_DEFAULT);
         }
 
         /**
@@ -1373,7 +1718,20 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static int consensusStreamId()
         {
-            return Integer.getInteger(CONSENSUS_STREAM_ID_PROP_NAME, CONSENSUS_STREAM_ID_DEFAULT);
+            return consensusStreamId(System.getProperties());
+        }
+
+        /**
+         * The value {@link #CONSENSUS_STREAM_ID_DEFAULT} or system property
+         * {@link #CONSENSUS_STREAM_ID_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #CONSENSUS_STREAM_ID_DEFAULT} or system property
+         * {@link #CONSENSUS_STREAM_ID_PROP_NAME} if set.
+         */
+        public static int consensusStreamId(final Properties properties)
+        {
+            return getInteger(properties, CONSENSUS_STREAM_ID_PROP_NAME, CONSENSUS_STREAM_ID_DEFAULT);
         }
 
         /**
@@ -1383,7 +1741,18 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static String replicationChannel()
         {
-            return System.getProperty(REPLICATION_CHANNEL_PROP_NAME);
+            return replicationChannel(System.getProperties());
+        }
+
+        /**
+         * The system property for {@link #REPLICATION_CHANNEL_PROP_NAME} if set or null.
+         *
+         * @param properties to read the configuration from.
+         * @return system property {@link #REPLICATION_CHANNEL_PROP_NAME} if set or null.
+         */
+        public static String replicationChannel(final Properties properties)
+        {
+            return properties.getProperty(REPLICATION_CHANNEL_PROP_NAME);
         }
 
         /**
@@ -1395,7 +1764,20 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static String followerCatchupChannel()
         {
-            return System.getProperty(FOLLOWER_CATCHUP_CHANNEL_PROP_NAME, FOLLOWER_CATCHUP_CHANNEL_DEFAULT);
+            return followerCatchupChannel(System.getProperties());
+        }
+
+        /**
+         * The value {@link #FOLLOWER_CATCHUP_CHANNEL_DEFAULT} or system property
+         * {@link #FOLLOWER_CATCHUP_CHANNEL_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #FOLLOWER_CATCHUP_CHANNEL_DEFAULT} or system property
+         * {@link #FOLLOWER_CATCHUP_CHANNEL_PROP_NAME} if set.
+         */
+        public static String followerCatchupChannel(final Properties properties)
+        {
+            return properties.getProperty(FOLLOWER_CATCHUP_CHANNEL_PROP_NAME, FOLLOWER_CATCHUP_CHANNEL_DEFAULT);
         }
 
         /**
@@ -1407,7 +1789,21 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static String leaderArchiveControlChannel()
         {
-            return System.getProperty(LEADER_ARCHIVE_CONTROL_CHANNEL_PROP_NAME, LEADER_ARCHIVE_CONTROL_CHANNEL_DEFAULT);
+            return leaderArchiveControlChannel(System.getProperties());
+        }
+
+        /**
+         * The value {@link #LEADER_ARCHIVE_CONTROL_CHANNEL_DEFAULT} or system property
+         * {@link #LEADER_ARCHIVE_CONTROL_CHANNEL_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #LEADER_ARCHIVE_CONTROL_CHANNEL_DEFAULT} or system property
+         * {@link #LEADER_ARCHIVE_CONTROL_CHANNEL_PROP_NAME} if set.
+         */
+        public static String leaderArchiveControlChannel(final Properties properties)
+        {
+            return properties.getProperty(
+                LEADER_ARCHIVE_CONTROL_CHANNEL_PROP_NAME, LEADER_ARCHIVE_CONTROL_CHANNEL_DEFAULT);
         }
 
         /**
@@ -1419,7 +1815,20 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static long wheelTickResolutionNs()
         {
-            return getDurationInNanos(WHEEL_TICK_RESOLUTION_PROP_NAME, WHEEL_TICK_RESOLUTION_DEFAULT_NS);
+            return wheelTickResolutionNs(System.getProperties());
+        }
+
+        /**
+         * The value {@link #WHEEL_TICK_RESOLUTION_DEFAULT_NS} or system property
+         * {@link #WHEEL_TICK_RESOLUTION_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #WHEEL_TICK_RESOLUTION_DEFAULT_NS} or system property
+         * {@link #WHEEL_TICK_RESOLUTION_PROP_NAME} if set.
+         */
+        public static long wheelTickResolutionNs(final Properties properties)
+        {
+            return getDurationInNanos(properties, WHEEL_TICK_RESOLUTION_PROP_NAME, WHEEL_TICK_RESOLUTION_DEFAULT_NS);
         }
 
         /**
@@ -1431,7 +1840,20 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static int ticksPerWheel()
         {
-            return Integer.getInteger(TICKS_PER_WHEEL_PROP_NAME, TICKS_PER_WHEEL_DEFAULT);
+            return ticksPerWheel(System.getProperties());
+        }
+
+        /**
+         * The value {@link #TICKS_PER_WHEEL_DEFAULT} or system property
+         * {@link #CLUSTER_MEMBER_ID_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #TICKS_PER_WHEEL_DEFAULT} or system property
+         * {@link #TICKS_PER_WHEEL_PROP_NAME} if set.
+         */
+        public static int ticksPerWheel(final Properties properties)
+        {
+            return getInteger(properties, TICKS_PER_WHEEL_PROP_NAME, TICKS_PER_WHEEL_DEFAULT);
         }
 
         /**
@@ -1446,7 +1868,23 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static int fileSyncLevel()
         {
-            return Integer.getInteger(FILE_SYNC_LEVEL_PROP_NAME, FILE_SYNC_LEVEL_DEFAULT);
+            return fileSyncLevel(System.getProperties());
+        }
+
+        /**
+         * The level at which files should be sync'ed to disk.
+         * <ul>
+         * <li>0 - normal writes.</li>
+         * <li>1 - sync file data.</li>
+         * <li>2 - sync file data + metadata.</li>
+         * </ul>
+         *
+         * @param properties to read the configuration from.
+         * @return level at which files should be sync'ed to disk.
+         */
+        public static int fileSyncLevel(final Properties properties)
+        {
+            return getInteger(properties, FILE_SYNC_LEVEL_PROP_NAME, FILE_SYNC_LEVEL_DEFAULT);
         }
 
         /**
@@ -1457,7 +1895,19 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static String timerServiceSupplier()
         {
-            return System.getProperty(TIMER_SERVICE_SUPPLIER_PROP_NAME, TIMER_SERVICE_SUPPLIER_DEFAULT);
+            return timerServiceSupplier(System.getProperties());
+        }
+
+        /**
+         * The name of the {@link TimerServiceSupplier} to use for supplying the {@link TimerService}.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #TIMER_SERVICE_SUPPLIER_DEFAULT} or system property.
+         * {@link #TIMER_SERVICE_SUPPLIER_PROP_NAME} if set.
+         */
+        public static String timerServiceSupplier(final Properties properties)
+        {
+            return properties.getProperty(TIMER_SERVICE_SUPPLIER_PROP_NAME, TIMER_SERVICE_SUPPLIER_DEFAULT);
         }
 
         /**
@@ -1468,7 +1918,19 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static String agentRoleName()
         {
-            return System.getProperty(CLUSTER_CONSENSUS_MODULE_AGENT_ROLE_NAME_PROP_NAME);
+            return agentRoleName(System.getProperties());
+        }
+
+        /**
+         * The name to be used for the {@link Agent#roleName()} for the consensus module agent.
+         *
+         * @param properties to read the configuration from.
+         * @return name to be used for the {@link Agent#roleName()} for the consensus module agent.
+         * @see #CLUSTER_CONSENSUS_MODULE_AGENT_ROLE_NAME_PROP_NAME
+         */
+        public static String agentRoleName(final Properties properties)
+        {
+            return properties.getProperty(CLUSTER_CONSENSUS_MODULE_AGENT_ROLE_NAME_PROP_NAME);
         }
 
         /**
@@ -1480,8 +1942,23 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static long replicationProgressTimeoutNs()
         {
-            return SystemUtil.getDurationInNanos(
-                CLUSTER_REPLICATION_PROGRESS_TIMEOUT_PROP_NAME, CLUSTER_REPLICATION_PROGRESS_TIMEOUT_DEFAULT_NS);
+            return replicationProgressTimeoutNs(System.getProperties());
+        }
+
+        /**
+         * The amount of time to wait to time out an archive replication when progress has stalled.
+         *
+         * @param properties to read the configuration from.
+         * @return system property {@link #CLUSTER_REPLICATION_PROGRESS_TIMEOUT_PROP_NAME} or
+         * {@link #CLUSTER_REPLICATION_PROGRESS_TIMEOUT_DEFAULT_NS}.
+         * @since 1.41.0
+         */
+        public static long replicationProgressTimeoutNs(final Properties properties)
+        {
+            return getDurationInNanos(
+                properties,
+                CLUSTER_REPLICATION_PROGRESS_TIMEOUT_PROP_NAME,
+                CLUSTER_REPLICATION_PROGRESS_TIMEOUT_DEFAULT_NS);
         }
 
 
@@ -1494,7 +1971,20 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static long replicationProgressIntervalNs()
         {
-            return SystemUtil.getDurationInNanos(CLUSTER_REPLICATION_PROGRESS_INTERVAL_PROP_NAME, Aeron.NULL_VALUE);
+            return replicationProgressIntervalNs(System.getProperties());
+        }
+
+        /**
+         * Interval between checks for progress on an archive replication.
+         *
+         * @param properties to read the configuration from.
+         * @return system property {@link #CLUSTER_REPLICATION_PROGRESS_INTERVAL_PROP_NAME} or {@link Aeron#NULL_VALUE}
+         * if not set.
+         * @since 1.41.0
+         */
+        public static long replicationProgressIntervalNs(final Properties properties)
+        {
+            return getDurationInNanos(properties, CLUSTER_REPLICATION_PROGRESS_INTERVAL_PROP_NAME, Aeron.NULL_VALUE);
         }
 
         /**
@@ -1504,7 +1994,18 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static boolean acceptStandbySnapshots()
         {
-            return Boolean.getBoolean(CLUSTER_ACCEPT_STANDBY_SNAPSHOTS_PROP_NAME);
+            return acceptStandbySnapshots(System.getProperties());
+        }
+
+        /**
+         * If this node should accept snapshots from standby nodes.
+         *
+         * @param properties to read the configuration from.
+         * @return value from property {@link #CLUSTER_ACCEPT_STANDBY_SNAPSHOTS_PROP_NAME} or false if not set.
+         */
+        public static boolean acceptStandbySnapshots(final Properties properties)
+        {
+            return getBoolean(properties, CLUSTER_ACCEPT_STANDBY_SNAPSHOTS_PROP_NAME);
         }
 
         /**
@@ -1516,7 +2017,21 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static ConsensusModuleExtension newConsensusModuleExtension()
         {
-            final String className = System.getProperty(Configuration.CONSENSUS_MODULE_EXTENSION_CLASS_NAME_PROP_NAME);
+            return newConsensusModuleExtension(System.getProperties());
+        }
+
+        /**
+         * Create a new {@link ConsensusModuleExtension} based on the configured
+         * {@link #CONSENSUS_MODULE_EXTENSION_CLASS_NAME_PROP_NAME}.
+         *
+         * @param properties to read the configuration from.
+         * @return a new {@link ConsensusModuleExtension} based on the configured
+         * {@link #CONSENSUS_MODULE_EXTENSION_CLASS_NAME_PROP_NAME}.
+         */
+        public static ConsensusModuleExtension newConsensusModuleExtension(final Properties properties)
+        {
+            final String className =
+                properties.getProperty(Configuration.CONSENSUS_MODULE_EXTENSION_CLASS_NAME_PROP_NAME);
             if (null != className)
             {
                 try
@@ -1540,7 +2055,19 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static boolean enableControlOnConsensusChannel()
         {
-            return parseBoolean(System.getProperty(
+            return enableControlOnConsensusChannel(System.getProperties());
+        }
+
+        /**
+         * Determine the ConsensusModule should bind the control endpoint of the consensus publication.
+         *
+         * @param properties to read the configuration from.
+         * @return <code>true</code> if the ConsensusModule should bind the control endpoint of the consensus
+         * publication.
+         */
+        public static boolean enableControlOnConsensusChannel(final Properties properties)
+        {
+            return parseBoolean(properties.getProperty(
                 CONSENSUS_MODULE_ENABLE_CONTROL_ON_CONSENSUS_CHANNEL_PROP_NAME, "true"));
         }
 
@@ -1552,7 +2079,20 @@ public final class ConsensusModule implements AutoCloseable
          */
         public static boolean enableControlOnLogChannel()
         {
-            return parseBoolean(System.getProperty(CONSENSUS_MODULE_ENABLE_CONTROL_ON_LOG_CHANNEL_PROP_NAME, "true"));
+            return enableControlOnLogChannel(System.getProperties());
+        }
+
+        /**
+         * Determine the ConsensusModule should bind the control endpoint of the log publication.
+         *
+         * @param properties to read the configuration from.
+         * @return <code>true</code> if the ConsensusModule should bind the log endpoint of the consensus
+         * publication.
+         */
+        public static boolean enableControlOnLogChannel(final Properties properties)
+        {
+            return parseBoolean(
+                properties.getProperty(CONSENSUS_MODULE_ENABLE_CONTROL_ON_LOG_CHANNEL_PROP_NAME, "true"));
         }
     }
 
@@ -1578,66 +2118,66 @@ public final class ConsensusModule implements AutoCloseable
             }
         }
 
+        private final Properties properties;
         private volatile boolean isConcluded;
-        private boolean ownsAeronClient = false;
-        private String aeronDirectoryName = CommonContext.getAeronDirectoryName();
+        private boolean ownsAeronClient;
+        private String aeronDirectoryName;
         private Aeron aeron;
 
-        private boolean deleteDirOnStart = false;
-        private String clusterDirectoryName = ClusteredServiceContainer.Configuration.clusterDirName();
-        private String clusterServicesDirectoryName = ClusteredServiceContainer.Configuration.clusterServicesDirName();
+        private boolean deleteDirOnStart;
+        private String clusterDirectoryName;
+        private String clusterServicesDirectoryName;
         private File clusterDir;
         private File markFileDir;
         private RecordingLog recordingLog;
         private ClusterMarkFile markFile;
         private NodeStateFile nodeStateFile;
-        private int fileSyncLevel = Archive.Configuration.fileSyncLevel();
+        private int fileSyncLevel;
 
-        private int appVersion = SemanticVersion.compose(0, 0, 1);
-        private int clusterId = ClusteredServiceContainer.Configuration.clusterId();
-        private int clusterMemberId = Configuration.clusterMemberId();
-        private int appointedLeaderId = Configuration.appointedLeaderId();
-        private String clusterMembers = Configuration.clusterMembers();
-        private String ingressChannel = AeronCluster.Configuration.ingressChannel();
-        private int ingressStreamId = AeronCluster.Configuration.ingressStreamId();
-        private boolean isIpcIngressAllowed = Configuration.isIpcIngressAllowed();
-        private int ingressFragmentLimit = Configuration.ingressFragmentLimit();
-        private String egressChannel = AeronCluster.Configuration.egressChannel();
-        private String logChannel = Configuration.logChannel();
-        private int logStreamId = Configuration.logStreamId();
-        private String memberEndpoints = Configuration.memberEndpoints();
-        private String replayChannel = ClusteredServiceContainer.Configuration.replayChannel();
-        private int replayStreamId = ClusteredServiceContainer.Configuration.replayStreamId();
-        private String controlChannel = ClusteredServiceContainer.Configuration.controlChannel();
-        private int consensusModuleStreamId = ClusteredServiceContainer.Configuration.consensusModuleStreamId();
-        private int serviceStreamId = ClusteredServiceContainer.Configuration.serviceStreamId();
-        private String snapshotChannel = Configuration.snapshotChannel();
-        private int snapshotStreamId = Configuration.snapshotStreamId();
-        private String consensusChannel = Configuration.consensusChannel();
-        private int consensusStreamId = Configuration.consensusStreamId();
-        private String replicationChannel = Configuration.replicationChannel();
-        private String followerCatchupChannel = Configuration.followerCatchupChannel();
-        private String leaderArchiveControlChannel = Configuration.leaderArchiveControlChannel();
-        private int logFragmentLimit = ClusteredServiceContainer.Configuration.logFragmentLimit();
+        private int appVersion;
+        private int clusterId;
+        private int clusterMemberId;
+        private int appointedLeaderId;
+        private String clusterMembers;
+        private String ingressChannel;
+        private int ingressStreamId;
+        private boolean isIpcIngressAllowed;
+        private int ingressFragmentLimit;
+        private String egressChannel;
+        private String logChannel;
+        private int logStreamId;
+        private String memberEndpoints;
+        private String replayChannel;
+        private int replayStreamId;
+        private String controlChannel;
+        private int consensusModuleStreamId;
+        private int serviceStreamId;
+        private String snapshotChannel;
+        private int snapshotStreamId;
+        private String consensusChannel;
+        private int consensusStreamId;
+        private String replicationChannel;
+        private String followerCatchupChannel;
+        private String leaderArchiveControlChannel;
+        private int logFragmentLimit;
 
-        private int serviceCount = Configuration.serviceCount();
-        private int errorBufferLength = Configuration.errorBufferLength();
-        private int maxConcurrentSessions = Configuration.maxConcurrentSessions();
-        private int ticksPerWheel = Configuration.ticksPerWheel();
-        private long wheelTickResolutionNs = Configuration.wheelTickResolutionNs();
-        private long sessionTimeoutNs = Configuration.sessionTimeoutNs();
-        private long leaderHeartbeatTimeoutNs = Configuration.leaderHeartbeatTimeoutNs();
-        private long leaderHeartbeatIntervalNs = Configuration.leaderHeartbeatIntervalNs();
-        private long startupCanvassTimeoutNs = Configuration.startupCanvassTimeoutNs();
-        private long electionTimeoutNs = Configuration.electionTimeoutNs();
-        private long electionStatusIntervalNs = Configuration.electionStatusIntervalNs();
-        private long terminationTimeoutNs = Configuration.terminationTimeoutNs();
-        private long cycleThresholdNs = Configuration.cycleThresholdNs();
-        private long totalSnapshotDurationThresholdNs = Configuration.totalSnapshotDurationThresholdNs();
-        private long standbySnapshotNotificationProcessingDelayNs =
-            Configuration.standbySnapshotNotificationProcessingDelayNs();
+        private int serviceCount;
+        private int errorBufferLength;
+        private int maxConcurrentSessions;
+        private int ticksPerWheel;
+        private long wheelTickResolutionNs;
+        private long sessionTimeoutNs;
+        private long leaderHeartbeatTimeoutNs;
+        private long leaderHeartbeatIntervalNs;
+        private long startupCanvassTimeoutNs;
+        private long electionTimeoutNs;
+        private long electionStatusIntervalNs;
+        private long terminationTimeoutNs;
+        private long cycleThresholdNs;
+        private long totalSnapshotDurationThresholdNs;
+        private long standbySnapshotNotificationProcessingDelayNs;
 
-        private String agentRoleName = Configuration.agentRoleName();
+        private String agentRoleName;
         private ThreadFactory threadFactory;
         private Supplier<IdleStrategy> idleStrategySupplier;
         private ClusterClock clusterClock;
@@ -1673,17 +2213,100 @@ public final class ConsensusModule implements AutoCloseable
         private SnapshotDurationTracker totalSnapshotDurationTracker;
         private VersionValidator appVersionValidator;
         private boolean isLogMdc;
-        private boolean useAgentInvoker = false;
-        private ConsensusModuleStateExport bootstrapState = null;
-        private boolean acceptStandbySnapshots = Configuration.acceptStandbySnapshots();
-        private boolean enableControlOnConsensusChannel = Configuration.enableControlOnConsensusChannel();
-        private boolean enableControlOnLogChannel = Configuration.enableControlOnLogChannel();
+        private boolean useAgentInvoker;
+        private ConsensusModuleStateExport bootstrapState;
+        private boolean acceptStandbySnapshots;
+        private boolean enableControlOnConsensusChannel;
+        private boolean enableControlOnLogChannel;
 
         /**
          * Construct a Context using default values and loading from system properties.
          */
         public Context()
         {
+            this(System.getProperties());
+        }
+
+        /**
+         * Construct a Context using default values loaded from the supplied properties.
+         *
+         * @param properties to load the configuration from.
+         */
+        public Context(final Properties properties)
+        {
+            this.properties = properties;
+            applyDefaults(properties);
+        }
+
+        /**
+         * The properties this context was constructed from, to be propagated to any context it
+         * creates.
+         *
+         * @return the properties this context was constructed from.
+         */
+        public Properties properties()
+        {
+            return properties;
+        }
+
+        private void applyDefaults(final Properties properties)
+        {
+            ownsAeronClient = false;
+            aeronDirectoryName = CommonContext.getAeronDirectoryName(properties);
+            deleteDirOnStart = false;
+            clusterDirectoryName = ClusteredServiceContainer.Configuration.clusterDirName(properties);
+            clusterServicesDirectoryName = ClusteredServiceContainer.Configuration.clusterServicesDirName(properties);
+            fileSyncLevel = Archive.Configuration.fileSyncLevel(properties);
+
+            appVersion = SemanticVersion.compose(0, 0, 1);
+            clusterId = ClusteredServiceContainer.Configuration.clusterId(properties);
+            clusterMemberId = Configuration.clusterMemberId(properties);
+            appointedLeaderId = Configuration.appointedLeaderId(properties);
+            clusterMembers = Configuration.clusterMembers(properties);
+            ingressChannel = AeronCluster.Configuration.ingressChannel(properties);
+            ingressStreamId = AeronCluster.Configuration.ingressStreamId(properties);
+            isIpcIngressAllowed = Configuration.isIpcIngressAllowed(properties);
+            ingressFragmentLimit = Configuration.ingressFragmentLimit(properties);
+            egressChannel = AeronCluster.Configuration.egressChannel(properties);
+            logChannel = Configuration.logChannel(properties);
+            logStreamId = Configuration.logStreamId(properties);
+            memberEndpoints = Configuration.memberEndpoints(properties);
+            replayChannel = ClusteredServiceContainer.Configuration.replayChannel(properties);
+            replayStreamId = ClusteredServiceContainer.Configuration.replayStreamId(properties);
+            controlChannel = ClusteredServiceContainer.Configuration.controlChannel(properties);
+            consensusModuleStreamId = ClusteredServiceContainer.Configuration.consensusModuleStreamId(properties);
+            serviceStreamId = ClusteredServiceContainer.Configuration.serviceStreamId(properties);
+            snapshotChannel = Configuration.snapshotChannel(properties);
+            snapshotStreamId = Configuration.snapshotStreamId(properties);
+            consensusChannel = Configuration.consensusChannel(properties);
+            consensusStreamId = Configuration.consensusStreamId(properties);
+            replicationChannel = Configuration.replicationChannel(properties);
+            followerCatchupChannel = Configuration.followerCatchupChannel(properties);
+            leaderArchiveControlChannel = Configuration.leaderArchiveControlChannel(properties);
+            logFragmentLimit = ClusteredServiceContainer.Configuration.logFragmentLimit(properties);
+
+            serviceCount = Configuration.serviceCount(properties);
+            errorBufferLength = Configuration.errorBufferLength(properties);
+            maxConcurrentSessions = Configuration.maxConcurrentSessions(properties);
+            ticksPerWheel = Configuration.ticksPerWheel(properties);
+            wheelTickResolutionNs = Configuration.wheelTickResolutionNs(properties);
+            sessionTimeoutNs = Configuration.sessionTimeoutNs(properties);
+            leaderHeartbeatTimeoutNs = Configuration.leaderHeartbeatTimeoutNs(properties);
+            leaderHeartbeatIntervalNs = Configuration.leaderHeartbeatIntervalNs(properties);
+            startupCanvassTimeoutNs = Configuration.startupCanvassTimeoutNs(properties);
+            electionTimeoutNs = Configuration.electionTimeoutNs(properties);
+            electionStatusIntervalNs = Configuration.electionStatusIntervalNs(properties);
+            terminationTimeoutNs = Configuration.terminationTimeoutNs(properties);
+            cycleThresholdNs = Configuration.cycleThresholdNs(properties);
+            totalSnapshotDurationThresholdNs = Configuration.totalSnapshotDurationThresholdNs(properties);
+            standbySnapshotNotificationProcessingDelayNs = Configuration.standbySnapshotNotificationProcessingDelayNs(
+                properties);
+            agentRoleName = Configuration.agentRoleName(properties);
+            useAgentInvoker = false;
+            bootstrapState = null;
+            acceptStandbySnapshots = Configuration.acceptStandbySnapshots(properties);
+            enableControlOnConsensusChannel = Configuration.enableControlOnConsensusChannel(properties);
+            enableControlOnLogChannel = Configuration.enableControlOnLogChannel(properties);
         }
 
         /**
@@ -1728,7 +2351,7 @@ public final class ConsensusModule implements AutoCloseable
 
             if (null == markFileDir)
             {
-                final String dir = ClusteredServiceContainer.Configuration.markFileDir();
+                final String dir = ClusteredServiceContainer.Configuration.markFileDir(properties);
                 markFileDir = Strings.isEmpty(dir) ? clusterDir : new File(dir);
             }
 
@@ -1769,12 +2392,12 @@ public final class ConsensusModule implements AutoCloseable
             {
                 throw new ClusterException(
                     "startupCanvassTimeoutNs=" + startupCanvassTimeoutNs +
-                    " must be a multiple of leaderHeartbeatTimeoutNs=" + leaderHeartbeatTimeoutNs);
+                        " must be a multiple of leaderHeartbeatTimeoutNs=" + leaderHeartbeatTimeoutNs);
             }
 
             if (null == clusterClock)
             {
-                final String clockClassName = System.getProperty(
+                final String clockClassName = properties.getProperty(
                     CLUSTER_CLOCK_PROP_NAME, MillisecondClusterClock.class.getName());
                 try
                 {
@@ -1811,7 +2434,8 @@ public final class ConsensusModule implements AutoCloseable
                     errorBufferLength,
                     epochClock,
                     ClusteredServiceContainer.Configuration.LIVENESS_TIMEOUT_MS,
-                    filePageSize);
+                    filePageSize,
+                    CommonContext.fallbackLogger(properties));
             }
 
             MarkFile.ensureMarkFileLink(
@@ -1842,7 +2466,7 @@ public final class ConsensusModule implements AutoCloseable
                 errorLog = new DistinctErrorLog(markFile.errorBuffer(), epochClock, StandardCharsets.US_ASCII);
             }
 
-            errorHandler = CommonContext.setupErrorHandler(errorHandler, errorLog);
+            errorHandler = CommonContext.setupErrorHandler(properties, errorHandler, errorLog);
 
             if (null == recordingLog)
             {
@@ -1852,7 +2476,9 @@ public final class ConsensusModule implements AutoCloseable
             if (Strings.isEmpty(agentRoleName))
             {
                 agentRoleName = threadName(
-                    AERON_CLUSTER_CONSENSUS_THREAD_NAME, "consensus-module-" + clusterId + "-" + clusterMemberId);
+                    properties,
+                    AERON_CLUSTER_CONSENSUS_THREAD_NAME,
+                    "consensus-module-" + clusterId + "-" + clusterMemberId);
             }
 
             final ExpandableArrayBuffer buffer = new ExpandableArrayBuffer();
@@ -1862,7 +2488,7 @@ public final class ConsensusModule implements AutoCloseable
                 ownsAeronClient = true;
 
                 aeron = Aeron.connect(
-                    new Aeron.Context()
+                    new Aeron.Context(properties)
                         .aeronDirectoryName(aeronDirectoryName)
                         .errorHandler(errorHandler)
                         .subscriberErrorHandler(RethrowingErrorHandler.INSTANCE)
@@ -2045,7 +2671,7 @@ public final class ConsensusModule implements AutoCloseable
 
             if (null == idleStrategySupplier)
             {
-                idleStrategySupplier = ClusteredServiceContainer.Configuration.idleStrategySupplier(null);
+                idleStrategySupplier = ClusteredServiceContainer.Configuration.idleStrategySupplier(properties, null);
             }
 
             if (null == timerServiceSupplier)
@@ -2055,12 +2681,12 @@ public final class ConsensusModule implements AutoCloseable
 
             if (null == archiveContext)
             {
-                archiveContext = new AeronArchive.Context()
-                    .controlRequestChannel(AeronArchive.Configuration.localControlChannel())
-                    .controlResponseChannel(AeronArchive.Configuration.localControlChannel())
-                    .controlRequestStreamId(AeronArchive.Configuration.localControlStreamId())
+                archiveContext = new AeronArchive.Context(properties)
+                    .controlRequestChannel(AeronArchive.Configuration.localControlChannel(properties))
+                    .controlResponseChannel(AeronArchive.Configuration.localControlChannel(properties))
+                    .controlRequestStreamId(AeronArchive.Configuration.localControlStreamId(properties))
                     .controlResponseStreamId(
-                        clusterId * 100 + 100 + AeronArchive.Configuration.controlResponseStreamId());
+                        clusterId * 100 + 100 + AeronArchive.Configuration.controlResponseStreamId(properties));
             }
 
             if (!archiveContext.controlRequestChannel().startsWith(CommonContext.IPC_CHANNEL))
@@ -2084,11 +2710,11 @@ public final class ConsensusModule implements AutoCloseable
                 .ownsAeronClient(false)
                 .lock(NoOpLock.INSTANCE)
                 .controlRequestChannel(addAliasIfAbsent(
-                archiveContext.controlRequestChannel(),
-                "cm-archive-ctrl-req-cluster-" + clusterId + "-member-" + clusterMemberId))
+                    archiveContext.controlRequestChannel(),
+                    "cm-archive-ctrl-req-cluster-" + clusterId + "-member-" + clusterMemberId))
                 .controlResponseChannel(addAliasIfAbsent(
-                archiveContext.controlResponseChannel(),
-                "cm-archive-ctrl-resp-cluster-" + clusterId + "-member-" + clusterMemberId))
+                    archiveContext.controlResponseChannel(),
+                    "cm-archive-ctrl-resp-cluster-" + clusterId + "-member-" + clusterMemberId))
                 .clientName(agentRoleName);
 
             if (null == terminationHook)
@@ -2098,12 +2724,12 @@ public final class ConsensusModule implements AutoCloseable
 
             if (null == authenticatorSupplier)
             {
-                authenticatorSupplier = Configuration.authenticatorSupplier();
+                authenticatorSupplier = Configuration.authenticatorSupplier(properties);
             }
 
             if (null == authorisationServiceSupplier)
             {
-                authorisationServiceSupplier = Configuration.authorisationServiceSupplier();
+                authorisationServiceSupplier = Configuration.authorisationServiceSupplier(properties);
             }
 
             if (null == random)
@@ -2126,7 +2752,7 @@ public final class ConsensusModule implements AutoCloseable
 
             if (null == consensusModuleExtension)
             {
-                consensusModuleExtension = Configuration.newConsensusModuleExtension();
+                consensusModuleExtension = Configuration.newConsensusModuleExtension(properties);
             }
 
             if (null != consensusModuleExtension && 0 != serviceCount)
@@ -2140,7 +2766,7 @@ public final class ConsensusModule implements AutoCloseable
 
             concludeMarkFile();
 
-            if (CommonContext.shouldPrintConfigurationOnStart())
+            if (CommonContext.shouldPrintConfigurationOnStart(properties))
             {
                 System.out.println(this);
             }
@@ -3194,7 +3820,7 @@ public final class ConsensusModule implements AutoCloseable
         @Config
         public long sessionTimeoutNs()
         {
-            return CommonContext.checkDebugTimeout(sessionTimeoutNs, TimeUnit.NANOSECONDS);
+            return CommonContext.checkDebugTimeout(properties, sessionTimeoutNs, TimeUnit.NANOSECONDS);
         }
 
         /**
@@ -4512,7 +5138,7 @@ public final class ConsensusModule implements AutoCloseable
 
         private TimerServiceSupplier getTimerServiceSupplierFromSystemProperty()
         {
-            final String timeServiceClassName = Configuration.timerServiceSupplier();
+            final String timeServiceClassName = Configuration.timerServiceSupplier(properties);
             if (WheelTimerServiceSupplier.class.getName().equals(timeServiceClassName))
             {
                 return new WheelTimerServiceSupplier(

--- a/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
@@ -75,12 +75,14 @@ import org.agrona.concurrent.UnsafeBuffer;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import static io.aeron.Aeron.NULL_VALUE;
 import static io.aeron.CommonContext.REJOIN_PARAM_NAME;
-import static org.agrona.SystemUtil.getDurationInNanos;
-import static org.agrona.SystemUtil.getProperty;
+import static io.aeron.PropertiesUtil.getDurationInNanos;
+import static io.aeron.PropertiesUtil.getInteger;
+import static io.aeron.PropertiesUtil.getProperty;
 
 /**
  * Client for interacting with an Aeron Cluster.
@@ -540,8 +542,8 @@ public final class AeronCluster implements AutoCloseable
 
         final int length =
             MessageHeaderEncoder.ENCODED_LENGTH +
-            AdminRequestEncoder.BLOCK_LENGTH +
-            AdminRequestEncoder.payloadHeaderLength();
+                AdminRequestEncoder.BLOCK_LENGTH +
+                AdminRequestEncoder.payloadHeaderLength();
 
         while (true)
         {
@@ -649,7 +651,7 @@ public final class AeronCluster implements AutoCloseable
     {
         if (State.PENDING_CLOSE == state ||
             ((State.AWAIT_NEW_LEADER == state || State.AWAIT_NEW_LEADER_CONNECTION == state) &&
-            0 <= nanoClock.nanoTime() - stateDeadline))
+                0 <= nanoClock.nanoTime() - stateDeadline))
         {
             close();
 
@@ -1335,7 +1337,19 @@ public final class AeronCluster implements AutoCloseable
          */
         public static long messageTimeoutNs()
         {
-            return getDurationInNanos(MESSAGE_TIMEOUT_PROP_NAME, MESSAGE_TIMEOUT_DEFAULT_NS);
+            return messageTimeoutNs(System.getProperties());
+        }
+
+        /**
+         * The timeout in nanoseconds to wait for a message.
+         *
+         * @param properties to read the configuration from.
+         * @return timeout in nanoseconds to wait for a message.
+         * @see #MESSAGE_TIMEOUT_PROP_NAME
+         */
+        public static long messageTimeoutNs(final Properties properties)
+        {
+            return getDurationInNanos(properties, MESSAGE_TIMEOUT_PROP_NAME, MESSAGE_TIMEOUT_DEFAULT_NS);
         }
 
         /**
@@ -1345,7 +1359,18 @@ public final class AeronCluster implements AutoCloseable
          */
         public static String ingressEndpoints()
         {
-            return System.getProperty(INGRESS_ENDPOINTS_PROP_NAME, INGRESS_ENDPOINTS_DEFAULT);
+            return ingressEndpoints(System.getProperties());
+        }
+
+        /**
+         * The value {@link #INGRESS_ENDPOINTS_DEFAULT} or system property {@link #INGRESS_ENDPOINTS_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #INGRESS_ENDPOINTS_DEFAULT} or system property {@link #INGRESS_ENDPOINTS_PROP_NAME} if set.
+         */
+        public static String ingressEndpoints(final Properties properties)
+        {
+            return properties.getProperty(INGRESS_ENDPOINTS_PROP_NAME, INGRESS_ENDPOINTS_DEFAULT);
         }
 
         /**
@@ -1355,7 +1380,18 @@ public final class AeronCluster implements AutoCloseable
          */
         public static String ingressChannel()
         {
-            return System.getProperty(INGRESS_CHANNEL_PROP_NAME, INGRESS_CHANNEL_DEFAULT);
+            return ingressChannel(System.getProperties());
+        }
+
+        /**
+         * The value {@link #INGRESS_CHANNEL_DEFAULT} or system property {@link #INGRESS_CHANNEL_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #INGRESS_CHANNEL_DEFAULT} or system property {@link #INGRESS_CHANNEL_PROP_NAME} if set.
+         */
+        public static String ingressChannel(final Properties properties)
+        {
+            return properties.getProperty(INGRESS_CHANNEL_PROP_NAME, INGRESS_CHANNEL_DEFAULT);
         }
 
         /**
@@ -1365,7 +1401,18 @@ public final class AeronCluster implements AutoCloseable
          */
         public static int ingressStreamId()
         {
-            return Integer.getInteger(INGRESS_STREAM_ID_PROP_NAME, INGRESS_STREAM_ID_DEFAULT);
+            return ingressStreamId(System.getProperties());
+        }
+
+        /**
+         * The value {@link #INGRESS_STREAM_ID_DEFAULT} or system property {@link #INGRESS_STREAM_ID_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #INGRESS_STREAM_ID_DEFAULT} or system property {@link #INGRESS_STREAM_ID_PROP_NAME} if set.
+         */
+        public static int ingressStreamId(final Properties properties)
+        {
+            return getInteger(properties, INGRESS_STREAM_ID_PROP_NAME, INGRESS_STREAM_ID_DEFAULT);
         }
 
         /**
@@ -1375,7 +1422,18 @@ public final class AeronCluster implements AutoCloseable
          */
         public static String egressChannel()
         {
-            return System.getProperty(EGRESS_CHANNEL_PROP_NAME, EGRESS_CHANNEL_DEFAULT);
+            return egressChannel(System.getProperties());
+        }
+
+        /**
+         * The value {@link #EGRESS_CHANNEL_DEFAULT} or system property {@link #EGRESS_CHANNEL_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #EGRESS_CHANNEL_DEFAULT} or system property {@link #EGRESS_CHANNEL_PROP_NAME} if set.
+         */
+        public static String egressChannel(final Properties properties)
+        {
+            return properties.getProperty(EGRESS_CHANNEL_PROP_NAME, EGRESS_CHANNEL_DEFAULT);
         }
 
         /**
@@ -1385,7 +1443,18 @@ public final class AeronCluster implements AutoCloseable
          */
         public static int egressStreamId()
         {
-            return Integer.getInteger(EGRESS_STREAM_ID_PROP_NAME, EGRESS_STREAM_ID_DEFAULT);
+            return egressStreamId(System.getProperties());
+        }
+
+        /**
+         * The value {@link #EGRESS_STREAM_ID_DEFAULT} or system property {@link #EGRESS_STREAM_ID_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #EGRESS_STREAM_ID_DEFAULT} or system property {@link #EGRESS_STREAM_ID_PROP_NAME} if set.
+         */
+        public static int egressStreamId(final Properties properties)
+        {
+            return getInteger(properties, EGRESS_STREAM_ID_PROP_NAME, EGRESS_STREAM_ID_DEFAULT);
         }
 
         /**
@@ -1397,7 +1466,20 @@ public final class AeronCluster implements AutoCloseable
          */
         public static String clientName()
         {
-            return getProperty(CLIENT_NAME_PROP_NAME, "");
+            return clientName(System.getProperties());
+        }
+
+        /**
+         * Get the configured client name.
+         *
+         * @param properties to read the configuration from.
+         * @return specified client name or empty string if not set.
+         * @see #CLIENT_NAME_PROP_NAME
+         * @since 1.49.0
+         */
+        public static String clientName(final Properties properties)
+        {
+            return getProperty(properties, CLIENT_NAME_PROP_NAME, "");
         }
     }
 
@@ -1420,32 +1502,73 @@ public final class AeronCluster implements AutoCloseable
             }
         }
 
+        private final Properties properties;
         private volatile boolean isConcluded;
-        private long messageTimeoutNs = Configuration.messageTimeoutNs();
-        private long newLeaderTimeoutNs = NULL_VALUE;
-        private String ingressEndpoints = Configuration.ingressEndpoints();
-        private String ingressChannel = Configuration.ingressChannel();
-        private int ingressStreamId = Configuration.ingressStreamId();
-        private String egressChannel = Configuration.egressChannel();
-        private int egressStreamId = Configuration.egressStreamId();
+        private long messageTimeoutNs;
+        private long newLeaderTimeoutNs;
+        private String ingressEndpoints;
+        private String ingressChannel;
+        private int ingressStreamId;
+        private String egressChannel;
+        private int egressStreamId;
         private IdleStrategy idleStrategy;
-        private String aeronDirectoryName = CommonContext.getAeronDirectoryName();
+        private String aeronDirectoryName;
         private Aeron aeron;
         private CredentialsSupplier credentialsSupplier;
-        private boolean ownsAeronClient = false;
-        private boolean isIngressExclusive = true;
-        private ErrorHandler errorHandler = Aeron.Configuration.DEFAULT_ERROR_HANDLER;
-        private boolean isDirectAssemblers = false;
+        private boolean ownsAeronClient;
+        private boolean isIngressExclusive;
+        private ErrorHandler errorHandler;
+        private boolean isDirectAssemblers;
         private EgressListener egressListener;
         private ControlledEgressListener controlledEgressListener;
         private AgentInvoker agentInvoker;
-        private String clientName = Configuration.clientName();
+        private String clientName;
 
         /**
          * Construct a Context using default values and loading from system properties.
          */
         public Context()
         {
+            this(System.getProperties());
+        }
+
+        /**
+         * Construct a Context using default values loaded from the supplied properties.
+         *
+         * @param properties to load the configuration from.
+         */
+        public Context(final Properties properties)
+        {
+            this.properties = properties;
+            applyDefaults(properties);
+        }
+
+        /**
+         * The properties this context was constructed from, to be propagated to any context it
+         * creates.
+         *
+         * @return the properties this context was constructed from.
+         */
+        public Properties properties()
+        {
+            return properties;
+        }
+
+        private void applyDefaults(final Properties properties)
+        {
+            messageTimeoutNs = Configuration.messageTimeoutNs(properties);
+            newLeaderTimeoutNs = NULL_VALUE;
+            ingressEndpoints = Configuration.ingressEndpoints(properties);
+            ingressChannel = Configuration.ingressChannel(properties);
+            ingressStreamId = Configuration.ingressStreamId(properties);
+            egressChannel = Configuration.egressChannel(properties);
+            egressStreamId = Configuration.egressStreamId(properties);
+            aeronDirectoryName = CommonContext.getAeronDirectoryName(properties);
+            ownsAeronClient = false;
+            isIngressExclusive = true;
+            errorHandler = Aeron.Configuration.DEFAULT_ERROR_HANDLER;
+            isDirectAssemblers = false;
+            clientName = Configuration.clientName(properties);
         }
 
         /**
@@ -1510,7 +1633,7 @@ public final class AeronCluster implements AutoCloseable
             if (null == aeron)
             {
                 aeron = Aeron.connect(
-                    new Aeron.Context()
+                    new Aeron.Context(properties)
                         .aeronDirectoryName(aeronDirectoryName)
                         .errorHandler(errorHandler)
                         .subscriberErrorHandler(RethrowingErrorHandler.INSTANCE)
@@ -1582,7 +1705,7 @@ public final class AeronCluster implements AutoCloseable
         @Config
         public long messageTimeoutNs()
         {
-            return CommonContext.checkDebugTimeout(messageTimeoutNs, TimeUnit.NANOSECONDS);
+            return CommonContext.checkDebugTimeout(properties, messageTimeoutNs, TimeUnit.NANOSECONDS);
         }
 
         /**
@@ -1612,7 +1735,7 @@ public final class AeronCluster implements AutoCloseable
          */
         public long newLeaderTimeoutNs()
         {
-            return CommonContext.checkDebugTimeout(newLeaderTimeoutNs, TimeUnit.NANOSECONDS);
+            return CommonContext.checkDebugTimeout(properties, newLeaderTimeoutNs, TimeUnit.NANOSECONDS);
         }
 
         /**
@@ -2326,12 +2449,12 @@ public final class AeronCluster implements AutoCloseable
                     egressSubscription.tryResolveChannelEndpointPort() : "<unknown>";
                 final TimeoutException ex = new TimeoutException(
                     "cluster connect timeout: state=" + state +
-                    " messageTimeout=" + SystemUtil.formatDuration(ctx.messageTimeoutNs()) +
-                    " ingressChannel=" + ctx.ingressChannel() +
-                    " ingressEndpoints=" + ctx.ingressEndpoints() +
-                    " ingressPublication=" + ingressPublication +
-                    " egress.isConnected=" + isConnected +
-                    " responseChannel=" + egressChannel);
+                        " messageTimeout=" + SystemUtil.formatDuration(ctx.messageTimeoutNs()) +
+                        " ingressChannel=" + ctx.ingressChannel() +
+                        " ingressEndpoints=" + ctx.ingressEndpoints() +
+                        " ingressPublication=" + ingressPublication +
+                        " egress.isConnected=" + isConnected +
+                        " responseChannel=" + egressChannel);
 
                 for (final MemberIngress member : memberByIdMap.values())
                 {

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusterMarkFile.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusterMarkFile.java
@@ -133,6 +133,29 @@ public final class ClusterMarkFile implements AutoCloseable
         final long timeoutMs,
         final int filePageSize)
     {
+        this(file, type, errorBufferLength, epochClock, timeoutMs, filePageSize, CommonContext.fallbackLogger());
+    }
+
+    /**
+     * Create new {@link MarkFile} for a cluster component but check if an existing component is active.
+     *
+     * @param file              full qualified file to the {@link MarkFile}.
+     * @param type              of cluster component the {@link MarkFile} represents.
+     * @param errorBufferLength for storing the error log.
+     * @param epochClock        for checking liveness against.
+     * @param timeoutMs         for the activity check on an existing {@link MarkFile}.
+     * @param filePageSize      for aligning file length to.
+     * @param fallbackLogger    for reporting errors found in an existing {@link MarkFile}.
+     */
+    public ClusterMarkFile(
+        final File file,
+        final ClusterComponentType type,
+        final int errorBufferLength,
+        final EpochClock epochClock,
+        final long timeoutMs,
+        final int filePageSize,
+        final PrintStream fallbackLogger)
+    {
         if (errorBufferLength < ERROR_BUFFER_MIN_LENGTH || errorBufferLength > ERROR_BUFFER_MAX_LENGTH)
         {
             throw new IllegalArgumentException("Invalid errorBufferLength: " + errorBufferLength);
@@ -198,7 +221,7 @@ public final class ClusterMarkFile implements AutoCloseable
             final UnsafeBuffer existingErrorBuffer =
                 new UnsafeBuffer(existingBuffer, headerLength, existingErrorBufferLength);
 
-            saveExistingErrors(file, existingErrorBuffer, type, CommonContext.fallbackLogger());
+            saveExistingErrors(file, existingErrorBuffer, type, fallbackLogger);
             existingErrorBuffer.setMemory(0, existingErrorBufferLength, (byte)0);
 
             candidateTermId = headerDecoder.candidateTermId();

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceContainer.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceContainer.java
@@ -63,6 +63,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
+import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
@@ -71,12 +72,13 @@ import java.util.function.Supplier;
 import static io.aeron.ChannelUri.addAliasIfAbsent;
 import static io.aeron.CommonContext.driverFilePageSize;
 import static io.aeron.CommonContext.threadName;
+import static io.aeron.PropertiesUtil.getDurationInNanos;
+import static io.aeron.PropertiesUtil.getInteger;
+import static io.aeron.PropertiesUtil.getSizeAsInt;
 import static io.aeron.cluster.service.ClusteredServiceContainer.Configuration.LIVENESS_TIMEOUT_MS;
 import static io.aeron.cluster.service.ClusteredServiceContainer.Configuration.MAX_SERVICE_COUNT;
 import static io.aeron.cluster.service.ClusteredServiceContainer.Configuration.SERVICE_NAME_PROP_NAME;
 import static java.nio.charset.StandardCharsets.US_ASCII;
-import static org.agrona.SystemUtil.getDurationInNanos;
-import static org.agrona.SystemUtil.getSizeAsInt;
 import static org.agrona.SystemUtil.loadPropertiesFiles;
 
 /**
@@ -459,7 +461,18 @@ public final class ClusteredServiceContainer implements AutoCloseable
          */
         public static int clusterId()
         {
-            return Integer.getInteger(CLUSTER_ID_PROP_NAME, CLUSTER_ID_DEFAULT);
+            return clusterId(System.getProperties());
+        }
+
+        /**
+         * The value {@link #CLUSTER_ID_DEFAULT} or system property {@link #CLUSTER_ID_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #CLUSTER_ID_DEFAULT} or system property {@link #CLUSTER_ID_PROP_NAME} if set.
+         */
+        public static int clusterId(final Properties properties)
+        {
+            return getInteger(properties, CLUSTER_ID_PROP_NAME, CLUSTER_ID_DEFAULT);
         }
 
         /**
@@ -469,7 +482,18 @@ public final class ClusteredServiceContainer implements AutoCloseable
          */
         public static int serviceId()
         {
-            return Integer.getInteger(SERVICE_ID_PROP_NAME, SERVICE_ID_DEFAULT);
+            return serviceId(System.getProperties());
+        }
+
+        /**
+         * The value {@link #SERVICE_ID_DEFAULT} or system property {@link #SERVICE_ID_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #SERVICE_ID_DEFAULT} or system property {@link #SERVICE_ID_PROP_NAME} if set.
+         */
+        public static int serviceId(final Properties properties)
+        {
+            return getInteger(properties, SERVICE_ID_PROP_NAME, SERVICE_ID_DEFAULT);
         }
 
         /**
@@ -479,7 +503,18 @@ public final class ClusteredServiceContainer implements AutoCloseable
          */
         public static String serviceName()
         {
-            return System.getProperty(SERVICE_NAME_PROP_NAME, SERVICE_NAME_DEFAULT);
+            return serviceName(System.getProperties());
+        }
+
+        /**
+         * The value {@link #SERVICE_NAME_DEFAULT} or system property {@link #SERVICE_NAME_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #SERVICE_NAME_DEFAULT} or system property {@link #SERVICE_NAME_PROP_NAME} if set.
+         */
+        public static String serviceName(final Properties properties)
+        {
+            return properties.getProperty(SERVICE_NAME_PROP_NAME, SERVICE_NAME_DEFAULT);
         }
 
         /**
@@ -489,7 +524,18 @@ public final class ClusteredServiceContainer implements AutoCloseable
          */
         public static String replayChannel()
         {
-            return System.getProperty(REPLAY_CHANNEL_PROP_NAME, REPLAY_CHANNEL_DEFAULT);
+            return replayChannel(System.getProperties());
+        }
+
+        /**
+         * The value {@link #REPLAY_CHANNEL_DEFAULT} or system property {@link #REPLAY_CHANNEL_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #REPLAY_CHANNEL_DEFAULT} or system property {@link #REPLAY_CHANNEL_PROP_NAME} if set.
+         */
+        public static String replayChannel(final Properties properties)
+        {
+            return properties.getProperty(REPLAY_CHANNEL_PROP_NAME, REPLAY_CHANNEL_DEFAULT);
         }
 
         /**
@@ -501,7 +547,20 @@ public final class ClusteredServiceContainer implements AutoCloseable
          */
         public static int replayStreamId()
         {
-            return Integer.getInteger(REPLAY_STREAM_ID_PROP_NAME, REPLAY_STREAM_ID_DEFAULT);
+            return replayStreamId(System.getProperties());
+        }
+
+        /**
+         * The value {@link #REPLAY_STREAM_ID_DEFAULT} or system property {@link #REPLAY_STREAM_ID_PROP_NAME}
+         * if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #REPLAY_STREAM_ID_DEFAULT} or system property {@link #REPLAY_STREAM_ID_PROP_NAME}
+         * if set.
+         */
+        public static int replayStreamId(final Properties properties)
+        {
+            return getInteger(properties, REPLAY_STREAM_ID_PROP_NAME, REPLAY_STREAM_ID_DEFAULT);
         }
 
         /**
@@ -513,7 +572,20 @@ public final class ClusteredServiceContainer implements AutoCloseable
          */
         public static String controlChannel()
         {
-            return System.getProperty(CONTROL_CHANNEL_PROP_NAME, CONTROL_CHANNEL_DEFAULT);
+            return controlChannel(System.getProperties());
+        }
+
+        /**
+         * The value {@link #CONTROL_CHANNEL_DEFAULT} or system property
+         * {@link #CONTROL_CHANNEL_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #CONTROL_CHANNEL_DEFAULT} or system property
+         * {@link #CONTROL_CHANNEL_PROP_NAME} if set.
+         */
+        public static String controlChannel(final Properties properties)
+        {
+            return properties.getProperty(CONTROL_CHANNEL_PROP_NAME, CONTROL_CHANNEL_DEFAULT);
         }
 
         /**
@@ -525,7 +597,20 @@ public final class ClusteredServiceContainer implements AutoCloseable
          */
         public static int consensusModuleStreamId()
         {
-            return Integer.getInteger(CONSENSUS_MODULE_STREAM_ID_PROP_NAME, CONSENSUS_MODULE_STREAM_ID_DEFAULT);
+            return consensusModuleStreamId(System.getProperties());
+        }
+
+        /**
+         * The value {@link #CONSENSUS_MODULE_STREAM_ID_DEFAULT} or system property
+         * {@link #CONSENSUS_MODULE_STREAM_ID_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #CONSENSUS_MODULE_STREAM_ID_DEFAULT} or system property
+         * {@link #CONSENSUS_MODULE_STREAM_ID_PROP_NAME} if set.
+         */
+        public static int consensusModuleStreamId(final Properties properties)
+        {
+            return getInteger(properties, CONSENSUS_MODULE_STREAM_ID_PROP_NAME, CONSENSUS_MODULE_STREAM_ID_DEFAULT);
         }
 
         /**
@@ -537,7 +622,20 @@ public final class ClusteredServiceContainer implements AutoCloseable
          */
         public static int serviceStreamId()
         {
-            return Integer.getInteger(SERVICE_STREAM_ID_PROP_NAME, SERVICE_STREAM_ID_DEFAULT);
+            return serviceStreamId(System.getProperties());
+        }
+
+        /**
+         * The value {@link #SERVICE_STREAM_ID_DEFAULT} or system property
+         * {@link #SERVICE_STREAM_ID_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #SERVICE_STREAM_ID_DEFAULT} or system property
+         * {@link #SERVICE_STREAM_ID_PROP_NAME} if set.
+         */
+        public static int serviceStreamId(final Properties properties)
+        {
+            return getInteger(properties, SERVICE_STREAM_ID_PROP_NAME, SERVICE_STREAM_ID_DEFAULT);
         }
 
         /**
@@ -547,7 +645,18 @@ public final class ClusteredServiceContainer implements AutoCloseable
          */
         public static String snapshotChannel()
         {
-            return System.getProperty(SNAPSHOT_CHANNEL_PROP_NAME, SNAPSHOT_CHANNEL_DEFAULT);
+            return snapshotChannel(System.getProperties());
+        }
+
+        /**
+         * The value {@link #SNAPSHOT_CHANNEL_DEFAULT} or system property {@link #SNAPSHOT_CHANNEL_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #SNAPSHOT_CHANNEL_DEFAULT} or system property {@link #SNAPSHOT_CHANNEL_PROP_NAME} if set.
+         */
+        public static String snapshotChannel(final Properties properties)
+        {
+            return properties.getProperty(SNAPSHOT_CHANNEL_PROP_NAME, SNAPSHOT_CHANNEL_DEFAULT);
         }
 
         /**
@@ -558,7 +667,19 @@ public final class ClusteredServiceContainer implements AutoCloseable
          */
         public static int snapshotStreamId()
         {
-            return Integer.getInteger(SNAPSHOT_STREAM_ID_PROP_NAME, SNAPSHOT_STREAM_ID_DEFAULT);
+            return snapshotStreamId(System.getProperties());
+        }
+
+        /**
+         * The value {@link #SNAPSHOT_STREAM_ID_DEFAULT} or system property {@link #SNAPSHOT_STREAM_ID_PROP_NAME}
+         * if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #SNAPSHOT_STREAM_ID_DEFAULT} or system property {@link #SNAPSHOT_STREAM_ID_PROP_NAME} if set.
+         */
+        public static int snapshotStreamId(final Properties properties)
+        {
+            return getInteger(properties, SNAPSHOT_STREAM_ID_PROP_NAME, SNAPSHOT_STREAM_ID_DEFAULT);
         }
 
         /**
@@ -581,9 +702,22 @@ public final class ClusteredServiceContainer implements AutoCloseable
          */
         public static Supplier<IdleStrategy> idleStrategySupplier(final StatusIndicator controllableStatus)
         {
+            return idleStrategySupplier(System.getProperties(), controllableStatus);
+        }
+
+        /**
+         * Create a supplier of {@link IdleStrategy}s that will use the supplied properties.
+         *
+         * @param properties         to read the configuration from.
+         * @param controllableStatus if a {@link org.agrona.concurrent.ControllableIdleStrategy} is required.
+         * @return the new idle strategy
+         */
+        public static Supplier<IdleStrategy> idleStrategySupplier(
+            final Properties properties, final StatusIndicator controllableStatus)
+        {
             return () ->
             {
-                final String name = System.getProperty(CLUSTER_IDLE_STRATEGY_PROP_NAME, DEFAULT_IDLE_STRATEGY);
+                final String name = properties.getProperty(CLUSTER_IDLE_STRATEGY_PROP_NAME, DEFAULT_IDLE_STRATEGY);
                 return io.aeron.driver.Configuration.agentIdleStrategy(name, controllableStatus);
             };
         }
@@ -595,7 +729,18 @@ public final class ClusteredServiceContainer implements AutoCloseable
          */
         public static String clusterDirName()
         {
-            return System.getProperty(CLUSTER_DIR_PROP_NAME, CLUSTER_DIR_DEFAULT);
+            return clusterDirName(System.getProperties());
+        }
+
+        /**
+         * The value {@link #CLUSTER_DIR_DEFAULT} or system property {@link #CLUSTER_DIR_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #CLUSTER_DIR_DEFAULT} or system property {@link #CLUSTER_DIR_PROP_NAME} if set.
+         */
+        public static String clusterDirName(final Properties properties)
+        {
+            return properties.getProperty(CLUSTER_DIR_PROP_NAME, CLUSTER_DIR_DEFAULT);
         }
 
         /**
@@ -605,7 +750,18 @@ public final class ClusteredServiceContainer implements AutoCloseable
          */
         public static String clusterServicesDirName()
         {
-            return System.getProperty(CLUSTER_SERVICES_DIR_PROP_NAME);
+            return clusterServicesDirName(System.getProperties());
+        }
+
+        /**
+         * The value of system property {@link #CLUSTER_DIR_PROP_NAME} if set or null.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #CLUSTER_DIR_PROP_NAME} if set or null.
+         */
+        public static String clusterServicesDirName(final Properties properties)
+        {
+            return properties.getProperty(CLUSTER_SERVICES_DIR_PROP_NAME);
         }
 
         /**
@@ -616,7 +772,19 @@ public final class ClusteredServiceContainer implements AutoCloseable
          */
         public static int errorBufferLength()
         {
-            return getSizeAsInt(ERROR_BUFFER_LENGTH_PROP_NAME, ERROR_BUFFER_LENGTH_DEFAULT);
+            return errorBufferLength(System.getProperties());
+        }
+
+        /**
+         * Size in bytes of the error buffer in the mark file.
+         *
+         * @param properties to read the configuration from.
+         * @return length of error buffer in bytes.
+         * @see #ERROR_BUFFER_LENGTH_PROP_NAME
+         */
+        public static int errorBufferLength(final Properties properties)
+        {
+            return getSizeAsInt(properties, ERROR_BUFFER_LENGTH_PROP_NAME, ERROR_BUFFER_LENGTH_DEFAULT);
         }
 
         /**
@@ -626,7 +794,18 @@ public final class ClusteredServiceContainer implements AutoCloseable
          */
         public static boolean isRespondingService()
         {
-            final String property = System.getProperty(RESPONDER_SERVICE_PROP_NAME);
+            return isRespondingService(System.getProperties());
+        }
+
+        /**
+         * The value {@link #RESPONDER_SERVICE_DEFAULT} or system property {@link #RESPONDER_SERVICE_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #RESPONDER_SERVICE_DEFAULT} or system property {@link #RESPONDER_SERVICE_PROP_NAME} if set.
+         */
+        public static boolean isRespondingService(final Properties properties)
+        {
+            final String property = properties.getProperty(RESPONDER_SERVICE_PROP_NAME);
             if (null == property)
             {
                 return RESPONDER_SERVICE_DEFAULT;
@@ -644,7 +823,20 @@ public final class ClusteredServiceContainer implements AutoCloseable
          */
         public static int logFragmentLimit()
         {
-            return Integer.getInteger(LOG_FRAGMENT_LIMIT_PROP_NAME, LOG_FRAGMENT_LIMIT_DEFAULT);
+            return logFragmentLimit(System.getProperties());
+        }
+
+        /**
+         * The value {@link #LOG_FRAGMENT_LIMIT_DEFAULT} or system property
+         * {@link #LOG_FRAGMENT_LIMIT_PROP_NAME} if set.
+         *
+         * @param properties to read the configuration from.
+         * @return {@link #LOG_FRAGMENT_LIMIT_DEFAULT} or system property
+         * {@link #LOG_FRAGMENT_LIMIT_PROP_NAME} if set.
+         */
+        public static int logFragmentLimit(final Properties properties)
+        {
+            return getInteger(properties, LOG_FRAGMENT_LIMIT_PROP_NAME, LOG_FRAGMENT_LIMIT_DEFAULT);
         }
 
         /**
@@ -654,7 +846,18 @@ public final class ClusteredServiceContainer implements AutoCloseable
          */
         public static long cycleThresholdNs()
         {
-            return getDurationInNanos(CYCLE_THRESHOLD_PROP_NAME, CYCLE_THRESHOLD_DEFAULT_NS);
+            return cycleThresholdNs(System.getProperties());
+        }
+
+        /**
+         * Get threshold value for the container work cycle threshold to track for being exceeded.
+         *
+         * @param properties to read the configuration from.
+         * @return threshold value in nanoseconds.
+         */
+        public static long cycleThresholdNs(final Properties properties)
+        {
+            return getDurationInNanos(properties, CYCLE_THRESHOLD_PROP_NAME, CYCLE_THRESHOLD_DEFAULT_NS);
         }
 
         /**
@@ -665,7 +868,20 @@ public final class ClusteredServiceContainer implements AutoCloseable
          */
         public static long snapshotDurationThresholdNs()
         {
-            return getDurationInNanos(SNAPSHOT_DURATION_THRESHOLD_PROP_NAME, SNAPSHOT_DURATION_THRESHOLD_DEFAULT_NS);
+            return snapshotDurationThresholdNs(System.getProperties());
+        }
+
+        /**
+         * Get threshold value, which is used for monitoring snapshot duration breaches of its predefined
+         * threshold.
+         *
+         * @param properties to read the configuration from.
+         * @return threshold value in nanoseconds.
+         */
+        public static long snapshotDurationThresholdNs(final Properties properties)
+        {
+            return getDurationInNanos(
+                properties, SNAPSHOT_DURATION_THRESHOLD_PROP_NAME, SNAPSHOT_DURATION_THRESHOLD_DEFAULT_NS);
         }
 
         /**
@@ -675,7 +891,18 @@ public final class ClusteredServiceContainer implements AutoCloseable
          */
         public static ClusteredService newClusteredService()
         {
-            final String className = System.getProperty(Configuration.SERVICE_CLASS_NAME_PROP_NAME);
+            return newClusteredService(System.getProperties());
+        }
+
+        /**
+         * Create a new {@link ClusteredService} based on the configured {@link #SERVICE_CLASS_NAME_PROP_NAME}.
+         *
+         * @param properties to read the configuration from.
+         * @return a new {@link ClusteredService} based on the configured {@link #SERVICE_CLASS_NAME_PROP_NAME}.
+         */
+        public static ClusteredService newClusteredService(final Properties properties)
+        {
+            final String className = properties.getProperty(Configuration.SERVICE_CLASS_NAME_PROP_NAME);
             if (null == className)
             {
                 throw new ClusterException("either a instance or class name for the service must be provided");
@@ -700,7 +927,19 @@ public final class ClusteredServiceContainer implements AutoCloseable
          */
         public static DelegatingErrorHandler newDelegatingErrorHandler()
         {
-            final String className = System.getProperty(Configuration.DELEGATING_ERROR_HANDLER_PROP_NAME);
+            return newDelegatingErrorHandler(System.getProperties());
+        }
+
+        /**
+         * Create a new {@link DelegatingErrorHandler} defined by {@link #DELEGATING_ERROR_HANDLER_PROP_NAME}.
+         *
+         * @param properties to read the configuration from.
+         * @return a new {@link DelegatingErrorHandler} defined by {@link #DELEGATING_ERROR_HANDLER_PROP_NAME} or
+         * null if property not set.
+         */
+        public static DelegatingErrorHandler newDelegatingErrorHandler(final Properties properties)
+        {
+            final String className = properties.getProperty(Configuration.DELEGATING_ERROR_HANDLER_PROP_NAME);
             if (null != className)
             {
                 try
@@ -723,7 +962,18 @@ public final class ClusteredServiceContainer implements AutoCloseable
          */
         public static String markFileDir()
         {
-            return System.getProperty(MARK_FILE_DIR_PROP_NAME);
+            return markFileDir(System.getProperties());
+        }
+
+        /**
+         * Get the alternative directory to be used for storing the Cluster component's mark file.
+         *
+         * @param properties to read the configuration from.
+         * @return the directory to be used for storing the archive mark file.
+         */
+        public static String markFileDir(final Properties properties)
+        {
+            return properties.getProperty(MARK_FILE_DIR_PROP_NAME);
         }
     }
 
@@ -747,23 +997,24 @@ public final class ClusteredServiceContainer implements AutoCloseable
             }
         }
 
+        private final Properties properties;
         private volatile boolean isConcluded;
-        private int appVersion = SemanticVersion.compose(0, 0, 1);
-        private int clusterId = Configuration.clusterId();
-        private int serviceId = Configuration.serviceId();
-        private String serviceName = System.getProperty(SERVICE_NAME_PROP_NAME);
-        private String replayChannel = Configuration.replayChannel();
-        private int replayStreamId = Configuration.replayStreamId();
-        private String controlChannel = Configuration.controlChannel();
-        private int consensusModuleStreamId = Configuration.consensusModuleStreamId();
-        private int serviceStreamId = Configuration.serviceStreamId();
-        private String snapshotChannel = Configuration.snapshotChannel();
-        private int snapshotStreamId = Configuration.snapshotStreamId();
-        private int errorBufferLength = Configuration.errorBufferLength();
-        private boolean isRespondingService = Configuration.isRespondingService();
-        private int logFragmentLimit = Configuration.logFragmentLimit();
-        private long cycleThresholdNs = Configuration.cycleThresholdNs();
-        private long snapshotDurationThresholdNs = Configuration.snapshotDurationThresholdNs();
+        private int appVersion;
+        private int clusterId;
+        private int serviceId;
+        private String serviceName;
+        private String replayChannel;
+        private int replayStreamId;
+        private String controlChannel;
+        private int consensusModuleStreamId;
+        private int serviceStreamId;
+        private String snapshotChannel;
+        private int snapshotStreamId;
+        private int errorBufferLength;
+        private boolean isRespondingService;
+        private int logFragmentLimit;
+        private long cycleThresholdNs;
+        private long snapshotDurationThresholdNs;
 
         private CountDownLatch abortLatch;
         private ThreadFactory threadFactory;
@@ -776,10 +1027,10 @@ public final class ClusteredServiceContainer implements AutoCloseable
         private AtomicCounter errorCounter;
         private CountedErrorHandler countedErrorHandler;
         private AeronArchive.Context archiveContext;
-        private String clusterDirectoryName = Configuration.clusterDirName();
+        private String clusterDirectoryName;
         private File clusterDir;
         private File markFileDir;
-        private String aeronDirectoryName = CommonContext.getAeronDirectoryName();
+        private String aeronDirectoryName;
         private Aeron aeron;
         private DutyCycleTracker dutyCycleTracker;
         private SnapshotDurationTracker snapshotDurationTracker;
@@ -795,6 +1046,52 @@ public final class ClusteredServiceContainer implements AutoCloseable
          */
         public Context()
         {
+            this(System.getProperties());
+        }
+
+        /**
+         * Construct a Context using default values loaded from the supplied properties.
+         *
+         * @param properties to load the configuration from.
+         */
+        public Context(final Properties properties)
+        {
+            this.properties = properties;
+            applyDefaults(properties);
+        }
+
+        /**
+         * The properties this context was constructed from, to be propagated to any context it
+         * creates.
+         *
+         * @return the properties this context was constructed from.
+         */
+        public Properties properties()
+        {
+            return properties;
+        }
+
+        private void applyDefaults(final Properties properties)
+        {
+            appVersion = SemanticVersion.compose(0, 0, 1);
+            clusterId = Configuration.clusterId(properties);
+            serviceId = Configuration.serviceId(properties);
+            serviceName = properties.getProperty(SERVICE_NAME_PROP_NAME);
+            replayChannel = Configuration.replayChannel(properties);
+            replayStreamId = Configuration.replayStreamId(properties);
+            controlChannel = Configuration.controlChannel(properties);
+            consensusModuleStreamId = Configuration.consensusModuleStreamId(properties);
+            serviceStreamId = Configuration.serviceStreamId(properties);
+            snapshotChannel = Configuration.snapshotChannel(properties);
+            snapshotStreamId = Configuration.snapshotStreamId(properties);
+            errorBufferLength = Configuration.errorBufferLength(properties);
+            isRespondingService = Configuration.isRespondingService(properties);
+            logFragmentLimit = Configuration.logFragmentLimit(properties);
+            cycleThresholdNs = Configuration.cycleThresholdNs(properties);
+            snapshotDurationThresholdNs = Configuration.snapshotDurationThresholdNs(properties);
+
+            clusterDirectoryName = Configuration.clusterDirName(properties);
+            aeronDirectoryName = CommonContext.getAeronDirectoryName(properties);
         }
 
         /**
@@ -838,7 +1135,7 @@ public final class ClusteredServiceContainer implements AutoCloseable
 
             if (null == idleStrategySupplier)
             {
-                idleStrategySupplier = Configuration.idleStrategySupplier(null);
+                idleStrategySupplier = Configuration.idleStrategySupplier(properties, null);
             }
 
             if (null == appVersionValidator)
@@ -863,7 +1160,7 @@ public final class ClusteredServiceContainer implements AutoCloseable
 
             if (null == markFileDir)
             {
-                final String dir = Configuration.markFileDir();
+                final String dir = Configuration.markFileDir(properties);
                 markFileDir = Strings.isEmpty(dir) ? clusterDir : new File(dir);
             }
 
@@ -891,7 +1188,8 @@ public final class ClusteredServiceContainer implements AutoCloseable
                     errorBufferLength,
                     epochClock,
                     LIVENESS_TIMEOUT_MS,
-                    filePageSize);
+                    filePageSize,
+                    CommonContext.fallbackLogger(properties));
             }
 
             MarkFile.ensureMarkFileLink(
@@ -904,11 +1202,11 @@ public final class ClusteredServiceContainer implements AutoCloseable
                 errorLog = new DistinctErrorLog(markFile.errorBuffer(), epochClock, US_ASCII);
             }
 
-            errorHandler = CommonContext.setupErrorHandler(this.errorHandler, errorLog);
+            errorHandler = CommonContext.setupErrorHandler(properties, this.errorHandler, errorLog);
 
             if (null == delegatingErrorHandler)
             {
-                delegatingErrorHandler = Configuration.newDelegatingErrorHandler();
+                delegatingErrorHandler = Configuration.newDelegatingErrorHandler(properties);
                 if (null != delegatingErrorHandler)
                 {
                     delegatingErrorHandler.next(errorHandler);
@@ -924,6 +1222,7 @@ public final class ClusteredServiceContainer implements AutoCloseable
             if (Strings.isEmpty(serviceName))
             {
                 serviceName = threadName(
+                    properties,
                     AERON_CLUSTER_CLUSTERED_SERVICE_THREAD_NAME_PREFIX + serviceId,
                     "clustered-service-" + clusterId + "-" + serviceId);
             }
@@ -931,7 +1230,7 @@ public final class ClusteredServiceContainer implements AutoCloseable
             if (null == aeron)
             {
                 aeron = Aeron.connect(
-                    new Aeron.Context()
+                    new Aeron.Context(properties)
                         .aeronDirectoryName(aeronDirectoryName)
                         .errorHandler(errorHandler)
                         .subscriberErrorHandler(RethrowingErrorHandler.INSTANCE)
@@ -1008,12 +1307,13 @@ public final class ClusteredServiceContainer implements AutoCloseable
 
             if (null == archiveContext)
             {
-                archiveContext = new AeronArchive.Context()
-                    .controlRequestChannel(AeronArchive.Configuration.localControlChannel())
-                    .controlResponseChannel(AeronArchive.Configuration.localControlChannel())
-                    .controlRequestStreamId(AeronArchive.Configuration.localControlStreamId())
+                archiveContext = new AeronArchive.Context(properties)
+                    .controlRequestChannel(AeronArchive.Configuration.localControlChannel(properties))
+                    .controlResponseChannel(AeronArchive.Configuration.localControlChannel(properties))
+                    .controlRequestStreamId(AeronArchive.Configuration.localControlStreamId(properties))
                     .controlResponseStreamId(
-                        clusterId * 100 + 100 + AeronArchive.Configuration.controlResponseStreamId() + (serviceId + 1));
+                        clusterId * 100 + 100 +
+                            AeronArchive.Configuration.controlResponseStreamId(properties) + (serviceId + 1));
             }
 
             if (!archiveContext.controlRequestChannel().startsWith(CommonContext.IPC_CHANNEL))
@@ -1032,11 +1332,11 @@ public final class ClusteredServiceContainer implements AutoCloseable
                 .lock(NoOpLock.INSTANCE)
                 .errorHandler(null) // propagate errors directly
                 .controlRequestChannel(addAliasIfAbsent(
-                archiveContext.controlRequestChannel(),
-                "sc-" + serviceId + "-archive-ctrl-req-cluster-" + clusterId))
+                    archiveContext.controlRequestChannel(),
+                    "sc-" + serviceId + "-archive-ctrl-req-cluster-" + clusterId))
                 .controlResponseChannel(addAliasIfAbsent(
-                archiveContext.controlResponseChannel(),
-                "sc-" + serviceId + "-archive-ctrl-resp-cluster-" + clusterId))
+                    archiveContext.controlResponseChannel(),
+                    "sc-" + serviceId + "-archive-ctrl-resp-cluster-" + clusterId))
                 .clientName(serviceName);
 
             if (null == terminationHook)
@@ -1046,13 +1346,13 @@ public final class ClusteredServiceContainer implements AutoCloseable
 
             if (null == clusteredService)
             {
-                clusteredService = Configuration.newClusteredService();
+                clusteredService = Configuration.newClusteredService(properties);
             }
 
             abortLatch = new CountDownLatch(!aeron.context().useConductorAgentInvoker() ? 1 : 0);
             concludeMarkFile();
 
-            if (CommonContext.shouldPrintConfigurationOnStart())
+            if (CommonContext.shouldPrintConfigurationOnStart(properties))
             {
                 System.out.println(this);
             }

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ClusterContextPropertiesTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ClusterContextPropertiesTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2014-2025 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.cluster;
+
+import io.aeron.cluster.client.AeronCluster;
+import io.aeron.cluster.service.ClusteredServiceContainer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import static io.aeron.CommonContext.AERON_DIR_PROP_NAME;
+import static io.aeron.cluster.ConsensusModule.Configuration.CLUSTER_MEMBERS_PROP_NAME;
+import static io.aeron.cluster.ConsensusModule.Configuration.CLUSTER_MEMBER_ID_PROP_NAME;
+import static io.aeron.cluster.ConsensusModule.Configuration.SERVICE_COUNT_PROP_NAME;
+import static io.aeron.cluster.ConsensusModule.Configuration.SESSION_TIMEOUT_PROP_NAME;
+import static io.aeron.cluster.client.AeronCluster.Configuration.INGRESS_CHANNEL_PROP_NAME;
+import static io.aeron.cluster.client.AeronCluster.Configuration.MESSAGE_TIMEOUT_PROP_NAME;
+import static io.aeron.cluster.service.ClusteredServiceContainer.Configuration.CLUSTER_DIR_PROP_NAME;
+import static io.aeron.cluster.service.ClusteredServiceContainer.Configuration.CLUSTER_ID_PROP_NAME;
+import static io.aeron.cluster.service.ClusteredServiceContainer.Configuration.SERVICE_NAME_PROP_NAME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class ClusterContextPropertiesTest
+{
+    @AfterEach
+    void tearDown()
+    {
+        System.clearProperty(CLUSTER_MEMBER_ID_PROP_NAME);
+        System.clearProperty(CLUSTER_ID_PROP_NAME);
+    }
+
+    @Test
+    void suppliedPropertiesConfigureTheConsensusModuleContext()
+    {
+        final Properties properties = new Properties();
+        properties.setProperty(AERON_DIR_PROP_NAME, "/tmp/aeron-a");
+        properties.setProperty(CLUSTER_MEMBER_ID_PROP_NAME, "3");
+        properties.setProperty(CLUSTER_MEMBERS_PROP_NAME, "0,localhost:20000,localhost:20001," +
+            "localhost:20002,localhost:20003,localhost:8010");
+        properties.setProperty(SERVICE_COUNT_PROP_NAME, "5");
+        properties.setProperty(SESSION_TIMEOUT_PROP_NAME, "9s");
+
+        final ConsensusModule.Context context = new ConsensusModule.Context(properties);
+
+        assertSame(properties, context.properties());
+        assertEquals("/tmp/aeron-a", context.aeronDirectoryName());
+        assertEquals(3, context.clusterMemberId());
+        assertEquals(5, context.serviceCount());
+        assertEquals(TimeUnit.SECONDS.toNanos(9), context.sessionTimeoutNs());
+    }
+
+    @Test
+    void twoConsensusModuleContextsFromDifferentPropertiesAreIndependent()
+    {
+        final Properties a = new Properties();
+        a.setProperty(CLUSTER_MEMBER_ID_PROP_NAME, "0");
+        a.setProperty(CLUSTER_DIR_PROP_NAME, "/tmp/cluster-0");
+
+        final Properties b = new Properties();
+        b.setProperty(CLUSTER_MEMBER_ID_PROP_NAME, "1");
+        b.setProperty(CLUSTER_DIR_PROP_NAME, "/tmp/cluster-1");
+
+        final ConsensusModule.Context contextA = new ConsensusModule.Context(a);
+        final ConsensusModule.Context contextB = new ConsensusModule.Context(b);
+
+        assertEquals(0, contextA.clusterMemberId());
+        assertEquals(1, contextB.clusterMemberId());
+        assertEquals("/tmp/cluster-0", contextA.clusterDirectoryName());
+        assertEquals("/tmp/cluster-1", contextB.clusterDirectoryName());
+        assertNotEquals(contextA.clusterDirectoryName(), contextB.clusterDirectoryName());
+    }
+
+    @Test
+    void suppliedPropertiesShadowSystemPropertiesAndAreNotWrittenBackToThem()
+    {
+        System.setProperty(CLUSTER_MEMBER_ID_PROP_NAME, "1");
+
+        final Properties properties = new Properties();
+        properties.setProperty(CLUSTER_MEMBER_ID_PROP_NAME, "2");
+
+        assertEquals(2, new ConsensusModule.Context(properties).clusterMemberId());
+        assertEquals(1, new ConsensusModule.Context().clusterMemberId());
+        assertEquals("1", System.getProperty(CLUSTER_MEMBER_ID_PROP_NAME));
+    }
+
+    @Test
+    void suppliedPropertiesConfigureTheClusteredServiceContainerContext()
+    {
+        final Properties properties = new Properties();
+        properties.setProperty(CLUSTER_ID_PROP_NAME, "8");
+        properties.setProperty(SERVICE_NAME_PROP_NAME, "service-a");
+        properties.setProperty(CLUSTER_DIR_PROP_NAME, "/tmp/cluster-a");
+
+        final ClusteredServiceContainer.Context context = new ClusteredServiceContainer.Context(properties);
+
+        assertSame(properties, context.properties());
+        assertEquals(8, context.clusterId());
+        assertEquals("service-a", context.serviceName());
+        assertEquals("/tmp/cluster-a", context.clusterDirectoryName());
+    }
+
+    @Test
+    void suppliedPropertiesConfigureTheClusterBackupContext()
+    {
+        final Properties properties = new Properties();
+        properties.setProperty(AERON_DIR_PROP_NAME, "/tmp/aeron-backup");
+        properties.setProperty(CLUSTER_DIR_PROP_NAME, "/tmp/cluster-backup");
+
+        final ClusterBackup.Context context = new ClusterBackup.Context(properties);
+
+        assertSame(properties, context.properties());
+        assertEquals("/tmp/cluster-backup", context.clusterDirectoryName());
+    }
+
+    @Test
+    void suppliedPropertiesConfigureTheAeronClusterClientContext()
+    {
+        final Properties properties = new Properties();
+        properties.setProperty(AERON_DIR_PROP_NAME, "/tmp/aeron-a");
+        properties.setProperty(INGRESS_CHANNEL_PROP_NAME, "aeron:udp?term-length=64k");
+        properties.setProperty(MESSAGE_TIMEOUT_PROP_NAME, "4s");
+
+        final AeronCluster.Context context = new AeronCluster.Context(properties);
+
+        assertSame(properties, context.properties());
+        assertEquals("/tmp/aeron-a", context.aeronDirectoryName());
+        assertEquals("aeron:udp?term-length=64k", context.ingressChannel());
+        assertEquals(TimeUnit.SECONDS.toNanos(4), context.messageTimeoutNs());
+    }
+}

--- a/aeron-driver/src/main/java/io/aeron/driver/Configuration.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Configuration.java
@@ -48,20 +48,21 @@ import org.agrona.concurrent.status.StatusIndicator;
 
 import java.net.InetSocketAddress;
 import java.util.Objects;
+import java.util.Properties;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
+import static io.aeron.PropertiesUtil.getDurationInNanos;
+import static io.aeron.PropertiesUtil.getInteger;
+import static io.aeron.PropertiesUtil.getLong;
+import static io.aeron.PropertiesUtil.getSizeAsInt;
+import static io.aeron.PropertiesUtil.getSizeAsLong;
 import static io.aeron.driver.ThreadingMode.DEDICATED;
 import static io.aeron.logbuffer.LogBufferDescriptor.PAGE_MAX_SIZE;
 import static io.aeron.logbuffer.LogBufferDescriptor.PAGE_MIN_SIZE;
-import static java.lang.Integer.getInteger;
-import static java.lang.Long.getLong;
 import static java.lang.System.getProperty;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static org.agrona.BitUtil.fromHex;
-import static org.agrona.SystemUtil.getDurationInNanos;
-import static org.agrona.SystemUtil.getSizeAsInt;
-import static org.agrona.SystemUtil.getSizeAsLong;
 
 /**
  * Configuration options for the {@link MediaDriver}.
@@ -596,7 +597,7 @@ public final class Configuration
     public static final String MULTICAST_FLOW_CONTROL_STRATEGY_PROP_NAME = "aeron.multicast.flow.control.strategy";
 
     /**
-     *  Default flow control strategy for multicast.
+     * Default flow control strategy for multicast.
      */
     @Config
     public static final String MULTICAST_FLOW_CONTROL_STRATEGY_DEFAULT = "io.aeron.driver.MaxMulticastFlowControl";
@@ -1226,7 +1227,19 @@ public final class Configuration
      */
     public static boolean useWindowsHighResTimer()
     {
-        return "true".equals(getProperty(USE_WINDOWS_HIGH_RES_TIMER_PROP_NAME));
+        return useWindowsHighResTimer(System.getProperties());
+    }
+
+    /**
+     * Should the high-resolution timer be used when running on Windows.
+     *
+     * @param properties to read the configuration from.
+     * @return true if the high-resolution timer be used when running on Windows.
+     * @see #USE_WINDOWS_HIGH_RES_TIMER_PROP_NAME
+     */
+    public static boolean useWindowsHighResTimer(final Properties properties)
+    {
+        return "true".equals(properties.getProperty(USE_WINDOWS_HIGH_RES_TIMER_PROP_NAME));
     }
 
     /**
@@ -1237,7 +1250,19 @@ public final class Configuration
      */
     public static boolean warnIfDirExists()
     {
-        return "true".equals(getProperty(DIR_WARN_IF_EXISTS_PROP_NAME));
+        return warnIfDirExists(System.getProperties());
+    }
+
+    /**
+     * Should a warning be printed if the aeron directory exist when starting.
+     *
+     * @param properties to read the configuration from.
+     * @return true if a warning be printed if the aeron directory exist when starting.
+     * @see #DIR_WARN_IF_EXISTS_PROP_NAME
+     */
+    public static boolean warnIfDirExists(final Properties properties)
+    {
+        return "true".equals(properties.getProperty(DIR_WARN_IF_EXISTS_PROP_NAME));
     }
 
     /**
@@ -1249,7 +1274,20 @@ public final class Configuration
      */
     public static boolean dirDeleteOnStart()
     {
-        return "true".equals(getProperty(DIR_DELETE_ON_START_PROP_NAME));
+        return dirDeleteOnStart(System.getProperties());
+    }
+
+    /**
+     * Should driver attempt to an immediate forced delete of {@link CommonContext#AERON_DIR_PROP_NAME} on start
+     * if it exists.
+     *
+     * @param properties to read the configuration from.
+     * @return true if the aeron directory be deleted on start without checking if active.
+     * @see #DIR_DELETE_ON_START_PROP_NAME
+     */
+    public static boolean dirDeleteOnStart(final Properties properties)
+    {
+        return "true".equals(properties.getProperty(DIR_DELETE_ON_START_PROP_NAME));
     }
 
     /**
@@ -1260,7 +1298,19 @@ public final class Configuration
      */
     public static boolean dirDeleteOnShutdown()
     {
-        return "true".equals(getProperty(DIR_DELETE_ON_SHUTDOWN_PROP_NAME));
+        return dirDeleteOnShutdown(System.getProperties());
+    }
+
+    /**
+     * Should driver attempt to delete {@link CommonContext#AERON_DIR_PROP_NAME} on shutdown.
+     *
+     * @param properties to read the configuration from.
+     * @return true if driver should attempt to delete {@link CommonContext#AERON_DIR_PROP_NAME} on shutdown.
+     * @see #DIR_DELETE_ON_SHUTDOWN_PROP_NAME
+     */
+    public static boolean dirDeleteOnShutdown(final Properties properties)
+    {
+        return "true".equals(properties.getProperty(DIR_DELETE_ON_SHUTDOWN_PROP_NAME));
     }
 
     /**
@@ -1271,7 +1321,19 @@ public final class Configuration
      */
     public static boolean termBufferSparseFile()
     {
-        return "true".equals(getProperty(TERM_BUFFER_SPARSE_FILE_PROP_NAME, "true"));
+        return termBufferSparseFile(System.getProperties());
+    }
+
+    /**
+     * Should term buffers be created as sparse files. This can save space at the expense of latency when required.
+     *
+     * @param properties to read the configuration from.
+     * @return true if term buffers should be created as sparse files.
+     * @see #TERM_BUFFER_SPARSE_FILE_PROP_NAME
+     */
+    public static boolean termBufferSparseFile(final Properties properties)
+    {
+        return "true".equals(properties.getProperty(TERM_BUFFER_SPARSE_FILE_PROP_NAME, "true"));
     }
 
     /**
@@ -1282,7 +1344,19 @@ public final class Configuration
      */
     public static boolean tetherSubscriptions()
     {
-        return "true".equals(getProperty(TETHER_SUBSCRIPTIONS_PROP_NAME, "true"));
+        return tetherSubscriptions(System.getProperties());
+    }
+
+    /**
+     * Default for if subscriptions should be tethered.
+     *
+     * @param properties to read the configuration from.
+     * @return true if the default subscriptions should be tethered.
+     * @see #TETHER_SUBSCRIPTIONS_PROP_NAME
+     */
+    public static boolean tetherSubscriptions(final Properties properties)
+    {
+        return "true".equals(properties.getProperty(TETHER_SUBSCRIPTIONS_PROP_NAME, "true"));
     }
 
     /**
@@ -1293,7 +1367,19 @@ public final class Configuration
      */
     public static boolean reliableStream()
     {
-        return "true".equals(getProperty(RELIABLE_STREAM_PROP_NAME, "true"));
+        return reliableStream(System.getProperties());
+    }
+
+    /**
+     * Default boolean value for if a stream is reliable. True to NAK, false to gap fill.
+     *
+     * @param properties to read the configuration from.
+     * @return true if NAK is default or false to gap fill.
+     * @see #RELIABLE_STREAM_PROP_NAME
+     */
+    public static boolean reliableStream(final Properties properties)
+    {
+        return "true".equals(properties.getProperty(RELIABLE_STREAM_PROP_NAME, "true"));
     }
 
     /**
@@ -1304,7 +1390,19 @@ public final class Configuration
      */
     public static boolean performStorageChecks()
     {
-        return "true".equals(getProperty(PERFORM_STORAGE_CHECKS_PROP_NAME, "true"));
+        return performStorageChecks(System.getProperties());
+    }
+
+    /**
+     * Should storage checks should be performed before allocating files.
+     *
+     * @param properties to read the configuration from.
+     * @return true of storage checks should be performed before allocating files.
+     * @see #PERFORM_STORAGE_CHECKS_PROP_NAME
+     */
+    public static boolean performStorageChecks(final Properties properties)
+    {
+        return "true".equals(properties.getProperty(PERFORM_STORAGE_CHECKS_PROP_NAME, "true"));
     }
 
     /**
@@ -1317,7 +1415,21 @@ public final class Configuration
      */
     public static boolean spiesSimulateConnection()
     {
-        return "true".equals(getProperty(SPIES_SIMULATE_CONNECTION_PROP_NAME, "false"));
+        return spiesSimulateConnection(System.getProperties());
+    }
+
+    /**
+     * Should spy subscriptions simulate a connection to a network publication.
+     * <p>
+     * If true then this will override the min group size of the min and tagged flow control strategies.
+     *
+     * @param properties to read the configuration from.
+     * @return true if spy subscriptions should simulate a connection to a network publication.
+     * @see #SPIES_SIMULATE_CONNECTION_PROP_NAME
+     */
+    public static boolean spiesSimulateConnection(final Properties properties)
+    {
+        return "true".equals(properties.getProperty(SPIES_SIMULATE_CONNECTION_PROP_NAME, "false"));
     }
 
     /**
@@ -1328,7 +1440,19 @@ public final class Configuration
      */
     public static CommonContext.InferableBoolean receiverGroupConsideration()
     {
-        return CommonContext.InferableBoolean.parse(getProperty(GROUP_RECEIVER_CONSIDERATION_PROP_NAME));
+        return receiverGroupConsideration(System.getProperties());
+    }
+
+    /**
+     * Should subscriptions should be considered a group member or individual connection, e.g. multicast vs unicast.
+     *
+     * @param properties to read the configuration from.
+     * @return FORCE_TRUE if subscriptions should be considered a group member or false if individual.
+     * @see #GROUP_RECEIVER_CONSIDERATION_PROP_NAME
+     */
+    public static CommonContext.InferableBoolean receiverGroupConsideration(final Properties properties)
+    {
+        return CommonContext.InferableBoolean.parse(properties.getProperty(GROUP_RECEIVER_CONSIDERATION_PROP_NAME));
     }
 
     /**
@@ -1339,7 +1463,19 @@ public final class Configuration
      */
     public static int conductorBufferLength()
     {
-        return getSizeAsInt(CONDUCTOR_BUFFER_LENGTH_PROP_NAME, CONDUCTOR_BUFFER_LENGTH_DEFAULT);
+        return conductorBufferLength(System.getProperties());
+    }
+
+    /**
+     * Length (in bytes) of the conductor buffer for control commands from the clients to the media driver conductor.
+     *
+     * @param properties to read the configuration from.
+     * @return length (in bytes) of the conductor buffer for control commands from the clients to the media driver.
+     * @see #CONDUCTOR_BUFFER_LENGTH_PROP_NAME
+     */
+    public static int conductorBufferLength(final Properties properties)
+    {
+        return getSizeAsInt(properties, CONDUCTOR_BUFFER_LENGTH_PROP_NAME, CONDUCTOR_BUFFER_LENGTH_DEFAULT);
     }
 
     /**
@@ -1350,7 +1486,19 @@ public final class Configuration
      */
     public static int toClientsBufferLength()
     {
-        return getSizeAsInt(TO_CLIENTS_BUFFER_LENGTH_PROP_NAME, TO_CLIENTS_BUFFER_LENGTH_DEFAULT);
+        return toClientsBufferLength(System.getProperties());
+    }
+
+    /**
+     * Length (in bytes) of the broadcast buffers from the media driver to the clients.
+     *
+     * @param properties to read the configuration from.
+     * @return length (in bytes) of the broadcast buffers from the media driver to the clients.
+     * @see #TO_CLIENTS_BUFFER_LENGTH_PROP_NAME
+     */
+    public static int toClientsBufferLength(final Properties properties)
+    {
+        return getSizeAsInt(properties, TO_CLIENTS_BUFFER_LENGTH_PROP_NAME, TO_CLIENTS_BUFFER_LENGTH_DEFAULT);
     }
 
     /**
@@ -1363,7 +1511,21 @@ public final class Configuration
      */
     public static int counterValuesBufferLength()
     {
-        return getSizeAsInt(COUNTERS_VALUES_BUFFER_LENGTH_PROP_NAME, COUNTERS_VALUES_BUFFER_LENGTH_DEFAULT);
+        return counterValuesBufferLength(System.getProperties());
+    }
+
+    /**
+     * Length of the buffer for the counters.
+     * <p>
+     * Each counter uses {@link org.agrona.concurrent.status.CountersReader#COUNTER_LENGTH} bytes.
+     *
+     * @param properties to read the configuration from.
+     * @return Length of the buffer for the counters.
+     * @see #COUNTERS_VALUES_BUFFER_LENGTH_PROP_NAME
+     */
+    public static int counterValuesBufferLength(final Properties properties)
+    {
+        return getSizeAsInt(properties, COUNTERS_VALUES_BUFFER_LENGTH_PROP_NAME, COUNTERS_VALUES_BUFFER_LENGTH_DEFAULT);
     }
 
     /**
@@ -1373,7 +1535,18 @@ public final class Configuration
      */
     public static int errorBufferLength()
     {
-        return getSizeAsInt(ERROR_BUFFER_LENGTH_PROP_NAME, ERROR_BUFFER_LENGTH_DEFAULT);
+        return errorBufferLength(System.getProperties());
+    }
+
+    /**
+     * Length of the memory mapped buffer for the distinct error log.
+     *
+     * @param properties to read the configuration from.
+     * @return length of the memory mapped buffer for the distinct error log.
+     */
+    public static int errorBufferLength(final Properties properties)
+    {
+        return getSizeAsInt(properties, ERROR_BUFFER_LENGTH_PROP_NAME, ERROR_BUFFER_LENGTH_DEFAULT);
     }
 
     /**
@@ -1384,7 +1557,19 @@ public final class Configuration
      */
     public static int nakMulticastGroupSize()
     {
-        return getInteger(NAK_MULTICAST_GROUP_SIZE_PROP_NAME, NAK_MULTICAST_GROUP_SIZE_DEFAULT);
+        return nakMulticastGroupSize(System.getProperties());
+    }
+
+    /**
+     * Expected size of typical multicast receiver groups.
+     *
+     * @param properties to read the configuration from.
+     * @return expected size of typical multicast receiver groups.
+     * @see #NAK_MULTICAST_GROUP_SIZE_PROP_NAME
+     */
+    public static int nakMulticastGroupSize(final Properties properties)
+    {
+        return getInteger(properties, NAK_MULTICAST_GROUP_SIZE_PROP_NAME, NAK_MULTICAST_GROUP_SIZE_DEFAULT);
     }
 
     /**
@@ -1395,7 +1580,19 @@ public final class Configuration
      */
     public static long nakMulticastMaxBackoffNs()
     {
-        return getDurationInNanos(NAK_MULTICAST_MAX_BACKOFF_PROP_NAME, NAK_MAX_BACKOFF_DEFAULT_NS);
+        return nakMulticastMaxBackoffNs(System.getProperties());
+    }
+
+    /**
+     * Max backoff time for multicast NAK delay randomisation in nanoseconds.
+     *
+     * @param properties to read the configuration from.
+     * @return max backoff time for multicast NAK delay randomisation in nanoseconds.
+     * @see #NAK_MULTICAST_MAX_BACKOFF_PROP_NAME
+     */
+    public static long nakMulticastMaxBackoffNs(final Properties properties)
+    {
+        return getDurationInNanos(properties, NAK_MULTICAST_MAX_BACKOFF_PROP_NAME, NAK_MAX_BACKOFF_DEFAULT_NS);
     }
 
     /**
@@ -1406,7 +1603,19 @@ public final class Configuration
      */
     public static long nakUnicastDelayNs()
     {
-        return getDurationInNanos(NAK_UNICAST_DELAY_PROP_NAME, NAK_UNICAST_DELAY_DEFAULT_NS);
+        return nakUnicastDelayNs(System.getProperties());
+    }
+
+    /**
+     * Unicast NAK delay in nanoseconds.
+     *
+     * @param properties to read the configuration from.
+     * @return unicast NAK delay in nanoseconds.
+     * @see #NAK_UNICAST_DELAY_PROP_NAME
+     */
+    public static long nakUnicastDelayNs(final Properties properties)
+    {
+        return getDurationInNanos(properties, NAK_UNICAST_DELAY_PROP_NAME, NAK_UNICAST_DELAY_DEFAULT_NS);
     }
 
     /**
@@ -1417,7 +1626,20 @@ public final class Configuration
      */
     public static long nakUnicastRetryDelayRatio()
     {
-        return getSizeAsLong(NAK_UNICAST_RETRY_DELAY_RATIO_PROP_NAME, NAK_UNICAST_RETRY_DELAY_RATIO_DEFAULT);
+        return nakUnicastRetryDelayRatio(System.getProperties());
+    }
+
+    /**
+     * Unicast NAK retry delay ratio.
+     *
+     * @param properties to read the configuration from.
+     * @return unicast NAK delay in nanoseconds.
+     * @see #NAK_UNICAST_DELAY_PROP_NAME
+     */
+    public static long nakUnicastRetryDelayRatio(final Properties properties)
+    {
+        return getSizeAsLong(
+            properties, NAK_UNICAST_RETRY_DELAY_RATIO_PROP_NAME, NAK_UNICAST_RETRY_DELAY_RATIO_DEFAULT);
     }
 
     /**
@@ -1428,7 +1650,19 @@ public final class Configuration
      */
     public static long timerIntervalNs()
     {
-        return getDurationInNanos(TIMER_INTERVAL_PROP_NAME, DEFAULT_TIMER_INTERVAL_NS);
+        return timerIntervalNs(System.getProperties());
+    }
+
+    /**
+     * Interval between checks for timers and timeouts.
+     *
+     * @param properties to read the configuration from.
+     * @return interval between checks for timers and timeouts.
+     * @see #TIMER_INTERVAL_PROP_NAME
+     */
+    public static long timerIntervalNs(final Properties properties)
+    {
+        return getDurationInNanos(properties, TIMER_INTERVAL_PROP_NAME, DEFAULT_TIMER_INTERVAL_NS);
     }
 
     /**
@@ -1440,7 +1674,21 @@ public final class Configuration
      */
     public static long lowStorageWarningThreshold()
     {
-        return getSizeAsLong(LOW_FILE_STORE_WARNING_THRESHOLD_PROP_NAME, LOW_FILE_STORE_WARNING_THRESHOLD_DEFAULT);
+        return lowStorageWarningThreshold(System.getProperties());
+    }
+
+    /**
+     * Low file storage warning threshold in bytes for when performing storage checks.
+     *
+     * @param properties to read the configuration from.
+     * @return Low file storage warning threshold for when performing storage checks.
+     * @see #LOW_FILE_STORE_WARNING_THRESHOLD_PROP_NAME
+     * @see #PERFORM_STORAGE_CHECKS_PROP_NAME
+     */
+    public static long lowStorageWarningThreshold(final Properties properties)
+    {
+        return getSizeAsLong(
+            properties, LOW_FILE_STORE_WARNING_THRESHOLD_PROP_NAME, LOW_FILE_STORE_WARNING_THRESHOLD_DEFAULT);
     }
 
     /**
@@ -1451,7 +1699,19 @@ public final class Configuration
      */
     public static int publicationTermWindowLength()
     {
-        return getSizeAsInt(PUBLICATION_TERM_WINDOW_LENGTH_PROP_NAME, 0);
+        return publicationTermWindowLength(System.getProperties());
+    }
+
+    /**
+     * The window limit on UDP {@link Publication} side by which the publisher can get ahead of consumers.
+     *
+     * @param properties to read the configuration from.
+     * @return window limit on UDP {@link Publication} side by which the publisher can get ahead of consumers.
+     * @see #PUBLICATION_TERM_WINDOW_LENGTH_PROP_NAME
+     */
+    public static int publicationTermWindowLength(final Properties properties)
+    {
+        return getSizeAsInt(properties, PUBLICATION_TERM_WINDOW_LENGTH_PROP_NAME, 0);
     }
 
     /**
@@ -1462,7 +1722,19 @@ public final class Configuration
      */
     public static int ipcPublicationTermWindowLength()
     {
-        return getSizeAsInt(IPC_PUBLICATION_TERM_WINDOW_LENGTH_PROP_NAME, 0);
+        return ipcPublicationTermWindowLength(System.getProperties());
+    }
+
+    /**
+     * The window limit on IPC {@link Publication} side by which the publisher can get ahead of consumers.
+     *
+     * @param properties to read the configuration from.
+     * @return window limit on IPC {@link Publication} side by which the publisher can get ahead of consumers.
+     * @see #IPC_PUBLICATION_TERM_WINDOW_LENGTH_PROP_NAME
+     */
+    public static int ipcPublicationTermWindowLength(final Properties properties)
+    {
+        return getSizeAsInt(properties, IPC_PUBLICATION_TERM_WINDOW_LENGTH_PROP_NAME, 0);
     }
 
     /**
@@ -1476,8 +1748,23 @@ public final class Configuration
      */
     public static long untetheredWindowLimitTimeoutNs()
     {
+        return untetheredWindowLimitTimeoutNs(System.getProperties());
+    }
+
+    /**
+     * The timeout for when an untethered subscription that is outside the window limit will participate in local
+     * flow control.
+     *
+     * @param properties to read the configuration from.
+     * @return the timeout for when an untethered subscription that is outside the window limit will be included.
+     * @see #UNTETHERED_WINDOW_LIMIT_TIMEOUT_PROP_NAME
+     * @see #UNTETHERED_RESTING_TIMEOUT_PROP_NAME
+     * @see #TETHER_SUBSCRIPTIONS_PROP_NAME
+     */
+    public static long untetheredWindowLimitTimeoutNs(final Properties properties)
+    {
         return getDurationInNanos(
-            UNTETHERED_WINDOW_LIMIT_TIMEOUT_PROP_NAME, UNTETHERED_WINDOW_LIMIT_TIMEOUT_DEFAULT_NS);
+            properties, UNTETHERED_WINDOW_LIMIT_TIMEOUT_PROP_NAME, UNTETHERED_WINDOW_LIMIT_TIMEOUT_DEFAULT_NS);
     }
 
     /**
@@ -1489,7 +1776,20 @@ public final class Configuration
      */
     public static long untetheredLingerTimeoutNs()
     {
-        return getDurationInNanos(UNTETHERED_LINGER_TIMEOUT_PROP_NAME, Aeron.NULL_VALUE);
+        return untetheredLingerTimeoutNs(System.getProperties());
+    }
+
+    /**
+     * The timeout for an untethered subscription to remain in the linger state.
+     *
+     * @param properties to read the configuration from.
+     * @return the timeout for an untethered subscription to remain in the linger state.
+     * @see #UNTETHERED_LINGER_TIMEOUT_PROP_NAME
+     * @since 1.48.0
+     */
+    public static long untetheredLingerTimeoutNs(final Properties properties)
+    {
+        return getDurationInNanos(properties, UNTETHERED_LINGER_TIMEOUT_PROP_NAME, Aeron.NULL_VALUE);
     }
 
     /**
@@ -1503,7 +1803,23 @@ public final class Configuration
      */
     public static long untetheredRestingTimeoutNs()
     {
-        return getDurationInNanos(UNTETHERED_RESTING_TIMEOUT_PROP_NAME, UNTETHERED_RESTING_TIMEOUT_DEFAULT_NS);
+        return untetheredRestingTimeoutNs(System.getProperties());
+    }
+
+    /**
+     * The timeout for when an untethered subscription is resting after not being able to keep up before it is allowed
+     * to rejoin a stream.
+     *
+     * @param properties to read the configuration from.
+     * @return The timeout for when an untethered subscription is resting before rejoining a stream.
+     * @see #UNTETHERED_RESTING_TIMEOUT_PROP_NAME
+     * @see #UNTETHERED_WINDOW_LIMIT_TIMEOUT_PROP_NAME
+     * @see #TETHER_SUBSCRIPTIONS_PROP_NAME
+     */
+    public static long untetheredRestingTimeoutNs(final Properties properties)
+    {
+        return getDurationInNanos(
+            properties, UNTETHERED_RESTING_TIMEOUT_PROP_NAME, UNTETHERED_RESTING_TIMEOUT_DEFAULT_NS);
     }
 
     /**
@@ -1514,8 +1830,20 @@ public final class Configuration
      */
     public static int maxResend()
     {
+        return maxResend(System.getProperties());
+    }
+
+    /**
+     * Max number of active retransmissions tracked for udp streams with group semantics.
+     *
+     * @param properties to read the configuration from.
+     * @return max retransmits
+     * @see #MAX_RESEND_PROP_NAME
+     */
+    public static int maxResend(final Properties properties)
+    {
         return Integer.min(
-            Integer.max(getInteger(MAX_RESEND_PROP_NAME, MAX_RESEND_DEFAULT), 1),
+            Integer.max(getInteger(properties, MAX_RESEND_PROP_NAME, MAX_RESEND_DEFAULT), 1),
             MAX_RESEND_MAX);
     }
 
@@ -1527,7 +1855,19 @@ public final class Configuration
      */
     public static boolean rejoinStream()
     {
-        return "true".equalsIgnoreCase(getProperty(REJOIN_STREAM_PROP_NAME, "true"));
+        return rejoinStream(System.getProperties());
+    }
+
+    /**
+     * Default boolean value for if a stream can be rejoined. True to allow stream rejoin, false to not.
+     *
+     * @param properties to read the configuration from.
+     * @return boolean value for if a stream can be rejoined. True to allow stream rejoin, false to not.
+     * @see #REJOIN_STREAM_PROP_NAME
+     */
+    public static boolean rejoinStream(final Properties properties)
+    {
+        return "true".equalsIgnoreCase(properties.getProperty(REJOIN_STREAM_PROP_NAME, "true"));
     }
 
     /**
@@ -1538,7 +1878,19 @@ public final class Configuration
      */
     public static Long groupTag()
     {
-        return getLong(RECEIVER_GROUP_TAG_PROP_NAME, null);
+        return groupTag(System.getProperties());
+    }
+
+    /**
+     * Default group tag (gtag) to send in all Status Messages. If not provided then no gtag is sent.
+     *
+     * @param properties to read the configuration from.
+     * @return Default group tag (gtag) to send in all Status Messages.
+     * @see #RECEIVER_GROUP_TAG_PROP_NAME
+     */
+    public static Long groupTag(final Properties properties)
+    {
+        return getLong(properties, RECEIVER_GROUP_TAG_PROP_NAME, null);
     }
 
     /**
@@ -1547,14 +1899,26 @@ public final class Configuration
      * @return group tag (gtag) used by the tagged flow control strategy to group receivers.
      * @see #FLOW_CONTROL_GROUP_TAG_PROP_NAME
      */
-    @SuppressWarnings("deprecation")
     public static long flowControlGroupTag()
     {
-        final String propertyValue = getProperty(
+        return flowControlGroupTag(System.getProperties());
+    }
+
+    /**
+     * Default group tag (gtag) used by the tagged flow control strategy to group receivers.
+     *
+     * @param properties to read the configuration from.
+     * @return group tag (gtag) used by the tagged flow control strategy to group receivers.
+     * @see #FLOW_CONTROL_GROUP_TAG_PROP_NAME
+     */
+    @SuppressWarnings("deprecation")
+    public static long flowControlGroupTag(final Properties properties)
+    {
+        final String propertyValue = properties.getProperty(
             PreferredMulticastFlowControl.PREFERRED_ASF_PROP_NAME, PreferredMulticastFlowControl.PREFERRED_ASF_DEFAULT);
         final long legacyAsfValue = new UnsafeBuffer(BitUtil.fromHex(propertyValue)).getLong(0, LITTLE_ENDIAN);
 
-        return getLong(FLOW_CONTROL_GROUP_TAG_PROP_NAME, legacyAsfValue);
+        return getLong(properties, FLOW_CONTROL_GROUP_TAG_PROP_NAME, legacyAsfValue);
     }
 
     /**
@@ -1565,7 +1929,19 @@ public final class Configuration
      */
     public static int flowControlGroupMinSize()
     {
-        return getInteger(FLOW_CONTROL_GROUP_MIN_SIZE_PROP_NAME, 0);
+        return flowControlGroupMinSize(System.getProperties());
+    }
+
+    /**
+     * Default minimum group size used by flow control strategies to determine connectivity.
+     *
+     * @param properties to read the configuration from.
+     * @return default minimum group size used by flow control strategies to determine connectivity.
+     * @see #FLOW_CONTROL_GROUP_MIN_SIZE_PROP_NAME
+     */
+    public static int flowControlGroupMinSize(final Properties properties)
+    {
+        return getInteger(properties, FLOW_CONTROL_GROUP_MIN_SIZE_PROP_NAME, 0);
     }
 
     /**
@@ -1576,7 +1952,20 @@ public final class Configuration
      */
     public static long flowControlReceiverTimeoutNs()
     {
-        return getDurationInNanos(FLOW_CONTROL_RECEIVER_TIMEOUT_PROP_NAME, FLOW_CONTROL_RECEIVER_TIMEOUT_DEFAULT_NS);
+        return flowControlReceiverTimeoutNs(System.getProperties());
+    }
+
+    /**
+     * Flow control timeout after which with no status messages the receiver is considered gone.
+     *
+     * @param properties to read the configuration from.
+     * @return flow control timeout after which with no status messages the receiver is considered gone.
+     * @see #FLOW_CONTROL_RECEIVER_TIMEOUT_PROP_NAME
+     */
+    public static long flowControlReceiverTimeoutNs(final Properties properties)
+    {
+        return getDurationInNanos(
+            properties, FLOW_CONTROL_RECEIVER_TIMEOUT_PROP_NAME, FLOW_CONTROL_RECEIVER_TIMEOUT_DEFAULT_NS);
     }
 
     /**
@@ -1587,7 +1976,19 @@ public final class Configuration
      */
     public static int unicastFlowControlRetransmitReceiverWindowMultiple()
     {
-        return getInteger(UNICAST_FLOW_CONTROL_RETRANSMIT_RECEIVER_WINDOW_MULTIPLE_PROP_NAME, 16);
+        return unicastFlowControlRetransmitReceiverWindowMultiple(System.getProperties());
+    }
+
+    /**
+     * Retransmit receiver window multiple used by the unicast flow control strategy to determine the maximum
+     * amount of data to retransmit.
+     *
+     * @param properties to read the configuration from.
+     * @return multiple.
+     */
+    public static int unicastFlowControlRetransmitReceiverWindowMultiple(final Properties properties)
+    {
+        return getInteger(properties, UNICAST_FLOW_CONTROL_RETRANSMIT_RECEIVER_WINDOW_MULTIPLE_PROP_NAME, 16);
     }
 
     /**
@@ -1598,7 +1999,19 @@ public final class Configuration
      */
     public static int multicastFlowControlRetransmitReceiverWindowMultiple()
     {
-        return getInteger(MULTICAST_FLOW_CONTROL_RETRANSMIT_RECEIVER_WINDOW_MULTIPLE_PROP_NAME, 4);
+        return multicastFlowControlRetransmitReceiverWindowMultiple(System.getProperties());
+    }
+
+    /**
+     * Retransmit receiver window multiple used by multicast flow control strategies to determine the maximum
+     * amount of data to retransmit.
+     *
+     * @param properties to read the configuration from.
+     * @return multiple.
+     */
+    public static int multicastFlowControlRetransmitReceiverWindowMultiple(final Properties properties)
+    {
+        return getInteger(properties, MULTICAST_FLOW_CONTROL_RETRANSMIT_RECEIVER_WINDOW_MULTIPLE_PROP_NAME, 4);
     }
 
     /**
@@ -1609,7 +2022,19 @@ public final class Configuration
      */
     public static String resolverName()
     {
-        return getProperty(RESOLVER_NAME_PROP_NAME);
+        return resolverName(System.getProperties());
+    }
+
+    /**
+     * Resolver name of the Media Driver used in name resolution.
+     *
+     * @param properties to read the configuration from.
+     * @return resolver name of the Media Driver used in name resolution.
+     * @see #RESOLVER_NAME_PROP_NAME
+     */
+    public static String resolverName(final Properties properties)
+    {
+        return properties.getProperty(RESOLVER_NAME_PROP_NAME);
     }
 
     /**
@@ -1620,7 +2045,19 @@ public final class Configuration
      */
     public static String resolverInterface()
     {
-        return getProperty(RESOLVER_INTERFACE_PROP_NAME);
+        return resolverInterface(System.getProperties());
+    }
+
+    /**
+     * Property name for resolver interface to which network connections are made, format is hostname:port.
+     *
+     * @param properties to read the configuration from.
+     * @return resolver interface to which network connections are made, format is hostname:port.
+     * @see #RESOLVER_INTERFACE_PROP_NAME
+     */
+    public static String resolverInterface(final Properties properties)
+    {
+        return properties.getProperty(RESOLVER_INTERFACE_PROP_NAME);
     }
 
     /**
@@ -1632,7 +2069,20 @@ public final class Configuration
      */
     public static String resolverBootstrapNeighbor()
     {
-        return getProperty(RESOLVER_BOOTSTRAP_NEIGHBOR_PROP_NAME);
+        return resolverBootstrapNeighbor(System.getProperties());
+    }
+
+    /**
+     * Resolver bootstrap neighbor for which it can bootstrap naming, format is hostname:port.
+     *
+     * @param properties to read the configuration from.
+     * @return resolver bootstrap neighbor for which it can bootstrap naming, format is hostname:port.
+     * @see #RESOLVER_BOOTSTRAP_NEIGHBOR_PROP_NAME
+     * @see #RESOLVER_INTERFACE_PROP_NAME
+     */
+    public static String resolverBootstrapNeighbor(final Properties properties)
+    {
+        return properties.getProperty(RESOLVER_BOOTSTRAP_NEIGHBOR_PROP_NAME);
     }
 
     /**
@@ -1646,7 +2096,23 @@ public final class Configuration
      */
     public static long resolverNeighborTimeoutNs()
     {
-        return getDurationInNanos(RESOLVER_NEIGHBOR_TIMEOUT_PROP_NAME, RESOLVER_NEIGHBOR_TIMEOUT_DEFAULT_NS);
+        return resolverNeighborTimeoutNs(System.getProperties());
+    }
+
+    /**
+     * Resolve configuration for time to wait before removing a neighbor entry from the cache if an update for that
+     * neighbor has not been received.
+     *
+     * @param properties to read the configuration from.
+     * @return time to wait before removing a neighbor entry from the cache if an update for that * neighbor has not
+     * been received.
+     * @see #RESOLVER_NEIGHBOR_TIMEOUT_DEFAULT_NS
+     * @see #RESOLVER_NEIGHBOR_TIMEOUT_PROP_NAME
+     */
+    public static long resolverNeighborTimeoutNs(final Properties properties)
+    {
+        return getDurationInNanos(
+            properties, RESOLVER_NEIGHBOR_TIMEOUT_PROP_NAME, RESOLVER_NEIGHBOR_TIMEOUT_DEFAULT_NS);
     }
 
     /**
@@ -1658,8 +2124,21 @@ public final class Configuration
      */
     public static long resolverSelfResolutionIntervalNs()
     {
+        return resolverSelfResolutionIntervalNs(System.getProperties());
+    }
+
+    /**
+     * Resolve configuration for the interval between sending name to address messages for this driver to its neighbors.
+     *
+     * @param properties to read the configuration from.
+     * @return interval between sending name to address messages for this driver to its neighbors.
+     * @see #RESOLVER_SELF_RESOLUTION_INTERVAL_DEFAULT_NS
+     * @see #RESOLVER_SELF_RESOLUTION_INTERVAL_PROP_NAME
+     */
+    public static long resolverSelfResolutionIntervalNs(final Properties properties)
+    {
         return getDurationInNanos(
-            RESOLVER_SELF_RESOLUTION_INTERVAL_PROP_NAME, RESOLVER_SELF_RESOLUTION_INTERVAL_DEFAULT_NS);
+            properties, RESOLVER_SELF_RESOLUTION_INTERVAL_PROP_NAME, RESOLVER_SELF_RESOLUTION_INTERVAL_DEFAULT_NS);
     }
 
     /**
@@ -1671,8 +2150,23 @@ public final class Configuration
      */
     public static long resolverNeighborResolutionIntervalNs()
     {
+        return resolverNeighborResolutionIntervalNs(System.getProperties());
+    }
+
+    /**
+     * Resolve configuration for the interval between sending name to address messages for all known neighbors.
+     *
+     * @param properties to read the configuration from.
+     * @return interval between sending name to address messages for all known neighbors.
+     * @see #RESOLVER_NEIGHBOR_RESOLUTION_INTERVAL_DEFAULT_NS
+     * @see #RESOLVER_NEIGHBOR_RESOLUTION_INTERVAL_PROP_NAME
+     */
+    public static long resolverNeighborResolutionIntervalNs(final Properties properties)
+    {
         return getDurationInNanos(
-            RESOLVER_NEIGHBOR_RESOLUTION_INTERVAL_PROP_NAME, RESOLVER_NEIGHBOR_RESOLUTION_INTERVAL_DEFAULT_NS);
+            properties,
+            RESOLVER_NEIGHBOR_RESOLUTION_INTERVAL_PROP_NAME,
+            RESOLVER_NEIGHBOR_RESOLUTION_INTERVAL_DEFAULT_NS);
     }
 
     /**
@@ -1684,8 +2178,21 @@ public final class Configuration
      */
     public static long resolverBootstrapNeighborResolutionIntervalNs()
     {
+        return resolverBootstrapNeighborResolutionIntervalNs(System.getProperties());
+    }
+
+    /**
+     * Resolve configuration for the interval between resolutions of bootstrap neighbors that are not active.
+     *
+     * @param properties to read the configuration from.
+     * @return interval between sending name to address messages for all known neighbors.
+     * @see #RESOLVER_BOOTSTRAP_NEIGHBOR_RESOLUTION_INTERVAL_DEFAULT_NS
+     * @see #RESOLVER_BOOTSTRAP_NEIGHBOR_RESOLUTION_INTERVAL_PROP_NAME
+     */
+    public static long resolverBootstrapNeighborResolutionIntervalNs(final Properties properties)
+    {
         return getDurationInNanos(
-            RESOLVER_BOOTSTRAP_NEIGHBOR_RESOLUTION_INTERVAL_PROP_NAME,
+            properties, RESOLVER_BOOTSTRAP_NEIGHBOR_RESOLUTION_INTERVAL_PROP_NAME,
             RESOLVER_BOOTSTRAP_NEIGHBOR_RESOLUTION_INTERVAL_DEFAULT_NS);
     }
 
@@ -1697,7 +2204,20 @@ public final class Configuration
      */
     public static long reResolutionCheckIntervalNs()
     {
-        return getDurationInNanos(RE_RESOLUTION_CHECK_INTERVAL_PROP_NAME, RE_RESOLUTION_CHECK_INTERVAL_DEFAULT_NS);
+        return reResolutionCheckIntervalNs(System.getProperties());
+    }
+
+    /**
+     * Re-resolution check interval for resolving names to IP address when they may have changed.
+     *
+     * @param properties to read the configuration from.
+     * @return re-resolution check interval for resolving names to IP address when they may have changed.
+     * @see #RE_RESOLUTION_CHECK_INTERVAL_PROP_NAME
+     */
+    public static long reResolutionCheckIntervalNs(final Properties properties)
+    {
+        return getDurationInNanos(
+            properties, RE_RESOLUTION_CHECK_INTERVAL_PROP_NAME, RE_RESOLUTION_CHECK_INTERVAL_DEFAULT_NS);
     }
 
     /**
@@ -1739,7 +2259,19 @@ public final class Configuration
      */
     public static int termBufferLength()
     {
-        return getSizeAsInt(TERM_BUFFER_LENGTH_PROP_NAME, TERM_BUFFER_LENGTH_DEFAULT);
+        return termBufferLength(System.getProperties());
+    }
+
+    /**
+     * Length (in bytes) of the log buffers for UDP publication terms.
+     *
+     * @param properties to read the configuration from.
+     * @return length (in bytes) of the log buffers for UDP publication terms.
+     * @see #TERM_BUFFER_LENGTH_PROP_NAME
+     */
+    public static int termBufferLength(final Properties properties)
+    {
+        return getSizeAsInt(properties, TERM_BUFFER_LENGTH_PROP_NAME, TERM_BUFFER_LENGTH_DEFAULT);
     }
 
     /**
@@ -1750,7 +2282,19 @@ public final class Configuration
      */
     public static int ipcTermBufferLength()
     {
-        return getSizeAsInt(IPC_TERM_BUFFER_LENGTH_PROP_NAME, TERM_BUFFER_IPC_LENGTH_DEFAULT);
+        return ipcTermBufferLength(System.getProperties());
+    }
+
+    /**
+     * Length (in bytes) of the log buffers for IPC publication terms.
+     *
+     * @param properties to read the configuration from.
+     * @return length (in bytes) of the log buffers for IPC publication terms.
+     * @see #IPC_TERM_BUFFER_LENGTH_PROP_NAME
+     */
+    public static int ipcTermBufferLength(final Properties properties)
+    {
+        return getSizeAsInt(properties, IPC_TERM_BUFFER_LENGTH_PROP_NAME, TERM_BUFFER_IPC_LENGTH_DEFAULT);
     }
 
     /**
@@ -1761,7 +2305,19 @@ public final class Configuration
      */
     public static int initialWindowLength()
     {
-        return getSizeAsInt(INITIAL_WINDOW_LENGTH_PROP_NAME, INITIAL_WINDOW_LENGTH_DEFAULT);
+        return initialWindowLength(System.getProperties());
+    }
+
+    /**
+     * Length of the initial window which must be sufficient for Bandwidth Delay Product (BDP).
+     *
+     * @param properties to read the configuration from.
+     * @return length of the initial window which must be sufficient for Bandwidth Delay Product (BDP).
+     * @see #INITIAL_WINDOW_LENGTH_PROP_NAME
+     */
+    public static int initialWindowLength(final Properties properties)
+    {
+        return getSizeAsInt(properties, INITIAL_WINDOW_LENGTH_PROP_NAME, INITIAL_WINDOW_LENGTH_DEFAULT);
     }
 
     /**
@@ -1772,7 +2328,19 @@ public final class Configuration
      */
     public static int socketSndbufLength()
     {
-        return getSizeAsInt(SOCKET_SNDBUF_LENGTH_PROP_NAME, SOCKET_SNDBUF_LENGTH_DEFAULT);
+        return socketSndbufLength(System.getProperties());
+    }
+
+    /**
+     * SO_SNDBUF setting on UDP sockets which must be sufficient for Bandwidth Delay Product (BDP).
+     *
+     * @param properties to read the configuration from.
+     * @return SO_SNDBUF setting on UDP sockets which must be sufficient for Bandwidth Delay Product (BDP).
+     * @see #SOCKET_SNDBUF_LENGTH_PROP_NAME
+     */
+    public static int socketSndbufLength(final Properties properties)
+    {
+        return getSizeAsInt(properties, SOCKET_SNDBUF_LENGTH_PROP_NAME, SOCKET_SNDBUF_LENGTH_DEFAULT);
     }
 
     /**
@@ -1783,7 +2351,19 @@ public final class Configuration
      */
     public static int socketRcvbufLength()
     {
-        return getSizeAsInt(SOCKET_RCVBUF_LENGTH_PROP_NAME, SOCKET_RCVBUF_LENGTH_DEFAULT);
+        return socketRcvbufLength(System.getProperties());
+    }
+
+    /**
+     * SO_RCVBUF setting on UDP sockets which must be sufficient for Bandwidth Delay Product (BDP).
+     *
+     * @param properties to read the configuration from.
+     * @return SO_RCVBUF setting on UDP sockets which must be sufficient for Bandwidth Delay Product (BDP).
+     * @see #SOCKET_RCVBUF_LENGTH_PROP_NAME
+     */
+    public static int socketRcvbufLength(final Properties properties)
+    {
+        return getSizeAsInt(properties, SOCKET_RCVBUF_LENGTH_PROP_NAME, SOCKET_RCVBUF_LENGTH_DEFAULT);
     }
 
     /**
@@ -1795,7 +2375,20 @@ public final class Configuration
      */
     public static int mtuLength()
     {
-        return getSizeAsInt(MTU_LENGTH_PROP_NAME, MTU_LENGTH_DEFAULT);
+        return mtuLength(System.getProperties());
+    }
+
+    /**
+     * Length of the maximum transmission unit of the media driver's protocol. If this is greater
+     * than the network MTU for UDP then the packet will be fragmented and can amplify the impact of loss.
+     *
+     * @param properties to read the configuration from.
+     * @return length of the maximum transmission unit of the media driver's protocol.
+     * @see #MTU_LENGTH_PROP_NAME
+     */
+    public static int mtuLength(final Properties properties)
+    {
+        return getSizeAsInt(properties, MTU_LENGTH_PROP_NAME, MTU_LENGTH_DEFAULT);
     }
 
     /**
@@ -1807,7 +2400,20 @@ public final class Configuration
      */
     public static int ipcMtuLength()
     {
-        return getSizeAsInt(IPC_MTU_LENGTH_PROP_NAME, IPC_MTU_LENGTH_DEFAULT);
+        return ipcMtuLength(System.getProperties());
+    }
+
+    /**
+     * Length of the maximum transmission unit of the media driver's protocol for IPC. This can be larger than the
+     * UDP version but if recorded replay needs to be considered.
+     *
+     * @param properties to read the configuration from.
+     * @return length of the maximum transmission unit of the media driver's protocol for IPC.
+     * @see #IPC_MTU_LENGTH_PROP_NAME
+     */
+    public static int ipcMtuLength(final Properties properties)
+    {
+        return getSizeAsInt(properties, IPC_MTU_LENGTH_PROP_NAME, IPC_MTU_LENGTH_DEFAULT);
     }
 
     /**
@@ -1818,7 +2424,19 @@ public final class Configuration
      */
     public static int socketMulticastTtl()
     {
-        return getInteger(SOCKET_MULTICAST_TTL_PROP_NAME, SOCKET_MULTICAST_TTL_DEFAULT);
+        return socketMulticastTtl(System.getProperties());
+    }
+
+    /**
+     * IP_MULTICAST_TTL setting on UDP sockets.
+     *
+     * @param properties to read the configuration from.
+     * @return IP_MULTICAST_TTL setting on UDP sockets.
+     * @see #SOCKET_MULTICAST_TTL_PROP_NAME
+     */
+    public static int socketMulticastTtl(final Properties properties)
+    {
+        return getInteger(properties, SOCKET_MULTICAST_TTL_PROP_NAME, SOCKET_MULTICAST_TTL_DEFAULT);
     }
 
     /**
@@ -1829,7 +2447,19 @@ public final class Configuration
      */
     public static int filePageSize()
     {
-        return getSizeAsInt(FILE_PAGE_SIZE_PROP_NAME, FILE_PAGE_SIZE_DEFAULT);
+        return filePageSize(System.getProperties());
+    }
+
+    /**
+     * Page size in bytes to align all files to. The file system must support the requested size.
+     *
+     * @param properties to read the configuration from.
+     * @return page size in bytes to align all files to.
+     * @see #FILE_PAGE_SIZE_PROP_NAME
+     */
+    public static int filePageSize(final Properties properties)
+    {
+        return getSizeAsInt(properties, FILE_PAGE_SIZE_PROP_NAME, FILE_PAGE_SIZE_DEFAULT);
     }
 
     /**
@@ -1840,7 +2470,20 @@ public final class Configuration
      */
     public static int publicationReservedSessionIdLow()
     {
-        return getInteger(PUBLICATION_RESERVED_SESSION_ID_LOW_PROP_NAME, PUBLICATION_RESERVED_SESSION_ID_LOW_DEFAULT);
+        return publicationReservedSessionIdLow(System.getProperties());
+    }
+
+    /**
+     * Low-end of the publication reserved session-id range which will not be automatically assigned.
+     *
+     * @param properties to read the configuration from.
+     * @return low-end of the publication reserved session-id range which will not be automatically assigned.
+     * @see #PUBLICATION_RESERVED_SESSION_ID_LOW_PROP_NAME
+     */
+    public static int publicationReservedSessionIdLow(final Properties properties)
+    {
+        return getInteger(
+            properties, PUBLICATION_RESERVED_SESSION_ID_LOW_PROP_NAME, PUBLICATION_RESERVED_SESSION_ID_LOW_DEFAULT);
     }
 
     /**
@@ -1851,7 +2494,20 @@ public final class Configuration
      */
     public static int publicationReservedSessionIdHigh()
     {
-        return getInteger(PUBLICATION_RESERVED_SESSION_ID_HIGH_PROP_NAME, PUBLICATION_RESERVED_SESSION_ID_HIGH_DEFAULT);
+        return publicationReservedSessionIdHigh(System.getProperties());
+    }
+
+    /**
+     * High-end of the publication reserved session-id range which will not be automatically assigned.
+     *
+     * @param properties to read the configuration from.
+     * @return high-end of the publication reserved session-id range which will not be automatically assigned.
+     * @see #PUBLICATION_RESERVED_SESSION_ID_HIGH_PROP_NAME
+     */
+    public static int publicationReservedSessionIdHigh(final Properties properties)
+    {
+        return getInteger(
+            properties, PUBLICATION_RESERVED_SESSION_ID_HIGH_PROP_NAME, PUBLICATION_RESERVED_SESSION_ID_HIGH_DEFAULT);
     }
 
     /**
@@ -1862,7 +2518,19 @@ public final class Configuration
      */
     public static long statusMessageTimeoutNs()
     {
-        return getDurationInNanos(STATUS_MESSAGE_TIMEOUT_PROP_NAME, STATUS_MESSAGE_TIMEOUT_DEFAULT_NS);
+        return statusMessageTimeoutNs(System.getProperties());
+    }
+
+    /**
+     * Status message timeout in nanoseconds after which one will be sent when data flow has not triggered one.
+     *
+     * @param properties to read the configuration from.
+     * @return status message timeout in nanoseconds after which one will be sent.
+     * @see #STATUS_MESSAGE_TIMEOUT_PROP_NAME
+     */
+    public static long statusMessageTimeoutNs(final Properties properties)
+    {
+        return getDurationInNanos(properties, STATUS_MESSAGE_TIMEOUT_PROP_NAME, STATUS_MESSAGE_TIMEOUT_DEFAULT_NS);
     }
 
     /**
@@ -1873,7 +2541,19 @@ public final class Configuration
      */
     public static int sendToStatusMessagePollRatio()
     {
-        return getInteger(SEND_TO_STATUS_POLL_RATIO_PROP_NAME, SEND_TO_STATUS_POLL_RATIO_DEFAULT);
+        return sendToStatusMessagePollRatio(System.getProperties());
+    }
+
+    /**
+     * Ratio of sending data to polling status messages in the {@link Sender}.
+     *
+     * @param properties to read the configuration from.
+     * @return ratio of sending data to polling status messages in the {@link Sender}.
+     * @see #SEND_TO_STATUS_POLL_RATIO_PROP_NAME
+     */
+    public static int sendToStatusMessagePollRatio(final Properties properties)
+    {
+        return getInteger(properties, SEND_TO_STATUS_POLL_RATIO_PROP_NAME, SEND_TO_STATUS_POLL_RATIO_DEFAULT);
     }
 
     /**
@@ -1885,7 +2565,20 @@ public final class Configuration
      */
     public static int resourceFreeLimit()
     {
-        return getInteger(RESOURCE_FREE_LIMIT_PROP_NAME, RESOURCE_FREE_LIMIT_DEFAULT);
+        return resourceFreeLimit(System.getProperties());
+    }
+
+    /**
+     * Limit the number of driver managed resources that can be freed in the same duty cycle.
+     *
+     * @param properties to read the configuration from.
+     * @return limit of the number of resources.
+     * @see #RESOURCE_FREE_LIMIT_PROP_NAME
+     * @see #RESOURCE_FREE_LIMIT_DEFAULT
+     */
+    public static int resourceFreeLimit(final Properties properties)
+    {
+        return getInteger(properties, RESOURCE_FREE_LIMIT_PROP_NAME, RESOURCE_FREE_LIMIT_DEFAULT);
     }
 
     /**
@@ -1896,7 +2589,20 @@ public final class Configuration
      */
     public static long counterFreeToReuseTimeoutNs()
     {
-        return getDurationInNanos(COUNTER_FREE_TO_REUSE_TIMEOUT_PROP_NAME, DEFAULT_COUNTER_FREE_TO_REUSE_TIMEOUT_NS);
+        return counterFreeToReuseTimeoutNs(System.getProperties());
+    }
+
+    /**
+     * Timeout between a counter being freed and being available to be reused.
+     *
+     * @param properties to read the configuration from.
+     * @return timeout between a counter being freed and being available to be reused.
+     * @see #COUNTER_FREE_TO_REUSE_TIMEOUT_PROP_NAME
+     */
+    public static long counterFreeToReuseTimeoutNs(final Properties properties)
+    {
+        return getDurationInNanos(
+            properties, COUNTER_FREE_TO_REUSE_TIMEOUT_PROP_NAME, DEFAULT_COUNTER_FREE_TO_REUSE_TIMEOUT_NS);
     }
 
     /**
@@ -1907,7 +2613,19 @@ public final class Configuration
      */
     public static long clientLivenessTimeoutNs()
     {
-        return getDurationInNanos(CLIENT_LIVENESS_TIMEOUT_PROP_NAME, CLIENT_LIVENESS_TIMEOUT_DEFAULT_NS);
+        return clientLivenessTimeoutNs(System.getProperties());
+    }
+
+    /**
+     * {@link Aeron} client liveness timeout after which it is considered not alive.
+     *
+     * @param properties to read the configuration from.
+     * @return {@link Aeron} client liveness timeout after which it is considered not alive.
+     * @see #CLIENT_LIVENESS_TIMEOUT_PROP_NAME
+     */
+    public static long clientLivenessTimeoutNs(final Properties properties)
+    {
+        return getDurationInNanos(properties, CLIENT_LIVENESS_TIMEOUT_PROP_NAME, CLIENT_LIVENESS_TIMEOUT_DEFAULT_NS);
     }
 
     /**
@@ -1920,7 +2638,21 @@ public final class Configuration
      */
     public static long imageLivenessTimeoutNs()
     {
-        return getDurationInNanos(IMAGE_LIVENESS_TIMEOUT_PROP_NAME, IMAGE_LIVENESS_TIMEOUT_DEFAULT_NS);
+        return imageLivenessTimeoutNs(System.getProperties());
+    }
+
+    /**
+     * {@link Image} liveness timeout for how long it stays active without heartbeats or lingers around after being
+     * drained.
+     *
+     * @param properties to read the configuration from.
+     * @return {@link Image} liveness timeout for how long it stays active without heartbeats or lingers around after
+     * being drained.
+     * @see #IMAGE_LIVENESS_TIMEOUT_PROP_NAME
+     */
+    public static long imageLivenessTimeoutNs(final Properties properties)
+    {
+        return getDurationInNanos(properties, IMAGE_LIVENESS_TIMEOUT_PROP_NAME, IMAGE_LIVENESS_TIMEOUT_DEFAULT_NS);
     }
 
     /**
@@ -1935,7 +2667,24 @@ public final class Configuration
      */
     public static long publicationUnblockTimeoutNs()
     {
-        return getDurationInNanos(PUBLICATION_UNBLOCK_TIMEOUT_PROP_NAME, PUBLICATION_UNBLOCK_TIMEOUT_DEFAULT_NS);
+        return publicationUnblockTimeoutNs(System.getProperties());
+    }
+
+    /**
+     * {@link Publication} unblock timeout due to client crash or untimely commit.
+     * <p>
+     * A publication can become blocked if the client crashes while publishing or if
+     * {@link io.aeron.Publication#tryClaim(int, BufferClaim)} is used without following up by calling
+     * {@link BufferClaim#commit()} or {@link BufferClaim#abort()}.
+     *
+     * @param properties to read the configuration from.
+     * @return {@link Publication} unblock timeout due to client crash or untimely commit.
+     * @see #PUBLICATION_UNBLOCK_TIMEOUT_PROP_NAME
+     */
+    public static long publicationUnblockTimeoutNs(final Properties properties)
+    {
+        return getDurationInNanos(
+            properties, PUBLICATION_UNBLOCK_TIMEOUT_PROP_NAME, PUBLICATION_UNBLOCK_TIMEOUT_DEFAULT_NS);
     }
 
     /**
@@ -1946,7 +2695,20 @@ public final class Configuration
      */
     public static long publicationConnectionTimeoutNs()
     {
-        return getDurationInNanos(PUBLICATION_CONNECTION_TIMEOUT_PROP_NAME, PUBLICATION_CONNECTION_TIMEOUT_DEFAULT_NS);
+        return publicationConnectionTimeoutNs(System.getProperties());
+    }
+
+    /**
+     * {@link Publication} timeout due to lack of status messages which indicate a connection.
+     *
+     * @param properties to read the configuration from.
+     * @return {@link Publication} timeout due to lack of status messages which indicate a connection.
+     * @see #PUBLICATION_CONNECTION_TIMEOUT_PROP_NAME
+     */
+    public static long publicationConnectionTimeoutNs(final Properties properties)
+    {
+        return getDurationInNanos(
+            properties, PUBLICATION_CONNECTION_TIMEOUT_PROP_NAME, PUBLICATION_CONNECTION_TIMEOUT_DEFAULT_NS);
     }
 
     /**
@@ -1957,7 +2719,19 @@ public final class Configuration
      */
     public static long publicationLingerTimeoutNs()
     {
-        return getDurationInNanos(PUBLICATION_LINGER_PROP_NAME, PUBLICATION_LINGER_DEFAULT_NS);
+        return publicationLingerTimeoutNs(System.getProperties());
+    }
+
+    /**
+     * Linger timeout after draining on {@link Publication}s so they can respond to NAKs.
+     *
+     * @param properties to read the configuration from.
+     * @return linger timeout after draining on {@link Publication}s so they can respond to NAKs.
+     * @see #PUBLICATION_LINGER_PROP_NAME
+     */
+    public static long publicationLingerTimeoutNs(final Properties properties)
+    {
+        return getDurationInNanos(properties, PUBLICATION_LINGER_PROP_NAME, PUBLICATION_LINGER_DEFAULT_NS);
     }
 
     /**
@@ -1968,7 +2742,19 @@ public final class Configuration
      */
     public static long retransmitUnicastDelayNs()
     {
-        return getDurationInNanos(RETRANSMIT_UNICAST_DELAY_PROP_NAME, RETRANSMIT_UNICAST_DELAY_DEFAULT_NS);
+        return retransmitUnicastDelayNs(System.getProperties());
+    }
+
+    /**
+     * Setting how long to delay before sending a retransmit after receiving a NAK.
+     *
+     * @param properties to read the configuration from.
+     * @return setting how long to delay before sending a retransmit after receiving a NAK.
+     * @see #RETRANSMIT_UNICAST_DELAY_PROP_NAME
+     */
+    public static long retransmitUnicastDelayNs(final Properties properties)
+    {
+        return getDurationInNanos(properties, RETRANSMIT_UNICAST_DELAY_PROP_NAME, RETRANSMIT_UNICAST_DELAY_DEFAULT_NS);
     }
 
     /**
@@ -1979,7 +2765,20 @@ public final class Configuration
      */
     public static long retransmitUnicastLingerNs()
     {
-        return getDurationInNanos(RETRANSMIT_UNICAST_LINGER_PROP_NAME, RETRANSMIT_UNICAST_LINGER_DEFAULT_NS);
+        return retransmitUnicastLingerNs(System.getProperties());
+    }
+
+    /**
+     * Setting how long to linger after delay on a NAK before responding to another NAK.
+     *
+     * @param properties to read the configuration from.
+     * @return setting how long to linger after delay on a NAK before responding to another NAK.
+     * @see #RETRANSMIT_UNICAST_LINGER_PROP_NAME
+     */
+    public static long retransmitUnicastLingerNs(final Properties properties)
+    {
+        return getDurationInNanos(
+            properties, RETRANSMIT_UNICAST_LINGER_PROP_NAME, RETRANSMIT_UNICAST_LINGER_DEFAULT_NS);
     }
 
     /**
@@ -1990,7 +2789,19 @@ public final class Configuration
      */
     public static int lossReportBufferLength()
     {
-        return getSizeAsInt(LOSS_REPORT_BUFFER_LENGTH_PROP_NAME, LOSS_REPORT_BUFFER_LENGTH_DEFAULT);
+        return lossReportBufferLength(System.getProperties());
+    }
+
+    /**
+     * Length of the memory mapped buffer for the {@link io.aeron.driver.reports.LossReport}.
+     *
+     * @param properties to read the configuration from.
+     * @return length of the memory mapped buffer for the {@link io.aeron.driver.reports.LossReport}.
+     * @see #LOSS_REPORT_BUFFER_LENGTH_PROP_NAME
+     */
+    public static int lossReportBufferLength(final Properties properties)
+    {
+        return getSizeAsInt(properties, LOSS_REPORT_BUFFER_LENGTH_PROP_NAME, LOSS_REPORT_BUFFER_LENGTH_DEFAULT);
     }
 
     /**
@@ -2002,7 +2813,20 @@ public final class Configuration
      */
     public static ThreadingMode threadingMode()
     {
-        final String propertyValue = getProperty(THREADING_MODE_PROP_NAME);
+        return threadingMode(System.getProperties());
+    }
+
+    /**
+     * {@link ThreadingMode} to be used by the Aeron {@link MediaDriver}. This allows for CPU resource to be traded
+     * against throughput and latency.
+     *
+     * @param properties to read the configuration from.
+     * @return {@link ThreadingMode} to be used by the Aeron {@link MediaDriver}.
+     * @see #THREADING_MODE_PROP_NAME
+     */
+    public static ThreadingMode threadingMode(final Properties properties)
+    {
+        final String propertyValue = properties.getProperty(THREADING_MODE_PROP_NAME);
         if (null == propertyValue)
         {
             return DEDICATED;
@@ -2018,7 +2842,19 @@ public final class Configuration
      */
     public static long conductorCycleThresholdNs()
     {
-        return getDurationInNanos(CONDUCTOR_CYCLE_THRESHOLD_PROP_NAME, CONDUCTOR_CYCLE_THRESHOLD_DEFAULT_NS);
+        return conductorCycleThresholdNs(System.getProperties());
+    }
+
+    /**
+     * Get threshold value for the conductor work cycle threshold to track for being exceeded.
+     *
+     * @param properties to read the configuration from.
+     * @return threshold value in nanoseconds.
+     */
+    public static long conductorCycleThresholdNs(final Properties properties)
+    {
+        return getDurationInNanos(
+            properties, CONDUCTOR_CYCLE_THRESHOLD_PROP_NAME, CONDUCTOR_CYCLE_THRESHOLD_DEFAULT_NS);
     }
 
     /**
@@ -2028,7 +2864,18 @@ public final class Configuration
      */
     public static long senderCycleThresholdNs()
     {
-        return getDurationInNanos(SENDER_CYCLE_THRESHOLD_PROP_NAME, SENDER_CYCLE_THRESHOLD_DEFAULT_NS);
+        return senderCycleThresholdNs(System.getProperties());
+    }
+
+    /**
+     * Get threshold value for the sender work cycle threshold to track for being exceeded.
+     *
+     * @param properties to read the configuration from.
+     * @return threshold value in nanoseconds.
+     */
+    public static long senderCycleThresholdNs(final Properties properties)
+    {
+        return getDurationInNanos(properties, SENDER_CYCLE_THRESHOLD_PROP_NAME, SENDER_CYCLE_THRESHOLD_DEFAULT_NS);
     }
 
     /**
@@ -2038,7 +2885,18 @@ public final class Configuration
      */
     public static long receiverCycleThresholdNs()
     {
-        return getDurationInNanos(RECEIVER_CYCLE_THRESHOLD_PROP_NAME, RECEIVER_CYCLE_THRESHOLD_DEFAULT_NS);
+        return receiverCycleThresholdNs(System.getProperties());
+    }
+
+    /**
+     * Get threshold value for the receiver work cycle threshold to track for being exceeded.
+     *
+     * @param properties to read the configuration from.
+     * @return threshold value in nanoseconds.
+     */
+    public static long receiverCycleThresholdNs(final Properties properties)
+    {
+        return getDurationInNanos(properties, RECEIVER_CYCLE_THRESHOLD_PROP_NAME, RECEIVER_CYCLE_THRESHOLD_DEFAULT_NS);
     }
 
     /**
@@ -2048,7 +2906,18 @@ public final class Configuration
      */
     public static long nameResolverThresholdNs()
     {
-        return getDurationInNanos(NAME_RESOLVER_THRESHOLD_PROP_NAME, NAME_RESOLVER_THRESHOLD_DEFAULT_NS);
+        return nameResolverThresholdNs(System.getProperties());
+    }
+
+    /**
+     * Get threshold value for the name resolution time threshold to track for being exceeded.
+     *
+     * @param properties to read the configuration from.
+     * @return threshold value in nanoseconds.
+     */
+    public static long nameResolverThresholdNs(final Properties properties)
+    {
+        return getDurationInNanos(properties, NAME_RESOLVER_THRESHOLD_PROP_NAME, NAME_RESOLVER_THRESHOLD_DEFAULT_NS);
     }
 
     /**
@@ -2058,7 +2927,18 @@ public final class Configuration
      */
     public static String senderWildcardPortRange()
     {
-        return getProperty(SENDER_WILDCARD_PORT_RANGE_PROP_NAME);
+        return senderWildcardPortRange(System.getProperties());
+    }
+
+    /**
+     * Get wildcard port range in use for the Sender.
+     *
+     * @param properties to read the configuration from.
+     * @return port range as string with the format "low high"
+     */
+    public static String senderWildcardPortRange(final Properties properties)
+    {
+        return properties.getProperty(SENDER_WILDCARD_PORT_RANGE_PROP_NAME);
     }
 
     /**
@@ -2068,7 +2948,18 @@ public final class Configuration
      */
     public static String receiverWildcardPortRange()
     {
-        return getProperty(RECEIVER_WILDCARD_PORT_RANGE_PROP_NAME);
+        return receiverWildcardPortRange(System.getProperties());
+    }
+
+    /**
+     * Get wildcard port range in use for the Receiver.
+     *
+     * @param properties to read the configuration from.
+     * @return port range as string with the format "low high"
+     */
+    public static String receiverWildcardPortRange(final Properties properties)
+    {
+        return properties.getProperty(RECEIVER_WILDCARD_PORT_RANGE_PROP_NAME);
     }
 
     /**
@@ -2080,7 +2971,21 @@ public final class Configuration
      */
     public static IdleStrategy nativeResourceAgentIdleStrategy(final StatusIndicator controllableStatus)
     {
-        final String idleStategyName = getProperty(NATIVE_RESOURCE_AGENT_IDLE_STRATEGY_PROP_NAME);
+        return nativeResourceAgentIdleStrategy(System.getProperties(), controllableStatus);
+    }
+
+    /**
+     * {@return {@link IdleStrategy} to be employed by the async executor when enabled.}
+     *
+     * @param properties         to read the configuration from.
+     * @param controllableStatus to allow control of {@link ControllableIdleStrategy}, which can be null if not used.
+     * @see #NATIVE_RESOURCE_AGENT_IDLE_STRATEGY_PROP_NAME
+     * @since 1.51.0
+     */
+    public static IdleStrategy nativeResourceAgentIdleStrategy(
+        final Properties properties, final StatusIndicator controllableStatus)
+    {
+        final String idleStategyName = properties.getProperty(NATIVE_RESOURCE_AGENT_IDLE_STRATEGY_PROP_NAME);
         if (Strings.isEmpty(idleStategyName))
         {
             return new SleepingIdleStrategy(TimeUnit.MILLISECONDS.toNanos(1));
@@ -2152,8 +3057,22 @@ public final class Configuration
      */
     public static IdleStrategy senderIdleStrategy(final StatusIndicator controllableStatus)
     {
+        return senderIdleStrategy(System.getProperties(), controllableStatus);
+    }
+
+    /**
+     * {@link IdleStrategy} to be employed by {@link Sender} for {@link ThreadingMode#DEDICATED}.
+     *
+     * @param properties         to read the configuration from.
+     * @param controllableStatus to allow control of {@link ControllableIdleStrategy}, which can be null if not used.
+     * @return {@link IdleStrategy} to be employed by {@link Sender} for {@link ThreadingMode#DEDICATED}.
+     * @see #SENDER_IDLE_STRATEGY_PROP_NAME
+     */
+    public static IdleStrategy senderIdleStrategy(
+        final Properties properties, final StatusIndicator controllableStatus)
+    {
         return agentIdleStrategy(
-            getProperty(SENDER_IDLE_STRATEGY_PROP_NAME, SENDER_IDLE_STRATEGY_DEFAULT), controllableStatus);
+            properties.getProperty(SENDER_IDLE_STRATEGY_PROP_NAME, SENDER_IDLE_STRATEGY_DEFAULT), controllableStatus);
     }
 
     /**
@@ -2165,8 +3084,23 @@ public final class Configuration
      */
     public static IdleStrategy receiverIdleStrategy(final StatusIndicator controllableStatus)
     {
+        return receiverIdleStrategy(System.getProperties(), controllableStatus);
+    }
+
+    /**
+     * {@link IdleStrategy} to be employed by {@link Receiver} for {@link ThreadingMode#DEDICATED}.
+     *
+     * @param properties         to read the configuration from.
+     * @param controllableStatus to allow control of {@link ControllableIdleStrategy}, which can be null if not used.
+     * @return {@link IdleStrategy} to be employed by {@link Receiver} for {@link ThreadingMode#DEDICATED}.
+     * @see #RECEIVER_IDLE_STRATEGY_PROP_NAME
+     */
+    public static IdleStrategy receiverIdleStrategy(
+        final Properties properties, final StatusIndicator controllableStatus)
+    {
         return agentIdleStrategy(
-            getProperty(RECEIVER_IDLE_STRATEGY_PROP_NAME, RECEIVER_IDLE_STRATEGY_DEFAULT), controllableStatus);
+            properties.getProperty(RECEIVER_IDLE_STRATEGY_PROP_NAME, RECEIVER_IDLE_STRATEGY_DEFAULT),
+            controllableStatus);
     }
 
     /**
@@ -2180,8 +3114,25 @@ public final class Configuration
      */
     public static IdleStrategy conductorIdleStrategy(final StatusIndicator controllableStatus)
     {
+        return conductorIdleStrategy(System.getProperties(), controllableStatus);
+    }
+
+    /**
+     * {@link IdleStrategy} to be employed by {@link DriverConductor} for {@link ThreadingMode#DEDICATED} and
+     * {@link ThreadingMode#SHARED_NETWORK}.
+     *
+     * @param properties         to read the configuration from.
+     * @param controllableStatus to allow control of {@link ControllableIdleStrategy}, which can be null if not used.
+     * @return {@link IdleStrategy} to be employed by {@link DriverConductor} for {@link ThreadingMode#DEDICATED}
+     * and {@link ThreadingMode#SHARED_NETWORK}..
+     * @see #CONDUCTOR_IDLE_STRATEGY_PROP_NAME
+     */
+    public static IdleStrategy conductorIdleStrategy(
+        final Properties properties, final StatusIndicator controllableStatus)
+    {
         return agentIdleStrategy(
-            getProperty(CONDUCTOR_IDLE_STRATEGY_PROP_NAME, CONDUCTOR_IDLE_STRATEGY_DEFAULT), controllableStatus);
+            properties.getProperty(CONDUCTOR_IDLE_STRATEGY_PROP_NAME, CONDUCTOR_IDLE_STRATEGY_DEFAULT),
+            controllableStatus);
     }
 
     /**
@@ -2195,7 +3146,23 @@ public final class Configuration
      */
     public static IdleStrategy sharedNetworkIdleStrategy(final StatusIndicator controllableStatus)
     {
-        return agentIdleStrategy(getProperty(SHARED_NETWORK_IDLE_STRATEGY_PROP_NAME,
+        return sharedNetworkIdleStrategy(System.getProperties(), controllableStatus);
+    }
+
+    /**
+     * {@link IdleStrategy} to be employed by {@link Sender} and {@link Receiver} for
+     * {@link ThreadingMode#SHARED_NETWORK}.
+     *
+     * @param properties         to read the configuration from.
+     * @param controllableStatus to allow control of {@link ControllableIdleStrategy}, which can be null if not used.
+     * @return {@link IdleStrategy} to be employed by {@link Sender} and {@link Receiver} for
+     * {@link ThreadingMode#SHARED_NETWORK}.
+     * @see #SHARED_NETWORK_IDLE_STRATEGY_PROP_NAME
+     */
+    public static IdleStrategy sharedNetworkIdleStrategy(
+        final Properties properties, final StatusIndicator controllableStatus)
+    {
+        return agentIdleStrategy(properties.getProperty(SHARED_NETWORK_IDLE_STRATEGY_PROP_NAME,
             SHARED_NETWORK_IDLE_STRATEGY_DEFAULT), controllableStatus);
     }
 
@@ -2210,8 +3177,24 @@ public final class Configuration
      */
     public static IdleStrategy sharedIdleStrategy(final StatusIndicator controllableStatus)
     {
+        return sharedIdleStrategy(System.getProperties(), controllableStatus);
+    }
+
+    /**
+     * {@link IdleStrategy} to be employed by {@link Sender}, {@link Receiver}, and {@link DriverConductor} for
+     * {@link ThreadingMode#SHARED}.
+     *
+     * @param properties         to read the configuration from.
+     * @param controllableStatus to allow control of {@link ControllableIdleStrategy}, which can be null if not used.
+     * @return {@link IdleStrategy} to be employed by {@link Sender}, {@link Receiver}, and {@link DriverConductor} for
+     * {@link ThreadingMode#SHARED}.
+     * @see #SHARED_IDLE_STRATEGY_PROP_NAME
+     */
+    public static IdleStrategy sharedIdleStrategy(
+        final Properties properties, final StatusIndicator controllableStatus)
+    {
         return agentIdleStrategy(
-            getProperty(SHARED_IDLE_STRATEGY_PROP_NAME, SHARED_IDLE_STRATEGY_DEFAULT), controllableStatus);
+            properties.getProperty(SHARED_IDLE_STRATEGY_PROP_NAME, SHARED_IDLE_STRATEGY_DEFAULT), controllableStatus);
     }
 
     /**
@@ -2222,7 +3205,19 @@ public final class Configuration
     @Deprecated
     public static byte[] applicationSpecificFeedback()
     {
-        final String propertyValue = getProperty(SM_APPLICATION_SPECIFIC_FEEDBACK_PROP_NAME);
+        return applicationSpecificFeedback(System.getProperties());
+    }
+
+    /**
+     * @param properties to read the configuration from.
+     * @return Application Specific Feedback added to Status Messages by the driver for flow control.
+     * @see #SM_APPLICATION_SPECIFIC_FEEDBACK_PROP_NAME
+     * @deprecated see {@link #groupTag()}.
+     */
+    @Deprecated
+    public static byte[] applicationSpecificFeedback(final Properties properties)
+    {
+        final String propertyValue = properties.getProperty(SM_APPLICATION_SPECIFIC_FEEDBACK_PROP_NAME);
         if (null == propertyValue)
         {
             return ArrayUtil.EMPTY_BYTE_ARRAY;
@@ -2239,10 +3234,22 @@ public final class Configuration
      */
     public static SendChannelEndpointSupplier sendChannelEndpointSupplier()
     {
+        return sendChannelEndpointSupplier(System.getProperties());
+    }
+
+    /**
+     * Get the supplier of {@link SendChannelEndpoint}s which can be used for
+     * debugging, monitoring, or modifying the behaviour when sending to the channel.
+     *
+     * @param properties to read the configuration from.
+     * @return the {@link SendChannelEndpointSupplier}.
+     */
+    public static SendChannelEndpointSupplier sendChannelEndpointSupplier(final Properties properties)
+    {
         SendChannelEndpointSupplier supplier = null;
         try
         {
-            final String className = getProperty(SEND_CHANNEL_ENDPOINT_SUPPLIER_PROP_NAME);
+            final String className = properties.getProperty(SEND_CHANNEL_ENDPOINT_SUPPLIER_PROP_NAME);
             if (null == className)
             {
                 return new DefaultSendChannelEndpointSupplier();
@@ -2266,10 +3273,22 @@ public final class Configuration
      */
     public static ReceiveChannelEndpointSupplier receiveChannelEndpointSupplier()
     {
+        return receiveChannelEndpointSupplier(System.getProperties());
+    }
+
+    /**
+     * Get the supplier of {@link ReceiveChannelEndpoint}s which can be used for
+     * debugging, monitoring, or modifying the behaviour when receiving from the channel.
+     *
+     * @param properties to read the configuration from.
+     * @return the {@link SendChannelEndpointSupplier}.
+     */
+    public static ReceiveChannelEndpointSupplier receiveChannelEndpointSupplier(final Properties properties)
+    {
         ReceiveChannelEndpointSupplier supplier = null;
         try
         {
-            final String className = getProperty(RECEIVE_CHANNEL_ENDPOINT_SUPPLIER_PROP_NAME);
+            final String className = properties.getProperty(RECEIVE_CHANNEL_ENDPOINT_SUPPLIER_PROP_NAME);
             if (null == className)
             {
                 return new DefaultReceiveChannelEndpointSupplier();
@@ -2293,13 +3312,26 @@ public final class Configuration
      */
     public static FlowControlSupplier unicastFlowControlSupplier()
     {
+        return unicastFlowControlSupplier(System.getProperties());
+    }
+
+    /**
+     * Get the supplier of {@link FlowControl}s which can be used for changing behavior of flow control for unicast
+     * publications.
+     *
+     * @param properties to read the configuration from.
+     * @return the {@link FlowControlSupplier}.
+     */
+    public static FlowControlSupplier unicastFlowControlSupplier(final Properties properties)
+    {
         FlowControlSupplier supplier = null;
         try
         {
-            final String className = getProperty(UNICAST_FLOW_CONTROL_STRATEGY_SUPPLIER_PROP_NAME);
+            final String className = properties.getProperty(UNICAST_FLOW_CONTROL_STRATEGY_SUPPLIER_PROP_NAME);
             if (null == className)
             {
-                return new DefaultUnicastFlowControlSupplier();
+                return new DefaultUnicastFlowControlSupplier(properties.getProperty(
+                    UNICAST_FLOW_CONTROL_STRATEGY_PROP_NAME, UNICAST_FLOW_CONTROL_STRATEGY_DEFAULT));
             }
 
             supplier = (FlowControlSupplier)Class.forName(className).getConstructor().newInstance();
@@ -2320,13 +3352,26 @@ public final class Configuration
      */
     public static FlowControlSupplier multicastFlowControlSupplier()
     {
+        return multicastFlowControlSupplier(System.getProperties());
+    }
+
+    /**
+     * Get the supplier of {@link FlowControl}s which can be used for changing behavior of flow control for multicast
+     * publications.
+     *
+     * @param properties to read the configuration from.
+     * @return the {@link FlowControlSupplier}.
+     */
+    public static FlowControlSupplier multicastFlowControlSupplier(final Properties properties)
+    {
         FlowControlSupplier supplier = null;
         try
         {
-            final String className = getProperty(MULTICAST_FLOW_CONTROL_STRATEGY_SUPPLIER_PROP_NAME);
+            final String className = properties.getProperty(MULTICAST_FLOW_CONTROL_STRATEGY_SUPPLIER_PROP_NAME);
             if (null == className)
             {
-                return new DefaultMulticastFlowControlSupplier();
+                return new DefaultMulticastFlowControlSupplier(properties.getProperty(
+                    MULTICAST_FLOW_CONTROL_STRATEGY_PROP_NAME, MULTICAST_FLOW_CONTROL_STRATEGY_DEFAULT));
             }
 
             supplier = (FlowControlSupplier)Class.forName(className).getConstructor().newInstance();
@@ -2346,10 +3391,21 @@ public final class Configuration
      */
     public static CongestionControlSupplier congestionControlSupplier()
     {
+        return congestionControlSupplier(System.getProperties());
+    }
+
+    /**
+     * Get the supplier of {@link CongestionControl} implementations which can be used for receivers.
+     *
+     * @param properties to read the configuration from.
+     * @return the {@link CongestionControlSupplier}
+     */
+    public static CongestionControlSupplier congestionControlSupplier(final Properties properties)
+    {
         CongestionControlSupplier supplier = null;
         try
         {
-            final String className = getProperty(CONGESTION_CONTROL_STRATEGY_SUPPLIER_PROP_NAME);
+            final String className = properties.getProperty(CONGESTION_CONTROL_STRATEGY_SUPPLIER_PROP_NAME);
             if (null == className)
             {
                 return new DefaultCongestionControlSupplier();
@@ -2374,7 +3430,20 @@ public final class Configuration
      */
     public static int streamSessionLimit()
     {
-        final String streamSessionLimitString = getProperty(STREAM_SESSION_LIMIT_PROP_NAME);
+        return streamSessionLimit(System.getProperties());
+    }
+
+    /**
+     * Get the configured limit for the number of streams per session.
+     *
+     * @param properties to read the configuration from.
+     * @return configured session limit
+     * @throws AsciiNumberFormatException if the property referenced by {@link #STREAM_SESSION_LIMIT_PROP_NAME} is not
+     *                                    a valid number
+     */
+    public static int streamSessionLimit(final Properties properties)
+    {
+        final String streamSessionLimitString = properties.getProperty(STREAM_SESSION_LIMIT_PROP_NAME);
         try
         {
             return Strings.isEmpty(streamSessionLimitString) ?
@@ -2438,10 +3507,22 @@ public final class Configuration
      */
     public static TerminationValidator terminationValidator()
     {
+        return terminationValidator(System.getProperties());
+    }
+
+    /**
+     * Get the {@link TerminationValidator} implementations which can be used for validating a termination request
+     * sent to the driver to ensure the client has the right to terminate a driver.
+     *
+     * @param properties to read the configuration from.
+     * @return the {@link TerminationValidator}
+     */
+    public static TerminationValidator terminationValidator(final Properties properties)
+    {
         TerminationValidator validator = null;
         try
         {
-            final String className = getProperty(TERMINATION_VALIDATOR_PROP_NAME);
+            final String className = properties.getProperty(TERMINATION_VALIDATOR_PROP_NAME);
             if (null == className)
             {
                 return new DefaultDenyTerminationValidator();
@@ -2468,14 +3549,14 @@ public final class Configuration
         {
             System.err.println(
                 "WARNING: Could not set desired SO_SNDBUF, adjust OS to allow " + SOCKET_SNDBUF_LENGTH_PROP_NAME +
-                " attempted=" + ctx.socketSndbufLength() + ", actual=" + ctx.osMaxSocketSndbufLength());
+                    " attempted=" + ctx.socketSndbufLength() + ", actual=" + ctx.osMaxSocketSndbufLength());
         }
 
         if (ctx.osMaxSocketRcvbufLength() < ctx.socketRcvbufLength())
         {
             System.err.println(
                 "WARNING: Could not set desired SO_RCVBUF, adjust OS to allow " + SOCKET_RCVBUF_LENGTH_PROP_NAME +
-                " attempted=" + ctx.socketRcvbufLength() + ", actual=" + ctx.osMaxSocketRcvbufLength());
+                    " attempted=" + ctx.socketRcvbufLength() + ", actual=" + ctx.osMaxSocketRcvbufLength());
         }
 
         final int soSndBuf = 0 == ctx.socketSndbufLength() ?
@@ -2485,7 +3566,7 @@ public final class Configuration
         {
             throw new ConfigurationException(
                 "mtuLength=" + ctx.mtuLength() + " > SO_SNDBUF=" + soSndBuf +
-                ", increase " + SOCKET_SNDBUF_LENGTH_PROP_NAME + " to match MTU");
+                    ", increase " + SOCKET_SNDBUF_LENGTH_PROP_NAME + " to match MTU");
         }
 
         final int soRcvBuf = 0 == ctx.socketRcvbufLength() ?
@@ -2495,7 +3576,7 @@ public final class Configuration
         {
             throw new ConfigurationException(
                 "initialWindowLength=" + ctx.initialWindowLength() + " > SO_RCVBUF=" + soRcvBuf +
-                ", increase " + SOCKET_RCVBUF_LENGTH_PROP_NAME + " limits to match initialWindowLength");
+                    ", increase " + SOCKET_RCVBUF_LENGTH_PROP_NAME + " limits to match initialWindowLength");
         }
     }
 
@@ -2562,14 +3643,14 @@ public final class Configuration
         {
             throw new ConfigurationException(
                 "publicationUnblockTimeoutNs=" + publicationUnblockTimeoutNs +
-                " <= clientLivenessTimeoutNs=" + clientLivenessTimeoutNs);
+                    " <= clientLivenessTimeoutNs=" + clientLivenessTimeoutNs);
         }
 
         if (clientLivenessTimeoutNs <= timerIntervalNs)
         {
             throw new ConfigurationException(
                 "clientLivenessTimeoutNs=" + clientLivenessTimeoutNs +
-                " <= timerIntervalNs=" + timerIntervalNs);
+                    " <= timerIntervalNs=" + timerIntervalNs);
         }
     }
 
@@ -2592,14 +3673,14 @@ public final class Configuration
         {
             throw new ConfigurationException(
                 "untetheredWindowLimitTimeoutNs=" + untetheredWindowLimitTimeoutNs +
-                " <= timerIntervalNs=" + timerIntervalNs);
+                    " <= timerIntervalNs=" + timerIntervalNs);
         }
 
         if (untetheredRestingTimeoutNs <= timerIntervalNs)
         {
             throw new ConfigurationException(
                 "untetheredRestingTimeoutNs=" + untetheredRestingTimeoutNs +
-                " <= timerIntervalNs=" + timerIntervalNs);
+                    " <= timerIntervalNs=" + timerIntervalNs);
         }
 
         if (Aeron.NULL_VALUE != untetheredLingerTimeoutNs && untetheredLingerTimeoutNs <= timerIntervalNs)

--- a/aeron-driver/src/main/java/io/aeron/driver/DefaultMulticastFlowControlSupplier.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DefaultMulticastFlowControlSupplier.java
@@ -27,11 +27,26 @@ import static io.aeron.driver.Configuration.MULTICAST_FLOW_CONTROL_STRATEGY;
  */
 public class DefaultMulticastFlowControlSupplier implements FlowControlSupplier
 {
+    private final String flowControlStrategyClassName;
+
     /**
      * Default constructor.
      */
     public DefaultMulticastFlowControlSupplier()
     {
+        this(MULTICAST_FLOW_CONTROL_STRATEGY);
+    }
+
+    /**
+     * Construct a supplier for a given flow control strategy, allowing the strategy to be resolved from a context's
+     * own configuration rather than from a system property.
+     *
+     * @param flowControlStrategyClassName name of the {@link FlowControl} class to supply.
+     * @see Configuration#MULTICAST_FLOW_CONTROL_STRATEGY_PROP_NAME
+     */
+    public DefaultMulticastFlowControlSupplier(final String flowControlStrategyClassName)
+    {
+        this.flowControlStrategyClassName = flowControlStrategyClassName;
     }
 
     /**
@@ -62,15 +77,15 @@ public class DefaultMulticastFlowControlSupplier implements FlowControlSupplier
             }
         }
 
-        if (MaxMulticastFlowControl.class.getName().equals(MULTICAST_FLOW_CONTROL_STRATEGY))
+        if (MaxMulticastFlowControl.class.getName().equals(flowControlStrategyClassName))
         {
             return new MaxMulticastFlowControl();
         }
-        else if (MinMulticastFlowControl.class.getName().equals(MULTICAST_FLOW_CONTROL_STRATEGY))
+        else if (MinMulticastFlowControl.class.getName().equals(flowControlStrategyClassName))
         {
             return new MinMulticastFlowControl();
         }
-        else if (TaggedMulticastFlowControl.class.getName().equals(MULTICAST_FLOW_CONTROL_STRATEGY))
+        else if (TaggedMulticastFlowControl.class.getName().equals(flowControlStrategyClassName))
         {
             return new TaggedMulticastFlowControl();
         }
@@ -78,7 +93,7 @@ public class DefaultMulticastFlowControlSupplier implements FlowControlSupplier
         FlowControl flowControl = null;
         try
         {
-            flowControl = (FlowControl)Class.forName(MULTICAST_FLOW_CONTROL_STRATEGY)
+            flowControl = (FlowControl)Class.forName(flowControlStrategyClassName)
                 .getConstructor()
                 .newInstance();
         }
@@ -97,6 +112,6 @@ public class DefaultMulticastFlowControlSupplier implements FlowControlSupplier
     public String toString()
     {
         return "DefaultMulticastFlowControlSupplier{flowControlClass=" +
-            MULTICAST_FLOW_CONTROL_STRATEGY + "}";
+            flowControlStrategyClassName + "}";
     }
 }

--- a/aeron-driver/src/main/java/io/aeron/driver/DefaultUnicastFlowControlSupplier.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DefaultUnicastFlowControlSupplier.java
@@ -27,11 +27,26 @@ import static io.aeron.driver.Configuration.UNICAST_FLOW_CONTROL_STRATEGY;
  */
 public class DefaultUnicastFlowControlSupplier implements FlowControlSupplier
 {
+    private final String flowControlStrategyClassName;
+
     /**
      * Default constructor.
      */
     public DefaultUnicastFlowControlSupplier()
     {
+        this(UNICAST_FLOW_CONTROL_STRATEGY);
+    }
+
+    /**
+     * Construct a supplier for a given flow control strategy, allowing the strategy to be resolved from a context's
+     * own configuration rather than from a system property.
+     *
+     * @param flowControlStrategyClassName name of the {@link FlowControl} class to supply.
+     * @see Configuration#UNICAST_FLOW_CONTROL_STRATEGY_PROP_NAME
+     */
+    public DefaultUnicastFlowControlSupplier(final String flowControlStrategyClassName)
+    {
+        this.flowControlStrategyClassName = flowControlStrategyClassName;
     }
 
     /**
@@ -48,14 +63,14 @@ public class DefaultUnicastFlowControlSupplier implements FlowControlSupplier
             throw new IllegalArgumentException("unsupported unicast flow control strategy: fc=" + fcStr);
         }
 
-        if (UnicastFlowControl.class.getName().equals(UNICAST_FLOW_CONTROL_STRATEGY))
+        if (UnicastFlowControl.class.getName().equals(flowControlStrategyClassName))
         {
             return new UnicastFlowControl();
         }
 
         try
         {
-            flowControl = (FlowControl)Class.forName(UNICAST_FLOW_CONTROL_STRATEGY)
+            flowControl = (FlowControl)Class.forName(flowControlStrategyClassName)
                 .getConstructor()
                 .newInstance();
         }
@@ -74,6 +89,6 @@ public class DefaultUnicastFlowControlSupplier implements FlowControlSupplier
     public String toString()
     {
         return "DefaultUnicastFlowControlSupplier{flowControlClass=" +
-            UNICAST_FLOW_CONTROL_STRATEGY + "}";
+            flowControlStrategyClassName + "}";
     }
 }

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -242,7 +242,8 @@ public final class DriverConductor implements Agent
         clientCommandAdapter = new ClientCommandAdapter(ctx.countedErrorHandler(), toDriverCommands, clientProxy, this);
 
         lastCommandConsumerPosition = toDriverCommands.consumerPosition();
-        roleName = threadName(AERON_DRIVER_CONDUCTOR_THREAD_NAME, AERON_DRIVER_CONDUCTOR_THREAD_NAME_CLASSIC);
+        roleName = threadName(
+            ctx.properties(), AERON_DRIVER_CONDUCTOR_THREAD_NAME, AERON_DRIVER_CONDUCTOR_THREAD_NAME_CLASSIC);
 
     }
 
@@ -368,14 +369,14 @@ public final class DriverConductor implements Agent
     {
         recordError(new AeronEvent(
             "onPublicationError: " +
-            "registrationId=" + registrationId +
-            ", destinationRegistrationId=" + destinationRegistrationId +
-            ", sessionId=" + sessionId +
-            ", streamId=" + streamId +
-            ", receiverId=" + receiverId +
-            ", groupId=" + groupId +
-            ", errorCode=" + errorCode +
-            ", errorMessage=" + errorMessage,
+                "registrationId=" + registrationId +
+                ", destinationRegistrationId=" + destinationRegistrationId +
+                ", sessionId=" + sessionId +
+                ", streamId=" + streamId +
+                ", receiverId=" + receiverId +
+                ", groupId=" + groupId +
+                ", errorCode=" + errorCode +
+                ", errorMessage=" + errorMessage,
             AeronException.Category.WARN));
         clientProxy.onPublicationErrorFrame(
             registrationId,

--- a/aeron-driver/src/main/java/io/aeron/driver/FixedNameCompositeAgent.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/FixedNameCompositeAgent.java
@@ -20,6 +20,8 @@ import org.agrona.Strings;
 import org.agrona.concurrent.Agent;
 import org.agrona.concurrent.CompositeAgent;
 
+import java.util.Properties;
+
 class FixedNameCompositeAgent extends CompositeAgent
 {
     private final String name;
@@ -30,10 +32,11 @@ class FixedNameCompositeAgent extends CompositeAgent
         return prefix + super.roleName();
     }
 
-    FixedNameCompositeAgent(final String newName, final String classicName, final Agent... agents)
+    FixedNameCompositeAgent(
+        final Properties properties, final String newName, final String classicName, final Agent... agents)
     {
         super(agents);
-        this.name = CommonContext.threadName(newName, generateClassicName(classicName));
+        this.name = CommonContext.threadName(properties, newName, generateClassicName(classicName));
     }
 
     public String roleName()

--- a/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
@@ -92,6 +92,7 @@ import java.nio.channels.DatagramChannel;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.Properties;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -122,7 +123,6 @@ import static io.aeron.driver.Configuration.validateUntetheredTimeouts;
 import static io.aeron.driver.Configuration.validateValueRange;
 import static io.aeron.driver.reports.LossReportUtil.mapLossReport;
 import static io.aeron.driver.status.SystemCounterDescriptor.AERON_VERSION;
-import static io.aeron.driver.status.SystemCounterDescriptor.NATIVE_RESOURCE_AGENT_PROXY_FAILS;
 import static io.aeron.driver.status.SystemCounterDescriptor.BYTES_CURRENTLY_MAPPED;
 import static io.aeron.driver.status.SystemCounterDescriptor.CONDUCTOR_CYCLE_TIME_THRESHOLD_EXCEEDED;
 import static io.aeron.driver.status.SystemCounterDescriptor.CONDUCTOR_MAX_CYCLE_TIME;
@@ -131,6 +131,7 @@ import static io.aeron.driver.status.SystemCounterDescriptor.CONTROL_PROTOCOL_VE
 import static io.aeron.driver.status.SystemCounterDescriptor.ERRORS;
 import static io.aeron.driver.status.SystemCounterDescriptor.NAME_RESOLVER_MAX_TIME;
 import static io.aeron.driver.status.SystemCounterDescriptor.NAME_RESOLVER_TIME_THRESHOLD_EXCEEDED;
+import static io.aeron.driver.status.SystemCounterDescriptor.NATIVE_RESOURCE_AGENT_PROXY_FAILS;
 import static io.aeron.driver.status.SystemCounterDescriptor.RECEIVER_CYCLE_TIME_THRESHOLD_EXCEEDED;
 import static io.aeron.driver.status.SystemCounterDescriptor.RECEIVER_MAX_CYCLE_TIME;
 import static io.aeron.driver.status.SystemCounterDescriptor.RECEIVER_PROXY_FAILS;
@@ -254,6 +255,7 @@ public final class MediaDriver implements AutoCloseable
                         errorHandler,
                         errorCounter,
                         new FixedNameCompositeAgent(
+                            ctx.properties(),
                             AERON_DRIVER_SHARED_THREAD_NAME,
                             ctx.aeronDirectoryName(), sender, receiver, nativeResourceAgent, conductor));
                     sharedInvoker = null;
@@ -272,6 +274,7 @@ public final class MediaDriver implements AutoCloseable
                         errorHandler,
                         errorCounter,
                         new FixedNameCompositeAgent(
+                            ctx.properties(),
                             AERON_DRIVER_SHARED_NETWORK_THREAD_NAME,
                             ctx.aeronDirectoryName(), sender, receiver));
                     conductorRunner = new AgentRunner(
@@ -573,77 +576,75 @@ public final class MediaDriver implements AutoCloseable
         }
 
         private volatile boolean isClosed;
-        private boolean printConfigurationOnStart = CommonContext.shouldPrintConfigurationOnStart();
-        private boolean useWindowsHighResTimer = Configuration.useWindowsHighResTimer();
-        private boolean warnIfDirectoryExists = Configuration.warnIfDirExists();
-        private boolean dirDeleteOnStart = Configuration.dirDeleteOnStart();
-        private boolean dirDeleteOnShutdown = Configuration.dirDeleteOnShutdown();
-        private boolean termBufferSparseFile = Configuration.termBufferSparseFile();
-        private boolean performStorageChecks = Configuration.performStorageChecks();
-        private boolean spiesSimulateConnection = Configuration.spiesSimulateConnection();
-        private boolean reliableStream = Configuration.reliableStream();
-        private boolean tetherSubscriptions = Configuration.tetherSubscriptions();
-        private boolean rejoinStream = Configuration.rejoinStream();
-        private long lowStorageWarningThreshold = Configuration.lowStorageWarningThreshold();
-        private long timerIntervalNs = Configuration.timerIntervalNs();
-        private long clientLivenessTimeoutNs = Configuration.clientLivenessTimeoutNs();
-        private long imageLivenessTimeoutNs = Configuration.imageLivenessTimeoutNs();
-        private long publicationUnblockTimeoutNs = Configuration.publicationUnblockTimeoutNs();
-        private long publicationConnectionTimeoutNs = Configuration.publicationConnectionTimeoutNs();
-        private long publicationLingerTimeoutNs = Configuration.publicationLingerTimeoutNs();
-        private long untetheredWindowLimitTimeoutNs = Configuration.untetheredWindowLimitTimeoutNs();
-        private long untetheredLingerTimeoutNs = Configuration.untetheredLingerTimeoutNs();
-        private long untetheredRestingTimeoutNs = Configuration.untetheredRestingTimeoutNs();
-        private long statusMessageTimeoutNs = Configuration.statusMessageTimeoutNs();
-        private long counterFreeToReuseTimeoutNs = Configuration.counterFreeToReuseTimeoutNs();
-        private long retransmitUnicastDelayNs = Configuration.retransmitUnicastDelayNs();
-        private long retransmitUnicastLingerNs = Configuration.retransmitUnicastLingerNs();
-        private long nakUnicastDelayNs = Configuration.nakUnicastDelayNs();
-        private long nakUnicastRetryDelayRatio = Configuration.nakUnicastRetryDelayRatio();
-        private long nakMulticastMaxBackoffNs = Configuration.nakMulticastMaxBackoffNs();
-        private long flowControlReceiverTimeoutNs = Configuration.flowControlReceiverTimeoutNs();
-        private int unicastFlowControlRetransmitReceiverWindowMultiple = Configuration
-            .unicastFlowControlRetransmitReceiverWindowMultiple();
-        private int multicastFlowControlRetransmitReceiverWindowMultiple = Configuration
-            .multicastFlowControlRetransmitReceiverWindowMultiple();
-        private long reResolutionCheckIntervalNs = Configuration.reResolutionCheckIntervalNs();
-        private long conductorCycleThresholdNs = Configuration.conductorCycleThresholdNs();
-        private long senderCycleThresholdNs = Configuration.senderCycleThresholdNs();
-        private long receiverCycleThresholdNs = Configuration.receiverCycleThresholdNs();
-        private long nameResolverThresholdNs = Configuration.nameResolverThresholdNs();
+        private boolean printConfigurationOnStart;
+        private boolean useWindowsHighResTimer;
+        private boolean warnIfDirectoryExists;
+        private boolean dirDeleteOnStart;
+        private boolean dirDeleteOnShutdown;
+        private boolean termBufferSparseFile;
+        private boolean performStorageChecks;
+        private boolean spiesSimulateConnection;
+        private boolean reliableStream;
+        private boolean tetherSubscriptions;
+        private boolean rejoinStream;
+        private long lowStorageWarningThreshold;
+        private long timerIntervalNs;
+        private long clientLivenessTimeoutNs;
+        private long imageLivenessTimeoutNs;
+        private long publicationUnblockTimeoutNs;
+        private long publicationConnectionTimeoutNs;
+        private long publicationLingerTimeoutNs;
+        private long untetheredWindowLimitTimeoutNs;
+        private long untetheredLingerTimeoutNs;
+        private long untetheredRestingTimeoutNs;
+        private long statusMessageTimeoutNs;
+        private long counterFreeToReuseTimeoutNs;
+        private long retransmitUnicastDelayNs;
+        private long retransmitUnicastLingerNs;
+        private long nakUnicastDelayNs;
+        private long nakUnicastRetryDelayRatio;
+        private long nakMulticastMaxBackoffNs;
+        private long flowControlReceiverTimeoutNs;
+        private int unicastFlowControlRetransmitReceiverWindowMultiple;
+        private int multicastFlowControlRetransmitReceiverWindowMultiple;
+        private long reResolutionCheckIntervalNs;
+        private long conductorCycleThresholdNs;
+        private long senderCycleThresholdNs;
+        private long receiverCycleThresholdNs;
+        private long nameResolverThresholdNs;
 
-        private int conductorBufferLength = Configuration.conductorBufferLength();
-        private int toClientsBufferLength = Configuration.toClientsBufferLength();
-        private int counterValuesBufferLength = Configuration.counterValuesBufferLength();
-        private int errorBufferLength = Configuration.errorBufferLength();
-        private int nakMulticastGroupSize = Configuration.nakMulticastGroupSize();
-        private int publicationTermBufferLength = Configuration.termBufferLength();
-        private int ipcTermBufferLength = Configuration.ipcTermBufferLength();
-        private int publicationTermWindowLength = Configuration.publicationTermWindowLength();
-        private int ipcPublicationTermWindowLength = Configuration.ipcPublicationTermWindowLength();
-        private int initialWindowLength = Configuration.initialWindowLength();
-        private int socketSndbufLength = Configuration.socketSndbufLength();
-        private int socketRcvbufLength = Configuration.socketRcvbufLength();
-        private int socketMulticastTtl = Configuration.socketMulticastTtl();
-        private int mtuLength = Configuration.mtuLength();
-        private int ipcMtuLength = Configuration.ipcMtuLength();
-        private int filePageSize = Configuration.filePageSize();
-        private int publicationReservedSessionIdLow = Configuration.publicationReservedSessionIdLow();
-        private int publicationReservedSessionIdHigh = Configuration.publicationReservedSessionIdHigh();
-        private int lossReportBufferLength = Configuration.lossReportBufferLength();
-        private int sendToStatusMessagePollRatio = Configuration.sendToStatusMessagePollRatio();
-        private int resourceFreeLimit = Configuration.resourceFreeLimit();
-        private int maxResend = Configuration.maxResend();
+        private int conductorBufferLength;
+        private int toClientsBufferLength;
+        private int counterValuesBufferLength;
+        private int errorBufferLength;
+        private int nakMulticastGroupSize;
+        private int publicationTermBufferLength;
+        private int ipcTermBufferLength;
+        private int publicationTermWindowLength;
+        private int ipcPublicationTermWindowLength;
+        private int initialWindowLength;
+        private int socketSndbufLength;
+        private int socketRcvbufLength;
+        private int socketMulticastTtl;
+        private int mtuLength;
+        private int ipcMtuLength;
+        private int filePageSize;
+        private int publicationReservedSessionIdLow;
+        private int publicationReservedSessionIdHigh;
+        private int lossReportBufferLength;
+        private int sendToStatusMessagePollRatio;
+        private int resourceFreeLimit;
+        private int maxResend;
 
-        private Long receiverGroupTag = Configuration.groupTag();
-        private long flowControlGroupTag = Configuration.flowControlGroupTag();
-        private int flowControlGroupMinSize = Configuration.flowControlGroupMinSize();
-        private InferableBoolean receiverGroupConsideration = Configuration.receiverGroupConsideration();
-        private String resolverName = Configuration.resolverName();
-        private String resolverInterface = Configuration.resolverInterface();
-        private String resolverBootstrapNeighbor = Configuration.resolverBootstrapNeighbor();
-        private String senderWildcardPortRange = Configuration.senderWildcardPortRange();
-        private String receiverWildcardPortRange = Configuration.receiverWildcardPortRange();
+        private Long receiverGroupTag;
+        private long flowControlGroupTag;
+        private int flowControlGroupMinSize;
+        private InferableBoolean receiverGroupConsideration;
+        private String resolverName;
+        private String resolverInterface;
+        private String resolverBootstrapNeighbor;
+        private String senderWildcardPortRange;
+        private String receiverWildcardPortRange;
 
         private EpochClock epochClock;
         private NanoClock nanoClock;
@@ -706,10 +707,10 @@ public final class MediaDriver implements AutoCloseable
         private MappedByteBuffer cncByteBuffer;
         private UnsafeBuffer cncMetaDataBuffer;
 
-        private int osDefaultSocketRcvbufLength = Aeron.NULL_VALUE;
-        private int osMaxSocketRcvbufLength = Aeron.NULL_VALUE;
-        private int osDefaultSocketSndbufLength = Aeron.NULL_VALUE;
-        private int osMaxSocketSndbufLength = Aeron.NULL_VALUE;
+        private int osDefaultSocketRcvbufLength;
+        private int osMaxSocketRcvbufLength;
+        private int osDefaultSocketSndbufLength;
+        private int osMaxSocketSndbufLength;
         private EpochNanoClock channelReceiveTimestampClock;
         private EpochNanoClock channelSendTimestampClock;
 
@@ -719,18 +720,115 @@ public final class MediaDriver implements AutoCloseable
         private DutyCycleTracker nameResolverTimeTracker;
         private PortManager senderPortManager;
         private PortManager receiverPortManager;
-        private int streamSessionLimit = Configuration.streamSessionLimit();
-        private long resolverNeighbourTimeoutNs = Configuration.resolverNeighborTimeoutNs();
-        private long resolverSelfResolutionIntervalNs = Configuration.resolverSelfResolutionIntervalNs();
-        private long resolverNeighborResolutionIntervalNs = Configuration.resolverNeighborResolutionIntervalNs();
-        private long resolverBootstrapNeighborResolutionIntervalNs =
-            Configuration.resolverBootstrapNeighborResolutionIntervalNs();
+        private int streamSessionLimit;
+        private long resolverNeighbourTimeoutNs;
+        private long resolverSelfResolutionIntervalNs;
+        private long resolverNeighborResolutionIntervalNs;
+        private long resolverBootstrapNeighborResolutionIntervalNs;
 
         /**
          * Construct a Context using default values and loading from system properties.
          */
         public Context()
         {
+            this(System.getProperties());
+        }
+
+        /**
+         * Construct a Context using default values loaded from the supplied properties.
+         *
+         * @param properties to load the configuration from.
+         */
+        public Context(final Properties properties)
+        {
+            super(properties);
+            applyDefaults(properties);
+        }
+
+        private void applyDefaults(final Properties properties)
+        {
+            printConfigurationOnStart = CommonContext.shouldPrintConfigurationOnStart(properties);
+            useWindowsHighResTimer = Configuration.useWindowsHighResTimer(properties);
+            warnIfDirectoryExists = Configuration.warnIfDirExists(properties);
+            dirDeleteOnStart = Configuration.dirDeleteOnStart(properties);
+            dirDeleteOnShutdown = Configuration.dirDeleteOnShutdown(properties);
+            termBufferSparseFile = Configuration.termBufferSparseFile(properties);
+            performStorageChecks = Configuration.performStorageChecks(properties);
+            spiesSimulateConnection = Configuration.spiesSimulateConnection(properties);
+            reliableStream = Configuration.reliableStream(properties);
+            tetherSubscriptions = Configuration.tetherSubscriptions(properties);
+            rejoinStream = Configuration.rejoinStream(properties);
+            lowStorageWarningThreshold = Configuration.lowStorageWarningThreshold(properties);
+            timerIntervalNs = Configuration.timerIntervalNs(properties);
+            clientLivenessTimeoutNs = Configuration.clientLivenessTimeoutNs(properties);
+            imageLivenessTimeoutNs = Configuration.imageLivenessTimeoutNs(properties);
+            publicationUnblockTimeoutNs = Configuration.publicationUnblockTimeoutNs(properties);
+            publicationConnectionTimeoutNs = Configuration.publicationConnectionTimeoutNs(properties);
+            publicationLingerTimeoutNs = Configuration.publicationLingerTimeoutNs(properties);
+            untetheredWindowLimitTimeoutNs = Configuration.untetheredWindowLimitTimeoutNs(properties);
+            untetheredLingerTimeoutNs = Configuration.untetheredLingerTimeoutNs(properties);
+            untetheredRestingTimeoutNs = Configuration.untetheredRestingTimeoutNs(properties);
+            statusMessageTimeoutNs = Configuration.statusMessageTimeoutNs(properties);
+            counterFreeToReuseTimeoutNs = Configuration.counterFreeToReuseTimeoutNs(properties);
+            retransmitUnicastDelayNs = Configuration.retransmitUnicastDelayNs(properties);
+            retransmitUnicastLingerNs = Configuration.retransmitUnicastLingerNs(properties);
+            nakUnicastDelayNs = Configuration.nakUnicastDelayNs(properties);
+            nakUnicastRetryDelayRatio = Configuration.nakUnicastRetryDelayRatio(properties);
+            nakMulticastMaxBackoffNs = Configuration.nakMulticastMaxBackoffNs(properties);
+            flowControlReceiverTimeoutNs = Configuration.flowControlReceiverTimeoutNs(properties);
+            unicastFlowControlRetransmitReceiverWindowMultiple =
+                Configuration.unicastFlowControlRetransmitReceiverWindowMultiple(properties);
+            multicastFlowControlRetransmitReceiverWindowMultiple =
+                Configuration.multicastFlowControlRetransmitReceiverWindowMultiple(properties);
+            reResolutionCheckIntervalNs = Configuration.reResolutionCheckIntervalNs(properties);
+            conductorCycleThresholdNs = Configuration.conductorCycleThresholdNs(properties);
+            senderCycleThresholdNs = Configuration.senderCycleThresholdNs(properties);
+            receiverCycleThresholdNs = Configuration.receiverCycleThresholdNs(properties);
+            nameResolverThresholdNs = Configuration.nameResolverThresholdNs(properties);
+
+            conductorBufferLength = Configuration.conductorBufferLength(properties);
+            toClientsBufferLength = Configuration.toClientsBufferLength(properties);
+            counterValuesBufferLength = Configuration.counterValuesBufferLength(properties);
+            errorBufferLength = Configuration.errorBufferLength(properties);
+            nakMulticastGroupSize = Configuration.nakMulticastGroupSize(properties);
+            publicationTermBufferLength = Configuration.termBufferLength(properties);
+            ipcTermBufferLength = Configuration.ipcTermBufferLength(properties);
+            publicationTermWindowLength = Configuration.publicationTermWindowLength(properties);
+            ipcPublicationTermWindowLength = Configuration.ipcPublicationTermWindowLength(properties);
+            initialWindowLength = Configuration.initialWindowLength(properties);
+            socketSndbufLength = Configuration.socketSndbufLength(properties);
+            socketRcvbufLength = Configuration.socketRcvbufLength(properties);
+            socketMulticastTtl = Configuration.socketMulticastTtl(properties);
+            mtuLength = Configuration.mtuLength(properties);
+            ipcMtuLength = Configuration.ipcMtuLength(properties);
+            filePageSize = Configuration.filePageSize(properties);
+            publicationReservedSessionIdLow = Configuration.publicationReservedSessionIdLow(properties);
+            publicationReservedSessionIdHigh = Configuration.publicationReservedSessionIdHigh(properties);
+            lossReportBufferLength = Configuration.lossReportBufferLength(properties);
+            sendToStatusMessagePollRatio = Configuration.sendToStatusMessagePollRatio(properties);
+            resourceFreeLimit = Configuration.resourceFreeLimit(properties);
+            maxResend = Configuration.maxResend(properties);
+
+            receiverGroupTag = Configuration.groupTag(properties);
+            flowControlGroupTag = Configuration.flowControlGroupTag(properties);
+            flowControlGroupMinSize = Configuration.flowControlGroupMinSize(properties);
+            receiverGroupConsideration = Configuration.receiverGroupConsideration(properties);
+            resolverName = Configuration.resolverName(properties);
+            resolverInterface = Configuration.resolverInterface(properties);
+            resolverBootstrapNeighbor = Configuration.resolverBootstrapNeighbor(properties);
+            senderWildcardPortRange = Configuration.senderWildcardPortRange(properties);
+            receiverWildcardPortRange = Configuration.receiverWildcardPortRange(properties);
+
+            osDefaultSocketRcvbufLength = Aeron.NULL_VALUE;
+            osMaxSocketRcvbufLength = Aeron.NULL_VALUE;
+            osDefaultSocketSndbufLength = Aeron.NULL_VALUE;
+            osMaxSocketSndbufLength = Aeron.NULL_VALUE;
+            streamSessionLimit = Configuration.streamSessionLimit(properties);
+            resolverNeighbourTimeoutNs = Configuration.resolverNeighborTimeoutNs(properties);
+            resolverSelfResolutionIntervalNs = Configuration.resolverSelfResolutionIntervalNs(properties);
+            resolverNeighborResolutionIntervalNs = Configuration.resolverNeighborResolutionIntervalNs(properties);
+            resolverBootstrapNeighborResolutionIntervalNs =
+                Configuration.resolverBootstrapNeighborResolutionIntervalNs(properties);
         }
 
         /**
@@ -847,11 +945,11 @@ public final class MediaDriver implements AutoCloseable
 
                 final long cncFileLength = BitUtil.align(
                     (long)META_DATA_LENGTH +
-                    conductorBufferLength +
-                    toClientsBufferLength +
-                    countersMetadataBufferLength(counterValuesBufferLength) +
-                    counterValuesBufferLength +
-                    errorBufferLength,
+                        conductorBufferLength +
+                        toClientsBufferLength +
+                        countersMetadataBufferLength(counterValuesBufferLength) +
+                        counterValuesBufferLength +
+                        errorBufferLength,
                     filePageSize);
                 validateValueRange(cncFileLength, 0, Integer.MAX_VALUE, "CnC file length");
                 cncByteBuffer = mapNewFile(cncFile(), cncFileLength);
@@ -1616,7 +1714,7 @@ public final class MediaDriver implements AutoCloseable
         @Config
         public long clientLivenessTimeoutNs()
         {
-            return CommonContext.checkDebugTimeout(clientLivenessTimeoutNs, TimeUnit.NANOSECONDS);
+            return CommonContext.checkDebugTimeout(properties(), clientLivenessTimeoutNs, TimeUnit.NANOSECONDS);
         }
 
         /**
@@ -1696,7 +1794,8 @@ public final class MediaDriver implements AutoCloseable
         @Config
         public long publicationUnblockTimeoutNs()
         {
-            return CommonContext.checkDebugTimeout(publicationUnblockTimeoutNs, TimeUnit.NANOSECONDS, 1.5);
+            return CommonContext.checkDebugTimeout(
+                properties(), publicationUnblockTimeoutNs, TimeUnit.NANOSECONDS, 1.5);
         }
 
         /**
@@ -4314,27 +4413,27 @@ public final class MediaDriver implements AutoCloseable
 
             if (null == unicastFlowControlSupplier)
             {
-                unicastFlowControlSupplier = Configuration.unicastFlowControlSupplier();
+                unicastFlowControlSupplier = Configuration.unicastFlowControlSupplier(properties());
             }
 
             if (null == multicastFlowControlSupplier)
             {
-                multicastFlowControlSupplier = Configuration.multicastFlowControlSupplier();
+                multicastFlowControlSupplier = Configuration.multicastFlowControlSupplier(properties());
             }
 
             if (null == sendChannelEndpointSupplier)
             {
-                sendChannelEndpointSupplier = Configuration.sendChannelEndpointSupplier();
+                sendChannelEndpointSupplier = Configuration.sendChannelEndpointSupplier(properties());
             }
 
             if (null == receiveChannelEndpointSupplier)
             {
-                receiveChannelEndpointSupplier = Configuration.receiveChannelEndpointSupplier();
+                receiveChannelEndpointSupplier = Configuration.receiveChannelEndpointSupplier(properties());
             }
 
             if (null == applicationSpecificFeedback)
             {
-                applicationSpecificFeedback = Configuration.applicationSpecificFeedback();
+                applicationSpecificFeedback = Configuration.applicationSpecificFeedback(properties());
             }
 
             if (null == receiverGroupTag)
@@ -4345,7 +4444,7 @@ public final class MediaDriver implements AutoCloseable
                     {
                         throw new IllegalArgumentException(
                             "applicationSpecificFeedback length must be equal to " + SIZE_OF_LONG +
-                            " bytes: length=" + applicationSpecificFeedback.length);
+                                " bytes: length=" + applicationSpecificFeedback.length);
                     }
 
                     final UnsafeBuffer buffer = new UnsafeBuffer(applicationSpecificFeedback);
@@ -4360,12 +4459,12 @@ public final class MediaDriver implements AutoCloseable
 
             if (null == congestionControlSupplier)
             {
-                congestionControlSupplier = Configuration.congestionControlSupplier();
+                congestionControlSupplier = Configuration.congestionControlSupplier(properties());
             }
 
             if (null == threadingMode)
             {
-                threadingMode = Configuration.threadingMode();
+                threadingMode = Configuration.threadingMode(properties());
             }
 
             if (null == driverCommandQueue)
@@ -4412,7 +4511,7 @@ public final class MediaDriver implements AutoCloseable
 
             if (null == terminationValidator)
             {
-                terminationValidator = Configuration.terminationValidator();
+                terminationValidator = Configuration.terminationValidator(properties());
             }
 
             if (null == nameResolver)
@@ -4503,7 +4602,7 @@ public final class MediaDriver implements AutoCloseable
                     createErrorLogBuffer(cncByteBuffer, cncMetaDataBuffer), epochClock, US_ASCII);
             }
 
-            errorHandler = CommonContext.setupErrorHandler(errorHandler, errorLog);
+            errorHandler = CommonContext.setupErrorHandler(properties(), errorHandler, errorLog);
 
             if (null == countedErrorHandler)
             {
@@ -4623,7 +4722,7 @@ public final class MediaDriver implements AutoCloseable
                     }
                     if (null == sharedIdleStrategy)
                     {
-                        sharedIdleStrategy = Configuration.sharedIdleStrategy(indicator);
+                        sharedIdleStrategy = Configuration.sharedIdleStrategy(properties(), indicator);
                     }
                     break;
 
@@ -4634,7 +4733,7 @@ public final class MediaDriver implements AutoCloseable
                     }
                     if (null == conductorIdleStrategy)
                     {
-                        conductorIdleStrategy = Configuration.conductorIdleStrategy(indicator);
+                        conductorIdleStrategy = Configuration.conductorIdleStrategy(properties(), indicator);
                     }
                     if (null == nativeResourceAgentThreadFactory)
                     {
@@ -4646,11 +4745,12 @@ public final class MediaDriver implements AutoCloseable
                     }
                     if (null == sharedNetworkIdleStrategy)
                     {
-                        sharedNetworkIdleStrategy = Configuration.sharedNetworkIdleStrategy(indicator);
+                        sharedNetworkIdleStrategy = Configuration.sharedNetworkIdleStrategy(properties(), indicator);
                     }
                     if (null == nativeResourceAgentIdleStrategy)
                     {
-                        nativeResourceAgentIdleStrategy = Configuration.nativeResourceAgentIdleStrategy(indicator);
+                        nativeResourceAgentIdleStrategy =
+                            Configuration.nativeResourceAgentIdleStrategy(properties(), indicator);
                     }
                     break;
 
@@ -4673,19 +4773,20 @@ public final class MediaDriver implements AutoCloseable
                     }
                     if (null == conductorIdleStrategy)
                     {
-                        conductorIdleStrategy = Configuration.conductorIdleStrategy(indicator);
+                        conductorIdleStrategy = Configuration.conductorIdleStrategy(properties(), indicator);
                     }
                     if (null == senderIdleStrategy)
                     {
-                        senderIdleStrategy = Configuration.senderIdleStrategy(indicator);
+                        senderIdleStrategy = Configuration.senderIdleStrategy(properties(), indicator);
                     }
                     if (null == receiverIdleStrategy)
                     {
-                        receiverIdleStrategy = Configuration.receiverIdleStrategy(indicator);
+                        receiverIdleStrategy = Configuration.receiverIdleStrategy(properties(), indicator);
                     }
                     if (null == nativeResourceAgentIdleStrategy)
                     {
-                        nativeResourceAgentIdleStrategy = Configuration.nativeResourceAgentIdleStrategy(indicator);
+                        nativeResourceAgentIdleStrategy =
+                            Configuration.nativeResourceAgentIdleStrategy(properties(), indicator);
                     }
                     break;
             }

--- a/aeron-driver/src/main/java/io/aeron/driver/Receiver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Receiver.java
@@ -72,7 +72,8 @@ public final class Receiver implements Agent
         conductorProxy = ctx.driverConductorProxy();
         reResolutionCheckIntervalNs = ctx.reResolutionCheckIntervalNs();
         dutyCycleTracker = ctx.receiverDutyCycleTracker();
-        roleName = threadName(AERON_DRIVER_RECEIVER_THREAD_NAME, AERON_DRIVER_RECEIVER_THREAD_NAME_CLASSIC);
+        roleName = threadName(
+            ctx.properties(), AERON_DRIVER_RECEIVER_THREAD_NAME, AERON_DRIVER_RECEIVER_THREAD_NAME_CLASSIC);
     }
 
     /**

--- a/aeron-driver/src/main/java/io/aeron/driver/Sender.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Sender.java
@@ -30,7 +30,9 @@ import java.net.InetSocketAddress;
 import static io.aeron.CommonContext.threadName;
 import static io.aeron.driver.MediaDriver.AERON_DRIVER_SENDER_THREAD_NAME;
 import static io.aeron.driver.MediaDriver.AERON_DRIVER_SENDER_THREAD_NAME_CLASSIC;
-import static io.aeron.driver.status.SystemCounterDescriptor.*;
+import static io.aeron.driver.status.SystemCounterDescriptor.BYTES_SENT;
+import static io.aeron.driver.status.SystemCounterDescriptor.RESOLUTION_CHANGES;
+import static io.aeron.driver.status.SystemCounterDescriptor.SHORT_SENDS;
 
 class SenderLhsPadding
 {
@@ -92,7 +94,8 @@ public final class Sender extends SenderRhsPadding implements Agent
         dutyCycleRatio = ctx.sendToStatusMessagePollRatio();
         conductorProxy = ctx.driverConductorProxy();
         dutyCycleTracker = ctx.senderDutyCycleTracker();
-        roleName = threadName(AERON_DRIVER_SENDER_THREAD_NAME, AERON_DRIVER_SENDER_THREAD_NAME_CLASSIC);
+        roleName = threadName(
+            ctx.properties(), AERON_DRIVER_SENDER_THREAD_NAME, AERON_DRIVER_SENDER_THREAD_NAME_CLASSIC);
     }
 
     /**

--- a/aeron-driver/src/test/java/io/aeron/driver/MediaDriverContextPropertiesTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/MediaDriverContextPropertiesTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2014-2025 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.driver;
+
+import io.aeron.CommonContext;
+import io.aeron.driver.MediaDriver.Context;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import static io.aeron.CommonContext.AERON_DIR_PROP_NAME;
+import static io.aeron.driver.Configuration.CLIENT_LIVENESS_TIMEOUT_PROP_NAME;
+import static io.aeron.driver.Configuration.DIR_DELETE_ON_START_PROP_NAME;
+import static io.aeron.driver.Configuration.MTU_LENGTH_PROP_NAME;
+import static io.aeron.driver.Configuration.RESOLVER_NAME_PROP_NAME;
+import static io.aeron.driver.Configuration.TERM_BUFFER_LENGTH_PROP_NAME;
+import static io.aeron.driver.Configuration.THREADING_MODE_PROP_NAME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MediaDriverContextPropertiesTest
+{
+    @AfterEach
+    void tearDown()
+    {
+        System.clearProperty(MTU_LENGTH_PROP_NAME);
+        System.clearProperty(TERM_BUFFER_LENGTH_PROP_NAME);
+    }
+
+    @Test
+    void suppliedPropertiesConfigureTheContext()
+    {
+        final Properties properties = new Properties();
+        properties.setProperty(AERON_DIR_PROP_NAME, "/tmp/aeron-a");
+        properties.setProperty(MTU_LENGTH_PROP_NAME, "4k");
+        properties.setProperty(TERM_BUFFER_LENGTH_PROP_NAME, "128k");
+        properties.setProperty(CLIENT_LIVENESS_TIMEOUT_PROP_NAME, "7s");
+        properties.setProperty(DIR_DELETE_ON_START_PROP_NAME, "true");
+        properties.setProperty(RESOLVER_NAME_PROP_NAME, "node-a");
+
+        final Context context = new Context(properties);
+
+        assertSame(properties, context.properties());
+        assertEquals("/tmp/aeron-a", context.aeronDirectoryName());
+        assertEquals(4 * 1024, context.mtuLength());
+        assertEquals(128 * 1024, context.publicationTermBufferLength());
+        assertEquals(TimeUnit.SECONDS.toNanos(7), context.clientLivenessTimeoutNs());
+        assertTrue(context.dirDeleteOnStart());
+        assertEquals("node-a", context.resolverName());
+    }
+
+    @Test
+    void twoContextsFromDifferentPropertiesAreIndependent()
+    {
+        final Properties a = new Properties();
+        a.setProperty(AERON_DIR_PROP_NAME, "/tmp/aeron-a");
+        a.setProperty(MTU_LENGTH_PROP_NAME, "1408");
+
+        final Properties b = new Properties();
+        b.setProperty(AERON_DIR_PROP_NAME, "/tmp/aeron-b");
+        b.setProperty(MTU_LENGTH_PROP_NAME, "8k");
+
+        final Context contextA = new Context(a);
+        final Context contextB = new Context(b);
+
+        assertEquals("/tmp/aeron-a", contextA.aeronDirectoryName());
+        assertEquals("/tmp/aeron-b", contextB.aeronDirectoryName());
+        assertEquals(1408, contextA.mtuLength());
+        assertEquals(8 * 1024, contextB.mtuLength());
+        assertNotEquals(contextA.aeronDirectoryName(), contextB.aeronDirectoryName());
+    }
+
+    @Test
+    void suppliedPropertiesShadowSystemPropertiesAndAreNotWrittenBackToThem()
+    {
+        System.setProperty(MTU_LENGTH_PROP_NAME, "1408");
+
+        final Properties properties = new Properties();
+        properties.setProperty(MTU_LENGTH_PROP_NAME, "8k");
+
+        assertEquals(8 * 1024, new Context(properties).mtuLength());
+        assertEquals(1408, new Context().mtuLength());
+        assertEquals("1408", System.getProperty(MTU_LENGTH_PROP_NAME));
+    }
+
+    @Test
+    void emptyPropertiesYieldTheDocumentedDefaults()
+    {
+        final Context context = new Context(new Properties());
+
+        assertEquals(Configuration.MTU_LENGTH_DEFAULT, context.mtuLength());
+        assertEquals(Configuration.TERM_BUFFER_LENGTH_DEFAULT, context.publicationTermBufferLength());
+        assertEquals(Configuration.CLIENT_LIVENESS_TIMEOUT_DEFAULT_NS, context.clientLivenessTimeoutNs());
+        assertFalse(context.dirDeleteOnStart());
+        assertEquals(CommonContext.AERON_DIR_PROP_DEFAULT, context.aeronDirectoryName());
+    }
+
+    @Test
+    void defaultConstructorStillReadsSystemProperties()
+    {
+        System.setProperty(TERM_BUFFER_LENGTH_PROP_NAME, "256k");
+
+        assertEquals(256 * 1024, new Context().publicationTermBufferLength());
+    }
+
+    @Test
+    void concludeTimeLookupsAlsoUseTheSuppliedProperties(@TempDir final Path aeronDir)
+    {
+        final Properties properties = new Properties();
+        properties.setProperty(AERON_DIR_PROP_NAME, aeronDir.toString());
+        properties.setProperty(THREADING_MODE_PROP_NAME, ThreadingMode.SHARED.name());
+
+        final Context context = new Context(properties);
+        try
+        {
+            context.conclude();
+
+            assertEquals(ThreadingMode.SHARED, context.threadingMode());
+        }
+        finally
+        {
+            context.close();
+        }
+    }
+}

--- a/aeron-system-tests/src/test/java/io/aeron/MultiStackPropertiesTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MultiStackPropertiesTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2014-2025 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron;
+
+import io.aeron.driver.MediaDriver;
+import io.aeron.driver.ThreadingMode;
+import io.aeron.logbuffer.FragmentHandler;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.Tests;
+import org.agrona.CloseHelper;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.aeron.CommonContext.AERON_DIR_PROP_NAME;
+import static io.aeron.driver.Configuration.DIR_DELETE_ON_START_PROP_NAME;
+import static io.aeron.driver.Configuration.IPC_MTU_LENGTH_PROP_NAME;
+import static io.aeron.driver.Configuration.IPC_TERM_BUFFER_LENGTH_PROP_NAME;
+import static io.aeron.driver.Configuration.THREADING_MODE_PROP_NAME;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Two fully isolated Aeron stacks configured from two {@link Properties} instances in a single JVM, with no
+ * system properties involved. This is the scenario system property based configuration cannot express.
+ */
+@ExtendWith(InterruptingTestCallback.class)
+class MultiStackPropertiesTest
+{
+    private static final int STREAM_ID = 1001;
+    private static final String CHANNEL = "aeron:ipc";
+
+    private MediaDriver driverA;
+    private MediaDriver driverB;
+    private Aeron clientA;
+    private Aeron clientB;
+
+    @AfterEach
+    void tearDown()
+    {
+        CloseHelper.quietCloseAll(clientA, clientB, driverA, driverB);
+    }
+
+    @Test
+    @InterruptAfter(20)
+    void twoStacksConfiguredFromPropertiesAreIsolated(@TempDir final Path dirA, @TempDir final Path dirB)
+    {
+        final Properties propertiesA = stackProperties(dirA, "64k", "2k", "stack-a");
+        final Properties propertiesB = stackProperties(dirB, "128k", "4k", "stack-b");
+
+        driverA = MediaDriver.launch(new MediaDriver.Context(propertiesA));
+        driverB = MediaDriver.launch(new MediaDriver.Context(propertiesB));
+
+        assertEquals(dirA.toString(), driverA.context().aeronDirectoryName());
+        assertEquals(dirB.toString(), driverB.context().aeronDirectoryName());
+        assertEquals(64 * 1024, driverA.context().ipcTermBufferLength());
+        assertEquals(128 * 1024, driverB.context().ipcTermBufferLength());
+        assertEquals(2 * 1024, driverA.context().ipcMtuLength());
+        assertEquals(4 * 1024, driverB.context().ipcMtuLength());
+        assertNotEquals(driverA.context().aeronDirectory(), driverB.context().aeronDirectory());
+
+        clientA = Aeron.connect(new Aeron.Context(propertiesA));
+        clientB = Aeron.connect(new Aeron.Context(propertiesB));
+
+        assertEquals("stack-a", clientA.context().clientName());
+        assertEquals("stack-b", clientB.context().clientName());
+        assertEquals(dirA.toString(), clientA.context().aeronDirectoryName());
+        assertEquals(dirB.toString(), clientB.context().aeronDirectoryName());
+
+        assertEquals("message-a", roundTrip(clientA, "message-a"));
+        assertEquals("message-b", roundTrip(clientB, "message-b"));
+
+        assertNull(System.getProperty(AERON_DIR_PROP_NAME));
+        assertNull(System.getProperty(IPC_TERM_BUFFER_LENGTH_PROP_NAME));
+    }
+
+    private static Properties stackProperties(
+        final Path aeronDir, final String termLength, final String mtuLength, final String clientName)
+    {
+        final Properties properties = new Properties();
+        properties.setProperty(AERON_DIR_PROP_NAME, aeronDir.toString());
+        properties.setProperty(DIR_DELETE_ON_START_PROP_NAME, "true");
+        properties.setProperty(THREADING_MODE_PROP_NAME, ThreadingMode.SHARED.name());
+        properties.setProperty(IPC_TERM_BUFFER_LENGTH_PROP_NAME, termLength);
+        properties.setProperty(IPC_MTU_LENGTH_PROP_NAME, mtuLength);
+        properties.setProperty(Aeron.Configuration.CLIENT_NAME_PROP_NAME, clientName);
+
+        return properties;
+    }
+
+    private static String roundTrip(final Aeron aeron, final String message)
+    {
+        try (Subscription subscription = aeron.addSubscription(CHANNEL, STREAM_ID);
+            Publication publication = aeron.addPublication(CHANNEL, STREAM_ID))
+        {
+            Tests.awaitConnected(publication);
+
+            final UnsafeBuffer buffer = new UnsafeBuffer(message.getBytes(US_ASCII));
+            while (publication.offer(buffer, 0, buffer.capacity()) < 0)
+            {
+                Tests.yield();
+            }
+
+            final AtomicReference<String> received = new AtomicReference<>();
+            final FragmentHandler handler =
+                (buf, offset, length, header) -> received.set(buf.getStringWithoutLengthAscii(offset, length));
+
+            while (null == received.get())
+            {
+                if (0 == subscription.poll(handler, 1))
+                {
+                    Tests.yield();
+                }
+            }
+
+            return received.get();
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Part of #1937

## Changes

Each context gains a `Context(Properties)` constructor; the existing no-arg one delegates to `this(System.getProperties())`.

* instance field initializers removed.
* `conclude()` passes the context's properties to nested contexts, reflective suppliers and idle   strategies.
* New `io.aeron.PropertiesUtil` mirrors the `System` / `SystemUtil` lookups against a supplied  `Properties`, reusing Agrona's `parseSize`, `parseDuration` and `NULL_PROPERTY_VALUE`.
* `-D` configuration is unchanged and stays supported, no property renamed, no default value altered.

##  Behaviour changes

1. `aeron.driver.timeout` — `CommonContext.driverTimeoutMs` was `= DRIVER_TIMEOUT_MS` (static final resolved once when `CommonContext` loaded). Now read per construction.                                                                                                                                          
 2. Flow control strategy — unicastFlowControlSupplier() / multicastFlowControlSupplier() built new `Default*FlowControlSupplier()`, which read the static   `final *_FLOW_CONTROL_STRATEGY`. Now the strategy class name is read per construction and passed in.                                                     
                                                                                                                                                            
NOTE: it's only observable if the property changes between building one context and the next. The public constants `DRIVER_TIMEOUT_MS, UNICAST_FLOW_CONTROL_STRATEGY,  MULTICAST_FLOW_CONTROL_STRATEGY` are untouched and still hold the class-load value. 

##  Non-trivial but not behaviour changes                                                                                                                     

- `newDefaultCncFile()` — now routed through `getAeronDirectoryName(properties)`, which expands to the identical `properties.getProperty(AERON_DIR_PROP_NAME, AERON_DIR_PROP_DEFAULT)`. Refactor only.
- `Default{Unicast,Multicast}FlowControlSupplier` — gain `(String strategyClassName)` constructors; the no-arg ones still read the class-load constant, so direct users are unaffected. This is the mechanism behind behaviour change 2.
- `ArchiveMarkFile (package-private)` and `ClusterMarkFile (public)` — additive constructor overloads taking a `PrintStream`; existing constructors delegate with `CommonContext.fallbackLogger()`.
- `FixedNameCompositeAgent (package-private)` — constructor gains a Properties parameter.

## Config properties delegation semantic

```
System.setProperty(MTU_LENGTH_PROP_NAME, "1408"); // global value
properties.setProperty(MTU_LENGTH_PROP_NAME, "8k"); // injected value

assertEquals(8 * 1024, new Context(properties).mtuLength()); // 1. injected wins
assertEquals(1408, new Context().mtuLength());  // 2. global wins
assertEquals("1408", System.getProperty(MTU_LENGTH_PROP_NAME)); // 3. no write-back
```


## Scope

This is an initial PR to demonstrate the approach, deliberately limited to the context classes. Left
out: 
* CLI tools
* `-javaagent` event loggers (which run before any context exists)
* class-init configuration in `CubicCongestionControlConfiguration` and
`DebugChannelEndpointConfiguration`. 




