### PR TITLE
Renaming the concept of EventLogging to Tracing

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveConductor.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveConductor.java
@@ -33,7 +33,7 @@ import io.aeron.archive.client.ArchiveException;
 import io.aeron.archive.codecs.RecordingDescriptorDecoder;
 import io.aeron.archive.codecs.RecordingSignal;
 import io.aeron.archive.codecs.SourceLocation;
-import io.aeron.archive.logging.ArchiveLog;
+import io.aeron.archive.logging.ArchiveTracing;
 import io.aeron.archive.status.RecordingPos;
 import io.aeron.driver.DutyCycleTracker;
 import io.aeron.exceptions.AeronException;
@@ -245,7 +245,7 @@ abstract class ArchiveConductor
 
     public void onStart()
     {
-        ArchiveLog.logStart(ArchiveVersion.VERSION);
+        ArchiveTracing.traceStart(ArchiveVersion.VERSION);
 
         recorder = newRecorder();
         replayer = newReplayer();

--- a/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
@@ -19,7 +19,7 @@ import io.aeron.Aeron;
 import io.aeron.archive.checksum.Checksum;
 import io.aeron.archive.client.ArchiveException;
 import io.aeron.archive.codecs.*;
-import io.aeron.archive.logging.ArchiveLog;
+import io.aeron.archive.logging.ArchiveTracing;
 import org.agrona.*;
 import org.agrona.collections.Long2ObjectHashMap;
 import org.agrona.concurrent.EpochClock;
@@ -921,7 +921,7 @@ final class Catalog implements AutoCloseable
 
     void catalogResized(final long oldCapacity, final long newCapacity)
     {
-        ArchiveLog.logCatalogResize(oldCapacity, newCapacity);
+        ArchiveTracing.traceCatalogResize(oldCapacity, newCapacity);
     }
 
     private static void validateCapacity(final long catalogCapacity)

--- a/aeron-archive/src/main/java/io/aeron/archive/ControlResponseProxy.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ControlResponseProxy.java
@@ -20,7 +20,7 @@ import io.aeron.Subscription;
 import io.aeron.archive.client.AeronArchive;
 import io.aeron.archive.client.ArchiveEvent;
 import io.aeron.archive.codecs.*;
-import io.aeron.archive.logging.ArchiveLog;
+import io.aeron.archive.logging.ArchiveTracing;
 import io.aeron.exceptions.AeronException;
 import io.aeron.logbuffer.BufferClaim;
 import org.agrona.DirectBuffer;
@@ -263,11 +263,11 @@ class ControlResponseProxy
 
     private void logSendResponse(final DirectBuffer buffer, final int offset, final int length)
     {
-        ArchiveLog.logControlResponse(buffer, offset, length);
+        ArchiveTracing.traceControlResponse(buffer, offset, length);
     }
 
     private void logSendSignal(final DirectBuffer buffer, final int offset, final int length)
     {
-        ArchiveLog.logRecordingSignal(buffer, offset, length);
+        ArchiveTracing.traceRecordingSignal(buffer, offset, length);
     }
 }

--- a/aeron-archive/src/main/java/io/aeron/archive/ControlSession.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ControlSession.java
@@ -25,7 +25,7 @@ import io.aeron.archive.client.ArchiveEvent;
 import io.aeron.archive.codecs.ControlResponseCode;
 import io.aeron.archive.codecs.RecordingSignal;
 import io.aeron.archive.codecs.SourceLocation;
-import io.aeron.archive.logging.ArchiveLog;
+import io.aeron.archive.logging.ArchiveTracing;
 import io.aeron.exceptions.RegistrationException;
 import io.aeron.security.Authenticator;
 import org.agrona.CloseHelper;
@@ -1084,7 +1084,7 @@ final class ControlSession implements Session
     private void logStateChange(
         final State oldState, final State newState, final long controlSessionId, final String reason)
     {
-        ArchiveLog.logControlSessionStateChange(oldState, newState, controlSessionId, reason);
+        ArchiveTracing.traceControlSessionStateChange(oldState, newState, controlSessionId, reason);
     }
 
     String abortReason()

--- a/aeron-archive/src/main/java/io/aeron/archive/ControlSessionAdapter.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ControlSessionAdapter.java
@@ -63,7 +63,7 @@ import io.aeron.archive.codecs.StopReplicationRequestDecoder;
 import io.aeron.archive.codecs.TaggedReplicateRequestDecoder;
 import io.aeron.archive.codecs.TruncateRecordingRequestDecoder;
 import io.aeron.archive.codecs.UpdateChannelRequestDecoder;
-import io.aeron.archive.logging.ArchiveLog;
+import io.aeron.archive.logging.ArchiveTracing;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.Header;
 import io.aeron.security.AuthorisationService;
@@ -125,7 +125,7 @@ class ControlSessionAdapter implements FragmentHandler
     @SuppressWarnings("MethodLength")
     public void onFragment(final DirectBuffer buffer, final int offset, final int length, final Header header)
     {
-        ArchiveLog.logControlRequest(buffer, offset, length);
+        ArchiveTracing.traceControlRequest(buffer, offset, length);
 
         final MessageHeaderDecoder headerDecoder = decoders.header;
         headerDecoder.wrap(buffer, offset);

--- a/aeron-archive/src/main/java/io/aeron/archive/RecordingSession.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/RecordingSession.java
@@ -17,7 +17,7 @@ package io.aeron.archive;
 
 import io.aeron.*;
 import io.aeron.archive.client.ArchiveException;
-import io.aeron.archive.logging.ArchiveLog;
+import io.aeron.archive.logging.ArchiveTracing;
 import org.agrona.CloseHelper;
 import org.agrona.LangUtil;
 import org.agrona.concurrent.CountedErrorHandler;
@@ -296,6 +296,6 @@ class RecordingSession implements Session
         final long position,
         final String reason)
     {
-        ArchiveLog.logRecordingSessionStateChange(oldState, newState, recordingId, position, reason);
+        ArchiveTracing.traceRecordingSessionStateChange(oldState, newState, recordingId, position, reason);
     }
 }

--- a/aeron-archive/src/main/java/io/aeron/archive/ReplaySession.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ReplaySession.java
@@ -21,7 +21,7 @@ import io.aeron.Publication;
 import io.aeron.archive.checksum.Checksum;
 import io.aeron.archive.client.AeronArchive;
 import io.aeron.archive.client.ArchiveException;
-import io.aeron.archive.logging.ArchiveLog;
+import io.aeron.archive.logging.ArchiveTracing;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import org.agrona.CloseHelper;
 import org.agrona.concurrent.CachedEpochClock;
@@ -297,7 +297,7 @@ class ReplaySession implements Session, AutoCloseable
     @SuppressWarnings("unused")
     void onPendingError(final long sessionId, final long recordingId, final String errorMessage)
     {
-        ArchiveLog.logReplaySessionError(sessionId, recordingId, errorMessage);
+        ArchiveTracing.traceReplaySessionError(sessionId, recordingId, errorMessage);
     }
 
     private int init() throws IOException
@@ -648,7 +648,7 @@ class ReplaySession implements Session, AutoCloseable
         final long position,
         final String reason)
     {
-        ArchiveLog.logReplaySessionStateChange(oldState, newState, sessionId, recordingId, position, reason);
+        ArchiveTracing.traceReplaySessionStateChange(oldState, newState, sessionId, recordingId, position, reason);
     }
 
     static boolean isInvalidHeader(

--- a/aeron-archive/src/main/java/io/aeron/archive/ReplicationSession.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ReplicationSession.java
@@ -32,7 +32,7 @@ import io.aeron.archive.client.ReplayParams;
 import io.aeron.archive.codecs.ControlResponseCode;
 import io.aeron.archive.codecs.RecordingSignal;
 import io.aeron.archive.codecs.SourceLocation;
-import io.aeron.archive.logging.ArchiveLog;
+import io.aeron.archive.logging.ArchiveTracing;
 import io.aeron.exceptions.AeronException;
 import io.aeron.exceptions.TimeoutException;
 import org.agrona.CloseHelper;
@@ -1010,7 +1010,7 @@ class ReplicationSession implements Session, RecordingDescriptorConsumer
         final long position,
         final String reason)
     {
-        ArchiveLog.logReplicationSessionStateChange(
+        ArchiveTracing.traceReplicationSessionStateChange(
             oldState, newState, replicationId, srcRecordingId, dstRecordingId, position, reason);
     }
 
@@ -1027,7 +1027,7 @@ class ReplicationSession implements Session, RecordingDescriptorConsumer
         final boolean isEndOfStream,
         final boolean isSynced)
     {
-        ArchiveLog.logReplicationSessionDone(
+        ArchiveTracing.traceReplicationSessionDone(
             controlSessionId,
             replicationId,
             srcRecordingId,

--- a/aeron-archive/src/main/java/io/aeron/archive/client/PersistentSubscription.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/client/PersistentSubscription.java
@@ -28,7 +28,7 @@ import io.aeron.ImageControlledFragmentAssembler;
 import io.aeron.ImageFragmentAssembler;
 import io.aeron.RethrowingErrorHandler;
 import io.aeron.Subscription;
-import io.aeron.archive.logging.ArchiveLog;
+import io.aeron.archive.logging.ArchiveTracing;
 import io.aeron.archive.codecs.ControlResponseCode;
 import io.aeron.exceptions.AeronEvent;
 import io.aeron.exceptions.ConcurrentConcludeException;
@@ -1370,7 +1370,7 @@ public final class PersistentSubscription implements AutoCloseable
         final String liveChannel,
         final int liveStreamId)
     {
-        ArchiveLog.logPersistentSubscriptionStateChange(
+        ArchiveTracing.tracePersistentSubscriptionStateChange(
             oldState, newState, recordingId, replayChannel, replayStreamId, liveChannel, liveStreamId);
     }
 
@@ -1383,7 +1383,7 @@ public final class PersistentSubscription implements AutoCloseable
         final int liveSessionId,
         final long joinPosition)
     {
-        ArchiveLog.logPersistentSubscriptionJoinedLive(
+        ArchiveTracing.tracePersistentSubscriptionJoinedLive(
             recordingId, replayChannel, replayStreamId, liveChannel, liveStreamId, liveSessionId, joinPosition);
     }
 
@@ -1395,7 +1395,7 @@ public final class PersistentSubscription implements AutoCloseable
         final int liveStreamId,
         final long livePosition)
     {
-        ArchiveLog.logPersistentSubscriptionLeftLive(
+        ArchiveTracing.tracePersistentSubscriptionLeftLive(
             recordingId, replayChannel, replayStreamId, liveChannel, liveStreamId, livePosition);
     }
 

--- a/aeron-archive/src/main/java/io/aeron/archive/logging/ArchiveEventLogger.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/logging/ArchiveEventLogger.java
@@ -48,7 +48,7 @@ public interface ArchiveEventLogger
 
     /**
      * Set of event codes that represent an incoming control request, i.e. everything a caller resolving a control
-     * request's event code (see {@code ArchiveLog#logControlRequest}) may be asked to log.
+     * request's event code (see {@code ArchiveTracing#traceControlRequest}) may be asked to log.
      */
     EnumSet<ArchiveEventCode> CONTROL_REQUEST_EVENTS = complementOf(of(
         CMD_OUT_RESPONSE,

--- a/aeron-archive/src/main/java/io/aeron/archive/logging/ArchiveTracer.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/logging/ArchiveTracer.java
@@ -39,12 +39,12 @@ import static java.util.EnumSet.of;
  * {@link LoggerMethod}-annotated methods below.
  */
 @GeneratedLogger(eventCodeType = "io.aeron.archive.logging.ArchiveEventCode")
-public interface ArchiveEventLogger
+public interface ArchiveTracer
 {
     /**
      * Logger for writing into the {@link ManyToOneRingBuffer} held by {@link EventConfiguration#eventReader}.
      */
-    ArchiveEventLogger LOGGER = new CborArchiveEventLogger(eventReader().ringBuffer());
+    ArchiveTracer LOGGER = new CborArchiveTracer(eventReader().ringBuffer());
 
     /**
      * Set of event codes that represent an incoming control request, i.e. everything a caller resolving a control

--- a/aeron-archive/src/main/java/io/aeron/archive/logging/ArchiveTracer.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/logging/ArchiveTracer.java
@@ -44,7 +44,7 @@ public interface ArchiveTracer
     /**
      * Logger for writing into the {@link ManyToOneRingBuffer} held by {@link EventConfiguration#eventReader}.
      */
-    ArchiveTracer LOGGER = new CborArchiveTracer(eventReader().ringBuffer());
+    ArchiveTracer TRACER = new CborArchiveTracer(eventReader().ringBuffer());
 
     /**
      * Set of event codes that represent an incoming control request, i.e. everything a caller resolving a control

--- a/aeron-archive/src/main/java/io/aeron/archive/logging/ArchiveTracer.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/logging/ArchiveTracer.java
@@ -74,7 +74,7 @@ public interface ArchiveTracer
      * @param messageLength of the encoded event.
      */
     @LoggerMethod(bufferView = { "buffer", "offset", "messageLength" })
-    default void logControlRequest(
+    default void traceControlRequest(
         final ArchiveEventCode eventCode,
         @Tag(AERON_ARCHIVE_ADMIN_TAG) @AllowTruncate final DirectBuffer buffer,
         final int offset,
@@ -90,7 +90,7 @@ public interface ArchiveTracer
      * @param messageLength of the response in the buffer.
      */
     @LoggerMethod(eventCode = "CMD_OUT_RESPONSE", bufferView = { "buffer", "offset", "messageLength" })
-    default void logControlResponse(
+    default void traceControlResponse(
         @Tag(AERON_ARCHIVE_ADMIN_TAG) @AllowTruncate final DirectBuffer buffer,
         final int offset,
         final int messageLength)
@@ -105,7 +105,7 @@ public interface ArchiveTracer
      * @param messageLength of the response in the buffer.
      */
     @LoggerMethod(eventCode = "RECORDING_SIGNAL", bufferView = { "buffer", "offset", "messageLength" })
-    default void logRecordingSignal(
+    default void traceRecordingSignal(
         @Tag(AERON_ARCHIVE_ADMIN_TAG) @AllowTruncate final DirectBuffer buffer,
         final int offset,
         final int messageLength)
@@ -125,7 +125,7 @@ public interface ArchiveTracer
      * @param reason      a string indicating the reason for the state change.
      */
     @LoggerMethod(eventCode = "REPLAY_SESSION_STATE_CHANGE")
-    default <E extends Enum<E>> void logReplaySessionStateChange(
+    default <E extends Enum<E>> void traceReplaySessionStateChange(
         final E oldState,
         final E newState,
         final long sessionId,
@@ -148,7 +148,7 @@ public interface ArchiveTracer
      * @param liveStreamId   the live stream id used by the {@link PersistentSubscription}.
      */
     @LoggerMethod(eventCode = "PERSISTENT_SUBSCRIPTION_STATE_CHANGE")
-    default <E extends Enum<E>> void logPersistentSubscriptionStateChange(
+    default <E extends Enum<E>> void tracePersistentSubscriptionStateChange(
         final E oldState,
         final E newState,
         final long recordingId,
@@ -171,7 +171,7 @@ public interface ArchiveTracer
      * @param joinPosition   the position the {@link PersistentSubscription} joined the live stream at.
      */
     @LoggerMethod(eventCode = "PERSISTENT_SUBSCRIPTION_JOINED_LIVE")
-    default void logPersistentSubscriptionJoinedLive(
+    default void tracePersistentSubscriptionJoinedLive(
         final long recordingId,
         final String replayChannel,
         final int replayStreamId,
@@ -193,7 +193,7 @@ public interface ArchiveTracer
      * @param livePosition   the live position when the {@link PersistentSubscription} left.
      */
     @LoggerMethod(eventCode = "PERSISTENT_SUBSCRIPTION_LEFT_LIVE")
-    default void logPersistentSubscriptionLeftLive(
+    default void tracePersistentSubscriptionLeftLive(
         final long recordingId,
         final String replayChannel,
         final int replayStreamId,
@@ -215,7 +215,7 @@ public interface ArchiveTracer
      * @param reason      a string indicating the reason for the state change.
      */
     @LoggerMethod(eventCode = "RECORDING_SESSION_STATE_CHANGE")
-    default <E extends Enum<E>> void logRecordingSessionStateChange(
+    default <E extends Enum<E>> void traceRecordingSessionStateChange(
         final E oldState,
         final E newState,
         final long recordingId,
@@ -238,7 +238,7 @@ public interface ArchiveTracer
      * @param reason         a string indicating the reason for the state change.
      */
     @LoggerMethod(eventCode = "REPLICATION_SESSION_STATE_CHANGE")
-    default <E extends Enum<E>> void logReplicationSessionStateChange(
+    default <E extends Enum<E>> void traceReplicationSessionStateChange(
         final E oldState,
         final E newState,
         final long replicationId,
@@ -259,7 +259,7 @@ public interface ArchiveTracer
      * @param reason           a string indicating the reason for the state change.
      */
     @LoggerMethod(eventCode = "CONTROL_SESSION_STATE_CHANGE")
-    default <E extends Enum<E>> void logControlSessionStateChange(
+    default <E extends Enum<E>> void traceControlSessionStateChange(
         final E oldState,
         final E newState,
         final long controlSessionId,
@@ -284,7 +284,7 @@ public interface ArchiveTracer
      *                         recording.
      */
     @LoggerMethod(eventCode = "REPLICATION_SESSION_DONE")
-    default void logReplicationSessionDone(
+    default void traceReplicationSessionDone(
         final long controlSessionId,
         final long replicationId,
         final long srcRecordingId,
@@ -307,7 +307,7 @@ public interface ArchiveTracer
      * @param errorMessage which resulted.
      */
     @LoggerMethod(eventCode = "REPLAY_SESSION_ERROR")
-    default void logReplaySessionError(final long sessionId, final long recordingId, final String errorMessage)
+    default void traceReplaySessionError(final long sessionId, final long recordingId, final String errorMessage)
     {
     }
 
@@ -318,7 +318,7 @@ public interface ArchiveTracer
      * @param newCatalogLength after the resize.
      */
     @LoggerMethod(eventCode = "CATALOG_RESIZE")
-    default void logCatalogResize(final long oldCatalogLength, final long newCatalogLength)
+    default void traceCatalogResize(final long oldCatalogLength, final long newCatalogLength)
     {
     }
 
@@ -328,7 +328,7 @@ public interface ArchiveTracer
      * @param version   of the archive.
      */
     @LoggerMethod(eventCode = "START")
-    default void logStart(final String version)
+    default void traceStart(final String version)
     {
 
     }

--- a/aeron-archive/src/main/java/io/aeron/archive/logging/ArchiveTracing.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/logging/ArchiveTracing.java
@@ -62,7 +62,7 @@ public final class ArchiveTracing
     }
 
     private static final boolean TRACE_ANY_CONTROL_REQUEST_ENABLED =
-        ArchiveEventLogger.CONTROL_REQUEST_EVENTS.stream().anyMatch(ArchiveTracing::isEnabled);
+        ArchiveTracer.CONTROL_REQUEST_EVENTS.stream().anyMatch(ArchiveTracing::isEnabled);
     private static final boolean TRACE_CONTROL_RESPONSE_ENABLED = isEnabled(ArchiveEventCode.CMD_OUT_RESPONSE);
     private static final boolean TRACE_RECORDING_SIGNAL_ENABLED = isEnabled(ArchiveEventCode.RECORDING_SIGNAL);
     private static final boolean TRACE_REPLAY_SESSION_STATE_CHANGE_ENABLED =
@@ -119,7 +119,7 @@ public final class ArchiveTracing
         final ArchiveEventCode eventCode = ArchiveEventCode.getByTemplateId(messageHeaderDecoder.templateId());
         if (isEnabled(eventCode))
         {
-            ArchiveEventLogger.LOGGER.logControlRequest(eventCode, buffer, offset, length);
+            ArchiveTracer.LOGGER.logControlRequest(eventCode, buffer, offset, length);
         }
     }
 
@@ -137,7 +137,7 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveEventLogger.LOGGER.logControlResponse(buffer, offset, length);
+        ArchiveTracer.LOGGER.logControlResponse(buffer, offset, length);
     }
 
     /**
@@ -154,7 +154,7 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveEventLogger.LOGGER.logRecordingSignal(buffer, offset, length);
+        ArchiveTracer.LOGGER.logRecordingSignal(buffer, offset, length);
     }
 
     /**
@@ -181,7 +181,7 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveEventLogger.LOGGER.logReplaySessionStateChange(oldState, newState, sessionId, recordingId,
+        ArchiveTracer.LOGGER.logReplaySessionStateChange(oldState, newState, sessionId, recordingId,
             position, reason);
     }
 
@@ -199,7 +199,7 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveEventLogger.LOGGER.logReplaySessionError(sessionId, recordingId, errorMessage);
+        ArchiveTracer.LOGGER.logReplaySessionError(sessionId, recordingId, errorMessage);
     }
 
     /**
@@ -224,7 +224,7 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveEventLogger.LOGGER.logRecordingSessionStateChange(oldState, newState, recordingId, position, reason);
+        ArchiveTracer.LOGGER.logRecordingSessionStateChange(oldState, newState, recordingId, position, reason);
     }
 
     /**
@@ -253,7 +253,7 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveEventLogger.LOGGER.logReplicationSessionStateChange(
+        ArchiveTracer.LOGGER.logReplicationSessionStateChange(
             oldState, newState, replicationId, srcRecordingId, dstRecordingId, position, reason);
     }
 
@@ -291,7 +291,7 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveEventLogger.LOGGER.logReplicationSessionDone(
+        ArchiveTracer.LOGGER.logReplicationSessionDone(
             controlSessionId,
             replicationId,
             srcRecordingId,
@@ -325,7 +325,7 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveEventLogger.LOGGER.logControlSessionStateChange(oldState, newState, controlSessionId, reason);
+        ArchiveTracer.LOGGER.logControlSessionStateChange(oldState, newState, controlSessionId, reason);
     }
 
     /**
@@ -341,7 +341,7 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveEventLogger.LOGGER.logCatalogResize(oldCatalogLength, newCatalogLength);
+        ArchiveTracer.LOGGER.logCatalogResize(oldCatalogLength, newCatalogLength);
     }
 
     /**
@@ -370,7 +370,7 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveEventLogger.LOGGER.logPersistentSubscriptionStateChange(
+        ArchiveTracer.LOGGER.logPersistentSubscriptionStateChange(
             oldState, newState, recordingId, replayChannel, replayStreamId, liveChannel, liveStreamId);
     }
 
@@ -400,7 +400,7 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveEventLogger.LOGGER.logPersistentSubscriptionJoinedLive(
+        ArchiveTracer.LOGGER.logPersistentSubscriptionJoinedLive(
             recordingId, replayChannel, replayStreamId, liveChannel, liveStreamId, liveSessionId, joinPosition);
     }
 
@@ -427,7 +427,7 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveEventLogger.LOGGER.logPersistentSubscriptionLeftLive(
+        ArchiveTracer.LOGGER.logPersistentSubscriptionLeftLive(
             recordingId, replayChannel, replayStreamId, liveChannel, liveStreamId, livePosition);
     }
 
@@ -443,6 +443,6 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveEventLogger.LOGGER.logStart(version);
+        ArchiveTracer.LOGGER.logStart(version);
     }
 }

--- a/aeron-archive/src/main/java/io/aeron/archive/logging/ArchiveTracing.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/logging/ArchiveTracing.java
@@ -119,7 +119,7 @@ public final class ArchiveTracing
         final ArchiveEventCode eventCode = ArchiveEventCode.getByTemplateId(messageHeaderDecoder.templateId());
         if (isEnabled(eventCode))
         {
-            ArchiveTracer.LOGGER.logControlRequest(eventCode, buffer, offset, length);
+            ArchiveTracer.TRACER.logControlRequest(eventCode, buffer, offset, length);
         }
     }
 
@@ -137,7 +137,7 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveTracer.LOGGER.logControlResponse(buffer, offset, length);
+        ArchiveTracer.TRACER.logControlResponse(buffer, offset, length);
     }
 
     /**
@@ -154,7 +154,7 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveTracer.LOGGER.logRecordingSignal(buffer, offset, length);
+        ArchiveTracer.TRACER.logRecordingSignal(buffer, offset, length);
     }
 
     /**
@@ -181,7 +181,7 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveTracer.LOGGER.logReplaySessionStateChange(oldState, newState, sessionId, recordingId,
+        ArchiveTracer.TRACER.logReplaySessionStateChange(oldState, newState, sessionId, recordingId,
             position, reason);
     }
 
@@ -199,7 +199,7 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveTracer.LOGGER.logReplaySessionError(sessionId, recordingId, errorMessage);
+        ArchiveTracer.TRACER.logReplaySessionError(sessionId, recordingId, errorMessage);
     }
 
     /**
@@ -224,7 +224,7 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveTracer.LOGGER.logRecordingSessionStateChange(oldState, newState, recordingId, position, reason);
+        ArchiveTracer.TRACER.logRecordingSessionStateChange(oldState, newState, recordingId, position, reason);
     }
 
     /**
@@ -253,7 +253,7 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveTracer.LOGGER.logReplicationSessionStateChange(
+        ArchiveTracer.TRACER.logReplicationSessionStateChange(
             oldState, newState, replicationId, srcRecordingId, dstRecordingId, position, reason);
     }
 
@@ -291,7 +291,7 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveTracer.LOGGER.logReplicationSessionDone(
+        ArchiveTracer.TRACER.logReplicationSessionDone(
             controlSessionId,
             replicationId,
             srcRecordingId,
@@ -325,7 +325,7 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveTracer.LOGGER.logControlSessionStateChange(oldState, newState, controlSessionId, reason);
+        ArchiveTracer.TRACER.logControlSessionStateChange(oldState, newState, controlSessionId, reason);
     }
 
     /**
@@ -341,7 +341,7 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveTracer.LOGGER.logCatalogResize(oldCatalogLength, newCatalogLength);
+        ArchiveTracer.TRACER.logCatalogResize(oldCatalogLength, newCatalogLength);
     }
 
     /**
@@ -370,7 +370,7 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveTracer.LOGGER.logPersistentSubscriptionStateChange(
+        ArchiveTracer.TRACER.logPersistentSubscriptionStateChange(
             oldState, newState, recordingId, replayChannel, replayStreamId, liveChannel, liveStreamId);
     }
 
@@ -400,7 +400,7 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveTracer.LOGGER.logPersistentSubscriptionJoinedLive(
+        ArchiveTracer.TRACER.logPersistentSubscriptionJoinedLive(
             recordingId, replayChannel, replayStreamId, liveChannel, liveStreamId, liveSessionId, joinPosition);
     }
 
@@ -427,7 +427,7 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveTracer.LOGGER.logPersistentSubscriptionLeftLive(
+        ArchiveTracer.TRACER.logPersistentSubscriptionLeftLive(
             recordingId, replayChannel, replayStreamId, liveChannel, liveStreamId, livePosition);
     }
 
@@ -443,6 +443,6 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveTracer.LOGGER.logStart(version);
+        ArchiveTracer.TRACER.logStart(version);
     }
 }

--- a/aeron-archive/src/main/java/io/aeron/archive/logging/ArchiveTracing.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/logging/ArchiveTracing.java
@@ -27,7 +27,7 @@ import java.util.Set;
 /**
  * Facade used to log Archive events directly, without requiring the ByteBuddy Java agent to be attached.
  */
-public final class ArchiveLog
+public final class ArchiveTracing
 {
     private static final ThreadLocal<MessageHeaderDecoder> HEADER_DECODER = ThreadLocal.withInitial(
         MessageHeaderDecoder::new);
@@ -62,7 +62,7 @@ public final class ArchiveLog
     }
 
     private static final boolean LOG_ANY_CONTROL_REQUEST_ENABLED =
-        ArchiveEventLogger.CONTROL_REQUEST_EVENTS.stream().anyMatch(ArchiveLog::isEnabled);
+        ArchiveEventLogger.CONTROL_REQUEST_EVENTS.stream().anyMatch(ArchiveTracing::isEnabled);
     private static final boolean LOG_CONTROL_RESPONSE_ENABLED = isEnabled(ArchiveEventCode.CMD_OUT_RESPONSE);
     private static final boolean LOG_RECORDING_SIGNAL_ENABLED = isEnabled(ArchiveEventCode.RECORDING_SIGNAL);
     private static final boolean LOG_REPLAY_SESSION_STATE_CHANGE_ENABLED =
@@ -86,7 +86,7 @@ public final class ArchiveLog
         isEnabled(ArchiveEventCode.PERSISTENT_SUBSCRIPTION_LEFT_LIVE);
     private static final boolean LOG_START = !ENABLED_EVENT_CODES.isEmpty();
 
-    private ArchiveLog()
+    private ArchiveTracing()
     {
     }
 
@@ -108,7 +108,7 @@ public final class ArchiveLog
      * @param offset in the buffer at which the request begins.
      * @param length of the request in the buffer.
      */
-    public static void logControlRequest(final DirectBuffer buffer, final int offset, final int length)
+    public static void traceControlRequest(final DirectBuffer buffer, final int offset, final int length)
     {
         if (!LOG_ANY_CONTROL_REQUEST_ENABLED)
         {
@@ -130,7 +130,7 @@ public final class ArchiveLog
      * @param offset at which response message begins.
      * @param length of the response in the buffer.
      */
-    public static void logControlResponse(final DirectBuffer buffer, final int offset, final int length)
+    public static void traceControlResponse(final DirectBuffer buffer, final int offset, final int length)
     {
         if (!LOG_CONTROL_RESPONSE_ENABLED)
         {
@@ -147,7 +147,7 @@ public final class ArchiveLog
      * @param offset at which response message begins.
      * @param length of the response in the buffer.
      */
-    public static void logRecordingSignal(final DirectBuffer buffer, final int offset, final int length)
+    public static void traceRecordingSignal(final DirectBuffer buffer, final int offset, final int length)
     {
         if (!LOG_RECORDING_SIGNAL_ENABLED)
         {
@@ -168,7 +168,7 @@ public final class ArchiveLog
      * @param position    position of state change.
      * @param reason      a string indicating the reason for the state change.
      */
-    public static <E extends Enum<E>> void logReplaySessionStateChange(
+    public static <E extends Enum<E>> void traceReplaySessionStateChange(
         final E oldState,
         final E newState,
         final long sessionId,
@@ -192,7 +192,7 @@ public final class ArchiveLog
      * @param recordingId  to which the error applies.
      * @param errorMessage which resulted.
      */
-    public static void logReplaySessionError(final long sessionId, final long recordingId, final String errorMessage)
+    public static void traceReplaySessionError(final long sessionId, final long recordingId, final String errorMessage)
     {
         if (!LOG_REPLAY_SESSION_ERROR_ENABLED)
         {
@@ -212,7 +212,7 @@ public final class ArchiveLog
      * @param position    position of state change.
      * @param reason      a string indicating the reason for the state change.
      */
-    public static <E extends Enum<E>> void logRecordingSessionStateChange(
+    public static <E extends Enum<E>> void traceRecordingSessionStateChange(
         final E oldState,
         final E newState,
         final long recordingId,
@@ -239,7 +239,7 @@ public final class ArchiveLog
      * @param position       position of state change.
      * @param reason         a string indicating the reason for the state change.
      */
-    public static <E extends Enum<E>> void logReplicationSessionStateChange(
+    public static <E extends Enum<E>> void traceReplicationSessionStateChange(
         final E oldState,
         final E newState,
         final long replicationId,
@@ -273,7 +273,7 @@ public final class ArchiveLog
      * @param isSynced         has the destination recording position reached the stop position of the source
      *                         recording.
      */
-    public static void logReplicationSessionDone(
+    public static void traceReplicationSessionDone(
         final long controlSessionId,
         final long replicationId,
         final long srcRecordingId,
@@ -314,7 +314,7 @@ public final class ArchiveLog
      * @param controlSessionId identity for the control session on the Archive.
      * @param reason           a string indicating the reason for the state change.
      */
-    public static <E extends Enum<E>> void logControlSessionStateChange(
+    public static <E extends Enum<E>> void traceControlSessionStateChange(
         final E oldState,
         final E newState,
         final long controlSessionId,
@@ -334,7 +334,7 @@ public final class ArchiveLog
      * @param oldCatalogLength before the resize.
      * @param newCatalogLength after the resize.
      */
-    public static void logCatalogResize(final long oldCatalogLength, final long newCatalogLength)
+    public static void traceCatalogResize(final long oldCatalogLength, final long newCatalogLength)
     {
         if (!LOG_CATALOG_RESIZE_ENABLED)
         {
@@ -356,7 +356,7 @@ public final class ArchiveLog
      * @param liveChannel    the live channel used by the {@link io.aeron.archive.client.PersistentSubscription}.
      * @param liveStreamId   the live stream id used by the {@link io.aeron.archive.client.PersistentSubscription}.
      */
-    public static <E extends Enum<E>> void logPersistentSubscriptionStateChange(
+    public static <E extends Enum<E>> void tracePersistentSubscriptionStateChange(
         final E oldState,
         final E newState,
         final long recordingId,
@@ -386,7 +386,7 @@ public final class ArchiveLog
      * @param joinPosition   the position the {@link io.aeron.archive.client.PersistentSubscription} joined the
      *                       live stream at.
      */
-    public static void logPersistentSubscriptionJoinedLive(
+    public static void tracePersistentSubscriptionJoinedLive(
         final long recordingId,
         final String replayChannel,
         final int replayStreamId,
@@ -414,7 +414,7 @@ public final class ArchiveLog
      * @param liveStreamId   the live stream id used by the {@link io.aeron.archive.client.PersistentSubscription}.
      * @param livePosition   the live position when the {@link io.aeron.archive.client.PersistentSubscription} left.
      */
-    public static void logPersistentSubscriptionLeftLive(
+    public static void tracePersistentSubscriptionLeftLive(
         final long recordingId,
         final String replayChannel,
         final int replayStreamId,
@@ -436,7 +436,7 @@ public final class ArchiveLog
      *
      * @param version   of the archive.
      */
-    public static void logStart(final String version)
+    public static void traceStart(final String version)
     {
         if (!LOG_START)
         {

--- a/aeron-archive/src/main/java/io/aeron/archive/logging/ArchiveTracing.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/logging/ArchiveTracing.java
@@ -119,7 +119,7 @@ public final class ArchiveTracing
         final ArchiveEventCode eventCode = ArchiveEventCode.getByTemplateId(messageHeaderDecoder.templateId());
         if (isEnabled(eventCode))
         {
-            ArchiveTracer.TRACER.logControlRequest(eventCode, buffer, offset, length);
+            ArchiveTracer.TRACER.traceControlRequest(eventCode, buffer, offset, length);
         }
     }
 
@@ -137,7 +137,7 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveTracer.TRACER.logControlResponse(buffer, offset, length);
+        ArchiveTracer.TRACER.traceControlResponse(buffer, offset, length);
     }
 
     /**
@@ -154,7 +154,7 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveTracer.TRACER.logRecordingSignal(buffer, offset, length);
+        ArchiveTracer.TRACER.traceRecordingSignal(buffer, offset, length);
     }
 
     /**
@@ -181,7 +181,7 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveTracer.TRACER.logReplaySessionStateChange(oldState, newState, sessionId, recordingId,
+        ArchiveTracer.TRACER.traceReplaySessionStateChange(oldState, newState, sessionId, recordingId,
             position, reason);
     }
 
@@ -199,7 +199,7 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveTracer.TRACER.logReplaySessionError(sessionId, recordingId, errorMessage);
+        ArchiveTracer.TRACER.traceReplaySessionError(sessionId, recordingId, errorMessage);
     }
 
     /**
@@ -224,7 +224,7 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveTracer.TRACER.logRecordingSessionStateChange(oldState, newState, recordingId, position, reason);
+        ArchiveTracer.TRACER.traceRecordingSessionStateChange(oldState, newState, recordingId, position, reason);
     }
 
     /**
@@ -253,7 +253,7 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveTracer.TRACER.logReplicationSessionStateChange(
+        ArchiveTracer.TRACER.traceReplicationSessionStateChange(
             oldState, newState, replicationId, srcRecordingId, dstRecordingId, position, reason);
     }
 
@@ -291,7 +291,7 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveTracer.TRACER.logReplicationSessionDone(
+        ArchiveTracer.TRACER.traceReplicationSessionDone(
             controlSessionId,
             replicationId,
             srcRecordingId,
@@ -325,7 +325,7 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveTracer.TRACER.logControlSessionStateChange(oldState, newState, controlSessionId, reason);
+        ArchiveTracer.TRACER.traceControlSessionStateChange(oldState, newState, controlSessionId, reason);
     }
 
     /**
@@ -341,7 +341,7 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveTracer.TRACER.logCatalogResize(oldCatalogLength, newCatalogLength);
+        ArchiveTracer.TRACER.traceCatalogResize(oldCatalogLength, newCatalogLength);
     }
 
     /**
@@ -370,7 +370,7 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveTracer.TRACER.logPersistentSubscriptionStateChange(
+        ArchiveTracer.TRACER.tracePersistentSubscriptionStateChange(
             oldState, newState, recordingId, replayChannel, replayStreamId, liveChannel, liveStreamId);
     }
 
@@ -400,7 +400,7 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveTracer.TRACER.logPersistentSubscriptionJoinedLive(
+        ArchiveTracer.TRACER.tracePersistentSubscriptionJoinedLive(
             recordingId, replayChannel, replayStreamId, liveChannel, liveStreamId, liveSessionId, joinPosition);
     }
 
@@ -427,7 +427,7 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveTracer.TRACER.logPersistentSubscriptionLeftLive(
+        ArchiveTracer.TRACER.tracePersistentSubscriptionLeftLive(
             recordingId, replayChannel, replayStreamId, liveChannel, liveStreamId, livePosition);
     }
 
@@ -443,6 +443,6 @@ public final class ArchiveTracing
             return;
         }
 
-        ArchiveTracer.TRACER.logStart(version);
+        ArchiveTracer.TRACER.traceStart(version);
     }
 }

--- a/aeron-archive/src/main/java/io/aeron/archive/logging/ArchiveTracing.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/logging/ArchiveTracing.java
@@ -61,30 +61,30 @@ public final class ArchiveTracing
         ENABLED_EVENT_CODES = Collections.unmodifiableSet(enabledEventCodeSet);
     }
 
-    private static final boolean LOG_ANY_CONTROL_REQUEST_ENABLED =
+    private static final boolean TRACE_ANY_CONTROL_REQUEST_ENABLED =
         ArchiveEventLogger.CONTROL_REQUEST_EVENTS.stream().anyMatch(ArchiveTracing::isEnabled);
-    private static final boolean LOG_CONTROL_RESPONSE_ENABLED = isEnabled(ArchiveEventCode.CMD_OUT_RESPONSE);
-    private static final boolean LOG_RECORDING_SIGNAL_ENABLED = isEnabled(ArchiveEventCode.RECORDING_SIGNAL);
-    private static final boolean LOG_REPLAY_SESSION_STATE_CHANGE_ENABLED =
+    private static final boolean TRACE_CONTROL_RESPONSE_ENABLED = isEnabled(ArchiveEventCode.CMD_OUT_RESPONSE);
+    private static final boolean TRACE_RECORDING_SIGNAL_ENABLED = isEnabled(ArchiveEventCode.RECORDING_SIGNAL);
+    private static final boolean TRACE_REPLAY_SESSION_STATE_CHANGE_ENABLED =
         isEnabled(ArchiveEventCode.REPLAY_SESSION_STATE_CHANGE);
-    private static final boolean LOG_REPLAY_SESSION_ERROR_ENABLED =
+    private static final boolean TRACE_REPLAY_SESSION_ERROR_ENABLED =
         isEnabled(ArchiveEventCode.REPLAY_SESSION_ERROR);
-    private static final boolean LOG_RECORDING_SESSION_STATE_CHANGE_ENABLED =
+    private static final boolean TRACE_RECORDING_SESSION_STATE_CHANGE_ENABLED =
         isEnabled(ArchiveEventCode.RECORDING_SESSION_STATE_CHANGE);
-    private static final boolean LOG_REPLICATION_SESSION_STATE_CHANGE_ENABLED =
+    private static final boolean TRACE_REPLICATION_SESSION_STATE_CHANGE_ENABLED =
         isEnabled(ArchiveEventCode.REPLICATION_SESSION_STATE_CHANGE);
-    private static final boolean LOG_REPLICATION_SESSION_DONE_ENABLED =
+    private static final boolean TRACE_REPLICATION_SESSION_DONE_ENABLED =
         isEnabled(ArchiveEventCode.REPLICATION_SESSION_DONE);
-    private static final boolean LOG_CONTROL_SESSION_STATE_CHANGE_ENABLED =
+    private static final boolean TRACE_CONTROL_SESSION_STATE_CHANGE_ENABLED =
         isEnabled(ArchiveEventCode.CONTROL_SESSION_STATE_CHANGE);
-    private static final boolean LOG_CATALOG_RESIZE_ENABLED = isEnabled(ArchiveEventCode.CATALOG_RESIZE);
-    private static final boolean LOG_PERSISTENT_SUBSCRIPTION_STATE_CHANGE_ENABLED =
+    private static final boolean TRACE_CATALOG_RESIZE_ENABLED = isEnabled(ArchiveEventCode.CATALOG_RESIZE);
+    private static final boolean TRACE_PERSISTENT_SUBSCRIPTION_STATE_CHANGE_ENABLED =
         isEnabled(ArchiveEventCode.PERSISTENT_SUBSCRIPTION_STATE_CHANGE);
-    private static final boolean LOG_PERSISTENT_SUBSCRIPTION_JOINED_LIVE_ENABLED =
+    private static final boolean TRACE_PERSISTENT_SUBSCRIPTION_JOINED_LIVE_ENABLED =
         isEnabled(ArchiveEventCode.PERSISTENT_SUBSCRIPTION_JOINED_LIVE);
-    private static final boolean LOG_PERSISTENT_SUBSCRIPTION_LEFT_LIVE_ENABLED =
+    private static final boolean TRACE_PERSISTENT_SUBSCRIPTION_LEFT_LIVE_ENABLED =
         isEnabled(ArchiveEventCode.PERSISTENT_SUBSCRIPTION_LEFT_LIVE);
-    private static final boolean LOG_START = !ENABLED_EVENT_CODES.isEmpty();
+    private static final boolean TRACE_START = !ENABLED_EVENT_CODES.isEmpty();
 
     private ArchiveTracing()
     {
@@ -110,7 +110,7 @@ public final class ArchiveTracing
      */
     public static void traceControlRequest(final DirectBuffer buffer, final int offset, final int length)
     {
-        if (!LOG_ANY_CONTROL_REQUEST_ENABLED)
+        if (!TRACE_ANY_CONTROL_REQUEST_ENABLED)
         {
             return;
         }
@@ -132,7 +132,7 @@ public final class ArchiveTracing
      */
     public static void traceControlResponse(final DirectBuffer buffer, final int offset, final int length)
     {
-        if (!LOG_CONTROL_RESPONSE_ENABLED)
+        if (!TRACE_CONTROL_RESPONSE_ENABLED)
         {
             return;
         }
@@ -149,7 +149,7 @@ public final class ArchiveTracing
      */
     public static void traceRecordingSignal(final DirectBuffer buffer, final int offset, final int length)
     {
-        if (!LOG_RECORDING_SIGNAL_ENABLED)
+        if (!TRACE_RECORDING_SIGNAL_ENABLED)
         {
             return;
         }
@@ -176,7 +176,7 @@ public final class ArchiveTracing
         final long position,
         final String reason)
     {
-        if (!LOG_REPLAY_SESSION_STATE_CHANGE_ENABLED)
+        if (!TRACE_REPLAY_SESSION_STATE_CHANGE_ENABLED)
         {
             return;
         }
@@ -194,7 +194,7 @@ public final class ArchiveTracing
      */
     public static void traceReplaySessionError(final long sessionId, final long recordingId, final String errorMessage)
     {
-        if (!LOG_REPLAY_SESSION_ERROR_ENABLED)
+        if (!TRACE_REPLAY_SESSION_ERROR_ENABLED)
         {
             return;
         }
@@ -219,7 +219,7 @@ public final class ArchiveTracing
         final long position,
         final String reason)
     {
-        if (!LOG_RECORDING_SESSION_STATE_CHANGE_ENABLED)
+        if (!TRACE_RECORDING_SESSION_STATE_CHANGE_ENABLED)
         {
             return;
         }
@@ -248,7 +248,7 @@ public final class ArchiveTracing
         final long position,
         final String reason)
     {
-        if (!LOG_REPLICATION_SESSION_STATE_CHANGE_ENABLED)
+        if (!TRACE_REPLICATION_SESSION_STATE_CHANGE_ENABLED)
         {
             return;
         }
@@ -286,7 +286,7 @@ public final class ArchiveTracing
         final boolean isEndOfStream,
         final boolean isSynced)
     {
-        if (!LOG_REPLICATION_SESSION_DONE_ENABLED)
+        if (!TRACE_REPLICATION_SESSION_DONE_ENABLED)
         {
             return;
         }
@@ -320,7 +320,7 @@ public final class ArchiveTracing
         final long controlSessionId,
         final String reason)
     {
-        if (!LOG_CONTROL_SESSION_STATE_CHANGE_ENABLED)
+        if (!TRACE_CONTROL_SESSION_STATE_CHANGE_ENABLED)
         {
             return;
         }
@@ -336,7 +336,7 @@ public final class ArchiveTracing
      */
     public static void traceCatalogResize(final long oldCatalogLength, final long newCatalogLength)
     {
-        if (!LOG_CATALOG_RESIZE_ENABLED)
+        if (!TRACE_CATALOG_RESIZE_ENABLED)
         {
             return;
         }
@@ -365,7 +365,7 @@ public final class ArchiveTracing
         final String liveChannel,
         final int liveStreamId)
     {
-        if (!LOG_PERSISTENT_SUBSCRIPTION_STATE_CHANGE_ENABLED)
+        if (!TRACE_PERSISTENT_SUBSCRIPTION_STATE_CHANGE_ENABLED)
         {
             return;
         }
@@ -395,7 +395,7 @@ public final class ArchiveTracing
         final int liveSessionId,
         final long joinPosition)
     {
-        if (!LOG_PERSISTENT_SUBSCRIPTION_JOINED_LIVE_ENABLED)
+        if (!TRACE_PERSISTENT_SUBSCRIPTION_JOINED_LIVE_ENABLED)
         {
             return;
         }
@@ -422,7 +422,7 @@ public final class ArchiveTracing
         final int liveStreamId,
         final long livePosition)
     {
-        if (!LOG_PERSISTENT_SUBSCRIPTION_LEFT_LIVE_ENABLED)
+        if (!TRACE_PERSISTENT_SUBSCRIPTION_LEFT_LIVE_ENABLED)
         {
             return;
         }
@@ -438,7 +438,7 @@ public final class ArchiveTracing
      */
     public static void traceStart(final String version)
     {
-        if (!LOG_START)
+        if (!TRACE_START)
         {
             return;
         }

--- a/aeron-archive/src/test/java/io/aeron/archive/logging/ArchiveEventEnablementTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/logging/ArchiveEventEnablementTest.java
@@ -145,17 +145,17 @@ public class ArchiveEventEnablementTest
             if (code.name().startsWith("CMD_IN_"))
             {
                 headerEncoder.wrap(buffer, 0).templateId(code.templateId());
-                ArchiveLog.logControlRequest(buffer, 0, MessageHeaderEncoder.ENCODED_LENGTH);
+                ArchiveTracing.traceControlRequest(buffer, 0, MessageHeaderEncoder.ENCODED_LENGTH);
             }
         }
     }
 
     private void callGeneralLogMethods()
     {
-        final List<Method> logMethods = Arrays.stream(ArchiveLog.class.getMethods())
-            .filter((m) -> m.getName().startsWith("log"))
+        final List<Method> logMethods = Arrays.stream(ArchiveTracing.class.getMethods())
+            .filter((m) -> m.getName().startsWith("trace"))
             .filter((m) -> 0 != (m.getModifiers() & Modifier.STATIC))
-            .filter((m) -> !"logControlRequest".equals(m.getName()))
+            .filter((m) -> !"traceControlRequest".equals(m.getName()))
             .toList();
 
         for (final Method logMethod : logMethods)

--- a/aeron-archive/src/test/java/io/aeron/archive/logging/ArchiveEventLoggerCborImplTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/logging/ArchiveEventLoggerCborImplTest.java
@@ -76,7 +76,7 @@ class ArchiveEventLoggerCborImplTest
         Arrays.fill(subRange, (byte)0xAA);
         final UnsafeBuffer buffer = new UnsafeBuffer(backing);
 
-        logger.logControlRequest(ArchiveEventCode.CMD_IN_AUTH_CONNECT, buffer, 100, 16);
+        logger.traceControlRequest(ArchiveEventCode.CMD_IN_AUTH_CONNECT, buffer, 100, 16);
 
         drain();
 
@@ -97,7 +97,7 @@ class ArchiveEventLoggerCborImplTest
         Arrays.fill(backing, (byte)0x11);
         final UnsafeBuffer buffer = new UnsafeBuffer(backing);
 
-        logger.logControlRequest(ArchiveEventCode.CMD_IN_AUTH_CONNECT, buffer, 0, backing.length);
+        logger.traceControlRequest(ArchiveEventCode.CMD_IN_AUTH_CONNECT, buffer, 0, backing.length);
 
         drain();
 
@@ -113,7 +113,7 @@ class ArchiveEventLoggerCborImplTest
         Arrays.fill(backing, (byte)0x1);
         final UnsafeBuffer buffer = new UnsafeBuffer(backing);
 
-        logger.logControlResponse(buffer, 4, 60);
+        logger.traceControlResponse(buffer, 4, 60);
 
         drain();
 
@@ -136,7 +136,7 @@ class ArchiveEventLoggerCborImplTest
         Arrays.fill(backing, (byte)0x3);
         final UnsafeBuffer buffer = new UnsafeBuffer(backing);
 
-        logger.logRecordingSignal(buffer, 10, 31);
+        logger.traceRecordingSignal(buffer, 10, 31);
 
         drain();
 
@@ -153,7 +153,7 @@ class ArchiveEventLoggerCborImplTest
         final ChronoUnit oldState = ChronoUnit.CENTURIES;
         final ChronoUnit newState = ChronoUnit.MICROS;
 
-        logger.logReplaySessionStateChange(oldState, newState, 111L, 222L, 333L, "a reason");
+        logger.traceReplaySessionStateChange(oldState, newState, 111L, 222L, 333L, "a reason");
 
         drain();
 
@@ -178,7 +178,7 @@ class ArchiveEventLoggerCborImplTest
         final ChronoUnit oldState = ChronoUnit.CENTURIES;
         final ChronoUnit newState = ChronoUnit.MICROS;
 
-        logger.logPersistentSubscriptionStateChange(
+        logger.tracePersistentSubscriptionStateChange(
             oldState, newState, 555L, "replay-channel", 10, "live-channel", 11);
 
         drain();
@@ -197,7 +197,7 @@ class ArchiveEventLoggerCborImplTest
     @Test
     void logPersistentSubscriptionJoinedLive()
     {
-        logger.logPersistentSubscriptionJoinedLive(
+        logger.tracePersistentSubscriptionJoinedLive(
             555L, "replay-channel", 10, "live-channel", 11, 5, 128L);
 
         drain();
@@ -216,7 +216,7 @@ class ArchiveEventLoggerCborImplTest
     @Test
     void logPersistentSubscriptionLeftLive()
     {
-        logger.logPersistentSubscriptionLeftLive(555L, "replay-channel", 10, "live-channel", 11, 256L);
+        logger.tracePersistentSubscriptionLeftLive(555L, "replay-channel", 10, "live-channel", 11, 256L);
 
         drain();
 
@@ -236,7 +236,7 @@ class ArchiveEventLoggerCborImplTest
         final ChronoUnit oldState = ChronoUnit.ERAS;
         final ChronoUnit newState = ChronoUnit.MILLENNIA;
 
-        logger.logRecordingSessionStateChange(oldState, newState, 42L, 84L, "a reason");
+        logger.traceRecordingSessionStateChange(oldState, newState, 42L, 84L, "a reason");
 
         drain();
 
@@ -255,7 +255,7 @@ class ArchiveEventLoggerCborImplTest
         final ChronoUnit oldState = ChronoUnit.ERAS;
         final ChronoUnit newState = ChronoUnit.MILLENNIA;
 
-        logger.logReplicationSessionStateChange(oldState, newState, 1L, 2L, 3L, 4L, "some text goes here");
+        logger.traceReplicationSessionStateChange(oldState, newState, 1L, 2L, 3L, 4L, "some text goes here");
 
         drain();
 
@@ -276,7 +276,7 @@ class ArchiveEventLoggerCborImplTest
         final ChronoUnit oldState = ChronoUnit.CENTURIES;
         final ChronoUnit newState = ChronoUnit.MICROS;
 
-        logger.logControlSessionStateChange(oldState, newState, 555_000_000_000L, "test reason to check");
+        logger.traceControlSessionStateChange(oldState, newState, 555_000_000_000L, "test reason to check");
 
         drain();
 
@@ -291,7 +291,7 @@ class ArchiveEventLoggerCborImplTest
     @Test
     void logReplicationSessionDone()
     {
-        logger.logReplicationSessionDone(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, true, true, false);
+        logger.traceReplicationSessionDone(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, true, true, false);
 
         drain();
 
@@ -313,7 +313,7 @@ class ArchiveEventLoggerCborImplTest
     @Test
     void logReplaySessionError()
     {
-        logger.logReplaySessionError(123L, Long.MIN_VALUE, "the error");
+        logger.traceReplaySessionError(123L, Long.MIN_VALUE, "the error");
 
         drain();
 
@@ -327,7 +327,7 @@ class ArchiveEventLoggerCborImplTest
     @Test
     void logCatalogResize()
     {
-        logger.logCatalogResize(42L, 142L);
+        logger.traceCatalogResize(42L, 142L);
 
         drain();
 

--- a/aeron-archive/src/test/java/io/aeron/archive/logging/ArchiveEventLoggerCborImplTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/logging/ArchiveEventLoggerCborImplTest.java
@@ -51,7 +51,7 @@ class ArchiveEventLoggerCborImplTest
 
     private final LoggerEventCallback mockLoggingCallback = mock(LoggerEventCallback.class);
     private final CborDecode cborDecode = new CborDecode(List.of(new ProxyLoggerEventCallback(mockLoggingCallback)));
-    private final ArchiveEventLogger logger = new CborArchiveEventLogger(ringBuffer);
+    private final ArchiveTracer logger = new CborArchiveTracer(ringBuffer);
 
     private void drain()
     {

--- a/aeron-archive/src/test/java/io/aeron/archive/logging/CborArchiveTracerTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/logging/CborArchiveTracerTest.java
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-class ArchiveEventLoggerCborImplTest
+class CborArchiveTracerTest
 {
     private final ManyToOneRingBuffer ringBuffer = new ManyToOneRingBuffer(
         new UnsafeBuffer(BufferUtil.allocateDirectAligned(64 * 1024 + TRAILER_LENGTH, CACHE_LINE_LENGTH)));

--- a/aeron-archive/src/test/java/io/aeron/archive/logging/GenericLoggingTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/logging/GenericLoggingTest.java
@@ -25,7 +25,7 @@ import static org.agrona.BitUtil.CACHE_LINE_LENGTH;
 import static org.agrona.concurrent.ringbuffer.RingBufferDescriptor.TRAILER_LENGTH;
 
 /**
- * Reflectively drives every {@link ArchiveEventLogger} method with a range of nominal, boundary, and {@code null}
+ * Reflectively drives every {@link ArchiveTracer} method with a range of nominal, boundary, and {@code null}
  * values and verifies (via {@link io.aeron.logging.CborDecode}) that they all survive the CBOR round trip.
  */
 class GenericLoggingTest
@@ -35,8 +35,8 @@ class GenericLoggingTest
     {
         final ManyToOneRingBuffer ringBuffer = new ManyToOneRingBuffer(
             new UnsafeBuffer(BufferUtil.allocateDirectAligned(64 * 1024 + TRAILER_LENGTH, CACHE_LINE_LENGTH)));
-        final ArchiveEventLogger logger = new CborArchiveEventLogger(ringBuffer);
+        final ArchiveTracer logger = new CborArchiveTracer(ringBuffer);
 
-        GenericLoggerEventVerifier.verifyAllLogMethods(ArchiveEventLogger.class, logger, ringBuffer);
+        GenericLoggerEventVerifier.verifyAllLogMethods(ArchiveTracer.class, logger, ringBuffer);
     }
 }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackupAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackupAgent.java
@@ -37,7 +37,7 @@ import io.aeron.cluster.codecs.ChallengeDecoder;
 import io.aeron.cluster.codecs.EventCode;
 import io.aeron.cluster.codecs.MessageHeaderDecoder;
 import io.aeron.cluster.codecs.SessionEventDecoder;
-import io.aeron.cluster.logging.ClusterLog;
+import io.aeron.cluster.logging.ClusterTracing;
 import io.aeron.cluster.service.ClusterMarkFile;
 import io.aeron.exceptions.TimeoutException;
 import io.aeron.logbuffer.Header;
@@ -1046,7 +1046,7 @@ public final class ClusterBackupAgent implements Agent
     private void logStateChange(
         final ClusterBackup.State oldState, final ClusterBackup.State newState, final long nowMs)
     {
-        ClusterLog.logClusterBackupStateChange(oldState, newState);
+        ClusterTracing.traceClusterBackupStateChange(oldState, newState);
     }
 
     private int pollBackupArchiveEvents()

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusterSession.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusterSession.java
@@ -26,7 +26,7 @@ import io.aeron.cluster.client.ClusterEvent;
 import io.aeron.cluster.client.ClusterException;
 import io.aeron.cluster.codecs.CloseReason;
 import io.aeron.cluster.codecs.EventCode;
-import io.aeron.cluster.logging.ClusterLog;
+import io.aeron.cluster.logging.ClusterTracing;
 import io.aeron.cluster.service.ClusterCounters;
 import io.aeron.exceptions.AeronException;
 import io.aeron.exceptions.RegistrationException;
@@ -531,7 +531,7 @@ final class ClusterSession implements ClusterClientSession
         final State newState,
         final String reason)
     {
-        ClusterLog.logClusterSessionStateChange(memberId, sessionId, action, oldState, newState, reason);
+        ClusterTracing.traceClusterSessionStateChange(memberId, sessionId, action, oldState, newState, reason);
     }
 
     static void checkEncodedPrincipalLength(final byte[] encodedPrincipal)

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -41,7 +41,7 @@ import io.aeron.cluster.codecs.CloseReason;
 import io.aeron.cluster.codecs.ClusterAction;
 import io.aeron.cluster.codecs.MessageHeaderDecoder;
 import io.aeron.cluster.codecs.SessionMessageHeaderDecoder;
-import io.aeron.cluster.logging.ClusterLog;
+import io.aeron.cluster.logging.ClusterTracing;
 import io.aeron.cluster.service.Cluster;
 import io.aeron.cluster.service.ClusterClock;
 import io.aeron.cluster.service.ClusterMarkFile;
@@ -327,7 +327,7 @@ final class ConsensusModuleAgent
     @Override
     public void onStart()
     {
-        ClusterLog.logStart(ConsensusModuleVersion.VERSION);
+        ClusterTracing.traceStart(ConsensusModuleVersion.VERSION);
 
         archive = AeronArchive.connect(ctx.archiveContext().clone());
         recordingSignalPoller = new RecordingSignalPoller(
@@ -1331,7 +1331,7 @@ final class ConsensusModuleAgent
         final ConsensusModule.State newState,
         final String reason)
     {
-        ClusterLog.logStateChange(memberId, oldState, newState, reason);
+        ClusterTracing.traceStateChange(memberId, oldState, newState, reason);
     }
 
     void role(final Cluster.Role newRole)
@@ -1349,7 +1349,7 @@ final class ConsensusModuleAgent
 
     private void logRoleChange(final int memberId, final Cluster.Role oldRole, final Cluster.Role newRole)
     {
-        ClusterLog.logRoleChange(memberId, oldRole, newRole);
+        ClusterTracing.traceRoleChange(memberId, oldRole, newRole);
     }
 
     Cluster.Role role()
@@ -2158,7 +2158,7 @@ final class ConsensusModuleAgent
         final int appVersion,
         final boolean isStartup)
     {
-        ClusterLog.logOnNewLeadershipTerm(
+        ClusterTracing.traceOnNewLeadershipTerm(
             memberId,
             logLeadershipTermId,
             nextLeadershipTermId,
@@ -2182,7 +2182,7 @@ final class ConsensusModuleAgent
         final long logPosition,
         final int leaderMemberId)
     {
-        ClusterLog.logOnCommitPosition(memberId, leadershipTermId, logPosition, leaderMemberId);
+        ClusterTracing.traceOnCommitPosition(memberId, leadershipTermId, logPosition, leaderMemberId);
     }
 
     static void logAppendSessionOpen(
@@ -2193,7 +2193,7 @@ final class ConsensusModuleAgent
         final long timestamp,
         final TimeUnit timeUnit)
     {
-        ClusterLog.logAppendSessionOpen(memberId, id, leadershipTermId, logPosition, timestamp, timeUnit);
+        ClusterTracing.traceAppendSessionOpen(memberId, id, leadershipTermId, logPosition, timestamp, timeUnit);
     }
 
     static void logAppendSessionClose(
@@ -2204,7 +2204,7 @@ final class ConsensusModuleAgent
         final long timestamp,
         final TimeUnit timeUnit)
     {
-        ClusterLog.logAppendSessionClose(memberId, id, closeReason, leadershipTermId, timestamp, timeUnit);
+        ClusterTracing.traceAppendSessionClose(memberId, id, closeReason, leadershipTermId, timestamp, timeUnit);
     }
 
     private static void logOnReplayNewLeadershipTermEvent(
@@ -2217,7 +2217,7 @@ final class ConsensusModuleAgent
         final TimeUnit timeUnit,
         final int appVersion)
     {
-        ClusterLog.logOnReplayNewLeadershipTermEvent(
+        ClusterTracing.traceOnReplayNewLeadershipTermEvent(
             memberId, isInElection, leadershipTermId, logPosition, timestamp, termBaseLogPosition, timeUnit,
             appVersion);
     }
@@ -2230,7 +2230,7 @@ final class ConsensusModuleAgent
         final int candidateId,
         final int protocolVersion)
     {
-        ClusterLog.logOnRequestVote(
+        ClusterTracing.traceOnRequestVote(
             memberId, logLeadershipTermId, logPosition, candidateTermId, candidateId, protocolVersion);
     }
 
@@ -2243,7 +2243,7 @@ final class ConsensusModuleAgent
         final int voterId,
         final boolean vote)
     {
-        ClusterLog.logOnVote(
+        ClusterTracing.traceOnVote(
             memberId, logLeadershipTermId, logPosition, candidateTermId, candidateId, voterId, vote);
     }
 
@@ -2254,7 +2254,7 @@ final class ConsensusModuleAgent
         final int followerMemberId,
         final short flags)
     {
-        ClusterLog.logOnAppendPosition(memberId, leadershipTermId, logPosition, followerMemberId, flags);
+        ClusterTracing.traceOnAppendPosition(memberId, leadershipTermId, logPosition, followerMemberId, flags);
     }
 
     private static void logOnCanvassPosition(
@@ -2265,7 +2265,7 @@ final class ConsensusModuleAgent
         final int followerMemberId,
         final int protocolVersion)
     {
-        ClusterLog.logOnCanvassPosition(
+        ClusterTracing.traceOnCanvassPosition(
             memberId, logLeadershipTermId, logPosition, leadershipTermId, followerMemberId, protocolVersion);
     }
 
@@ -2280,7 +2280,7 @@ final class ConsensusModuleAgent
         final int serviceId,
         final String archiveEndpoint)
     {
-        ClusterLog.logStandbySnapshotNotification(
+        ClusterTracing.traceStandbySnapshotNotification(
             memberId,
             recordingId,
             leadershipTermId,
@@ -2294,7 +2294,7 @@ final class ConsensusModuleAgent
 
     private static void logOnStopCatchup(final int memberId, final long leadershipTermId, final int followerMemberId)
     {
-        ClusterLog.logOnStopCatchup(memberId, leadershipTermId, followerMemberId);
+        ClusterTracing.traceOnStopCatchup(memberId, leadershipTermId, followerMemberId);
     }
 
     private static void logOnCatchupPosition(
@@ -2304,7 +2304,8 @@ final class ConsensusModuleAgent
         final int followerMemberId,
         final String catchupEndpoint)
     {
-        ClusterLog.logOnCatchupPosition(memberId, leadershipTermId, logPosition, followerMemberId, catchupEndpoint);
+        ClusterTracing.traceOnCatchupPosition(
+            memberId, leadershipTermId, logPosition, followerMemberId, catchupEndpoint);
     }
 
     private static void logOnTerminationPosition(
@@ -2312,7 +2313,7 @@ final class ConsensusModuleAgent
         final long logLeadershipTermId,
         final long logPosition)
     {
-        ClusterLog.logTerminationPosition(memberId, logLeadershipTermId, logPosition);
+        ClusterTracing.traceTerminationPosition(memberId, logLeadershipTermId, logPosition);
     }
 
     private static void logOnTerminationAck(
@@ -2321,7 +2322,7 @@ final class ConsensusModuleAgent
         final long logPosition,
         final int senderMemberId)
     {
-        ClusterLog.logTerminationAck(memberId, logLeadershipTermId, logPosition, senderMemberId);
+        ClusterTracing.traceTerminationAck(memberId, logLeadershipTermId, logPosition, senderMemberId);
     }
 
     private static void logOnServiceAck(
@@ -2333,7 +2334,7 @@ final class ConsensusModuleAgent
         final long relevantId,
         final int serviceId)
     {
-        ClusterLog.logServiceAck(memberId, logPosition, timestamp, timeUnit, ackId, relevantId, serviceId);
+        ClusterTracing.traceServiceAck(memberId, logPosition, timestamp, timeUnit, ackId, relevantId, serviceId);
     }
 
     private static void logNewElection(
@@ -2343,7 +2344,7 @@ final class ConsensusModuleAgent
         final long appendedPosition,
         final String reason)
     {
-        ClusterLog.logNewElection(memberId, logLeadershipTermId, logPosition, appendedPosition, reason);
+        ClusterTracing.traceNewElection(memberId, logLeadershipTermId, logPosition, appendedPosition, reason);
     }
 
     static void logReplicationEnded(
@@ -2355,7 +2356,7 @@ final class ConsensusModuleAgent
         final long position,
         final boolean hasSynced)
     {
-        ClusterLog.logReplicationEnded(
+        ClusterTracing.traceReplicationEnded(
             memberId, purpose, controlUri, srcRecordingId, dstRecordingId, position, hasSynced);
     }
 

--- a/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
@@ -23,7 +23,7 @@ import io.aeron.Subscription;
 import io.aeron.archive.codecs.RecordingSignal;
 import io.aeron.cluster.client.ClusterEvent;
 import io.aeron.cluster.client.ClusterException;
-import io.aeron.cluster.logging.ClusterLog;
+import io.aeron.cluster.logging.ClusterTracing;
 import io.aeron.cluster.service.Cluster;
 import io.aeron.exceptions.AeronException;
 import io.aeron.exceptions.TimeoutException;
@@ -619,7 +619,7 @@ class Election
         final long oldPosition,
         final long newPosition)
     {
-        ClusterLog.logOnTruncateLogEntry(
+        ClusterTracing.traceOnTruncateLogEntry(
             memberId,
             state,
             logLeadershipTermId,
@@ -1570,7 +1570,7 @@ class Election
         final long catchupPosition,
         final String reason)
     {
-        ClusterLog.logElectionStateChange(
+        ClusterTracing.traceElectionStateChange(
             memberId,
             oldState,
             newState,

--- a/aeron-cluster/src/main/java/io/aeron/cluster/RecordingLogValidator.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/RecordingLogValidator.java
@@ -17,7 +17,7 @@ package io.aeron.cluster;
 
 import io.aeron.archive.client.AeronArchive;
 import io.aeron.archive.client.ArchiveException;
-import io.aeron.cluster.logging.ClusterLog;
+import io.aeron.cluster.logging.ClusterTracing;
 import org.agrona.CloseHelper;
 import org.agrona.collections.LongArrayList;
 import org.agrona.collections.LongHashSet;
@@ -124,6 +124,6 @@ class RecordingLogValidator implements AutoCloseable
         final long logPosition,
         final int serviceId)
     {
-        ClusterLog.logSnapshotEntryInvalidation(memberId, entryIndex, recordingId, logPosition, serviceId);
+        ClusterTracing.traceSnapshotEntryInvalidation(memberId, entryIndex, recordingId, logPosition, serviceId);
     }
 }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/logging/ClusterTracer.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/logging/ClusterTracer.java
@@ -59,7 +59,7 @@ public interface ClusterTracer
      * @param isStartup               is the leader starting up fresh.
      */
     @LoggerMethod(eventCode = "NEW_LEADERSHIP_TERM")
-    default void logOnNewLeadershipTerm(
+    default void traceOnNewLeadershipTerm(
         final int memberId,
         final long logLeadershipTermId,
         final long nextLeadershipTermId,
@@ -88,7 +88,7 @@ public interface ClusterTracer
      * @param reason for state to change.
      */
     @LoggerMethod(eventCode = "STATE_CHANGE")
-    default <E extends Enum<E>> void logStateChange(
+    default <E extends Enum<E>> void traceStateChange(
         final int memberId,
         final E oldState,
         final E newState,
@@ -106,7 +106,7 @@ public interface ClusterTracer
      * @param reason for state to change.
      */
     @LoggerMethod(eventCode = "ROLE_CHANGE")
-    default <E extends Enum<E>> void logRoleChange(
+    default <E extends Enum<E>> void traceRoleChange(
         final int memberId,
         final E oldState,
         final E newState,
@@ -124,7 +124,7 @@ public interface ClusterTracer
      * @param reason for state to change.
      */
     @LoggerMethod(eventCode = "CLUSTER_BACKUP_STATE_CHANGE")
-    default <E extends Enum<E>> void logClusterBackupStateChange(
+    default <E extends Enum<E>> void traceClusterBackupStateChange(
         final int memberId,
         final E oldState,
         final E newState,
@@ -149,7 +149,7 @@ public interface ClusterTracer
      * @param reason              for the state transition to occur.
      */
     @LoggerMethod(eventCode = "ELECTION_STATE_CHANGE")
-    default <E extends Enum<E>> void logElectionStateChange(
+    default <E extends Enum<E>> void traceElectionStateChange(
         final int memberId,
         final E oldState,
         final E newState,
@@ -175,7 +175,7 @@ public interface ClusterTracer
      * @param protocolVersion     of the consensus module.
      */
     @LoggerMethod(eventCode = "CANVASS_POSITION")
-    default void logOnCanvassPosition(
+    default void traceOnCanvassPosition(
         final int memberId,
         final long logLeadershipTermId,
         final long logPosition,
@@ -196,7 +196,7 @@ public interface ClusterTracer
      * @param protocolVersion     from the request.
      */
     @LoggerMethod(eventCode = "REQUEST_VOTE")
-    default void logOnRequestVote(
+    default void traceOnRequestVote(
         final int memberId,
         final long logLeadershipTermId,
         final long logPosition,
@@ -218,7 +218,7 @@ public interface ClusterTracer
      * @param vote                expressed by the follower node.
      */
     @LoggerMethod(eventCode = "VOTE")
-    default void logOnVote(
+    default void traceOnVote(
         final int memberId,
         final long logLeadershipTermId,
         final long logPosition,
@@ -239,7 +239,7 @@ public interface ClusterTracer
      * @param catchupEndpoint  the endpoint to send catchup messages
      */
     @LoggerMethod(eventCode = "CATCHUP_POSITION")
-    default void logOnCatchupPosition(
+    default void traceOnCatchupPosition(
         final int memberId,
         final long leadershipTermId,
         final long logPosition,
@@ -256,7 +256,7 @@ public interface ClusterTracer
      * @param followerMemberId id of follower currently catching up.
      */
     @LoggerMethod(eventCode = "STOP_CATCHUP")
-    default void logOnStopCatchup(final int memberId, final long leadershipTermId, final int followerMemberId)
+    default void traceOnStopCatchup(final int memberId, final long leadershipTermId, final int followerMemberId)
     {
     }
 
@@ -276,7 +276,7 @@ public interface ClusterTracer
      * @param newPosition         truncated to.
      */
     @LoggerMethod(eventCode = "TRUNCATE_LOG_ENTRY")
-    default <E extends Enum<E>> void logOnTruncateLogEntry(
+    default <E extends Enum<E>> void traceOnTruncateLogEntry(
         final int memberId,
         final E state,
         final long logLeadershipTermId,
@@ -303,7 +303,7 @@ public interface ClusterTracer
      * @param appVersion          version of the application.
      */
     @LoggerMethod(eventCode = "REPLAY_NEW_LEADERSHIP_TERM")
-    default void logOnReplayNewLeadershipTermEvent(
+    default void traceOnReplayNewLeadershipTermEvent(
         final int memberId,
         final boolean isInElection,
         final long leadershipTermId,
@@ -325,7 +325,7 @@ public interface ClusterTracer
      * @param flags            applied to append position by follower.
      */
     @LoggerMethod(eventCode = "APPEND_POSITION")
-    default void logOnAppendPosition(
+    default void traceOnAppendPosition(
         final int memberId,
         final long leadershipTermId,
         final long logPosition,
@@ -343,7 +343,7 @@ public interface ClusterTracer
      * @param leaderId         leader member sending the commit position.
      */
     @LoggerMethod(eventCode = "COMMIT_POSITION")
-    default void logOnCommitPosition(
+    default void traceOnCommitPosition(
         final int memberId, final long leadershipTermId, final long logPosition, final int leaderId)
     {
     }
@@ -359,7 +359,7 @@ public interface ClusterTracer
      * @param timeUnit         units for the timestamp.
      */
     @LoggerMethod(eventCode = "APPEND_SESSION_CLOSE")
-    default void logAppendSessionClose(
+    default void traceAppendSessionClose(
         final int memberId,
         final long sessionId,
         final CloseReason closeReason,
@@ -380,7 +380,7 @@ public interface ClusterTracer
      * @param timeUnit         units for the timestamp.
      */
     @LoggerMethod(eventCode = "APPEND_SESSION_OPEN")
-    default void logAppendSessionOpen(
+    default void traceAppendSessionOpen(
         final int memberId,
         final long sessionId,
         final long leadershipTermId,
@@ -398,7 +398,7 @@ public interface ClusterTracer
      * @param logPosition         position to terminate at.
      */
     @LoggerMethod(eventCode = "TERMINATION_POSITION")
-    default void logTerminationPosition(final int memberId, final long logLeadershipTermId, final long logPosition)
+    default void traceTerminationPosition(final int memberId, final long logLeadershipTermId, final long logPosition)
     {
     }
 
@@ -411,7 +411,7 @@ public interface ClusterTracer
      * @param senderMemberId      member sending the ack.
      */
     @LoggerMethod(eventCode = "TERMINATION_ACK")
-    default void logTerminationAck(
+    default void traceTerminationAck(
         final int memberId, final long logLeadershipTermId, final long logPosition, final int senderMemberId)
     {
     }
@@ -428,7 +428,7 @@ public interface ClusterTracer
      * @param serviceId   the id of the service that sent the ack.
      */
     @LoggerMethod(eventCode = "SERVICE_ACK")
-    default void logServiceAck(
+    default void traceServiceAck(
         final int memberId,
         final long logPosition,
         final long timestamp,
@@ -451,7 +451,7 @@ public interface ClusterTracer
      * @param hasSynced      was the sync event been received for the replication.
      */
     @LoggerMethod(eventCode = "REPLICATION_ENDED")
-    default void logReplicationEnded(
+    default void traceReplicationEnded(
         final int memberId,
         final String purpose,
         final String channel,
@@ -476,7 +476,7 @@ public interface ClusterTracer
      * @param archiveEndpoint     the endpoint holding the standby snapshot.
      */
     @LoggerMethod(eventCode = "STANDBY_SNAPSHOT_NOTIFICATION")
-    default void logStandbySnapshotNotification(
+    default void traceStandbySnapshotNotification(
         final int memberId,
         final long recordingId,
         final long leadershipTermId,
@@ -499,7 +499,7 @@ public interface ClusterTracer
      * @param reason           for election to be started.
      */
     @LoggerMethod(eventCode = "NEW_ELECTION")
-    default void logNewElection(
+    default void traceNewElection(
         final int memberId,
         final long leadershipTermId,
         final long logPosition,
@@ -521,7 +521,7 @@ public interface ClusterTracer
      * @param reason    for the change.
      */
     @LoggerMethod(eventCode = "CLUSTER_SESSION_STATE_CHANGE")
-    default <A extends Enum<A>, S extends Enum<S>> void logClusterSessionStateChange(
+    default <A extends Enum<A>, S extends Enum<S>> void traceClusterSessionStateChange(
         final int memberId,
         final long sessionId,
         final A action,
@@ -541,7 +541,7 @@ public interface ClusterTracer
      * @param serviceId     that took the snapshot.
      */
     @LoggerMethod(eventCode = "SNAPSHOT_ENTRY_INVALIDATION")
-    default void logSnapshotEntryInvalidation(
+    default void traceSnapshotEntryInvalidation(
         final int memberId,
         final int entryIndex,
         final long recordingId,
@@ -556,7 +556,7 @@ public interface ClusterTracer
      * @param version   of the cluster.
      */
     @LoggerMethod(eventCode = "START")
-    default void logStart(final String version)
+    default void traceStart(final String version)
     {
     }
 }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/logging/ClusterTracer.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/logging/ClusterTracer.java
@@ -32,12 +32,12 @@ import java.util.concurrent.TimeUnit;
  * {@link LoggerMethod}-annotated methods below.
  */
 @GeneratedLogger(eventCodeType = "io.aeron.cluster.logging.ClusterEventCode")
-public interface ClusterEventLogger
+public interface ClusterTracer
 {
     /**
      * Logger for writing into the {@link ManyToOneRingBuffer} held by {@link EventConfiguration#eventReader}.
      */
-    ClusterEventLogger LOGGER = new CborClusterEventLogger(EventConfiguration.eventReader().ringBuffer());
+    ClusterTracer LOGGER = new CborClusterTracer(EventConfiguration.eventReader().ringBuffer());
 
     /**
      * Log a new leadership term event.

--- a/aeron-cluster/src/main/java/io/aeron/cluster/logging/ClusterTracer.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/logging/ClusterTracer.java
@@ -37,7 +37,7 @@ public interface ClusterTracer
     /**
      * Logger for writing into the {@link ManyToOneRingBuffer} held by {@link EventConfiguration#eventReader}.
      */
-    ClusterTracer LOGGER = new CborClusterTracer(EventConfiguration.eventReader().ringBuffer());
+    ClusterTracer TRACER = new CborClusterTracer(EventConfiguration.eventReader().ringBuffer());
 
     /**
      * Log a new leadership term event.

--- a/aeron-cluster/src/main/java/io/aeron/cluster/logging/ClusterTracing.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/logging/ClusterTracing.java
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Logging entry points for the cluster.
  */
-public final class ClusterLog
+public final class ClusterTracing
 {
     private static final Object2ObjectHashMap<String, EnumSet<ClusterEventCode>> SPECIAL_EVENTS =
         new Object2ObjectHashMap<>();
@@ -92,7 +92,7 @@ public final class ClusterLog
         isEnabled(ClusterEventCode.SNAPSHOT_ENTRY_INVALIDATION);
     static final boolean LOG_START = !ENABLED_EVENT_CODES.isEmpty();
 
-    private ClusterLog()
+    private ClusterTracing()
     {
     }
 
@@ -123,7 +123,7 @@ public final class ClusterLog
      * @param catchupPosition     of the node.
      * @param reason              for the state transition to occur.
      */
-    public static <E extends Enum<E>> void logElectionStateChange(
+    public static <E extends Enum<E>> void traceElectionStateChange(
         final int memberId,
         final E oldState,
         final E newState,
@@ -174,7 +174,7 @@ public final class ClusterLog
      * @param appVersion              associated with the recorded state.
      * @param isStartup               is the leader starting up fresh.
      */
-    public static void logOnNewLeadershipTerm(
+    public static void traceOnNewLeadershipTerm(
         final int memberId,
         final long logLeadershipTermId,
         final long nextLeadershipTermId,
@@ -224,7 +224,7 @@ public final class ClusterLog
      * @param reason   for the state change.
      * @param <E>      type of state.
      */
-    public static <E extends Enum<E>> void logStateChange(
+    public static <E extends Enum<E>> void traceStateChange(
         final int memberId, final E oldState, final E newState, final String reason)
     {
         if (!LOG_STATE_CHANGE_ENABLED)
@@ -243,7 +243,7 @@ public final class ClusterLog
      * @param newRole   role after the change.
      * @param <E>       type of the role.
      */
-    public static <E extends Enum<E>> void logRoleChange(final int memberId, final E oldRole, final E newRole)
+    public static <E extends Enum<E>> void traceRoleChange(final int memberId, final E oldRole, final E newRole)
     {
         if (!LOG_ROLE_CHANGE_ENABLED)
         {
@@ -263,7 +263,7 @@ public final class ClusterLog
      * @param followerMemberId    follower node id.
      * @param protocolVersion     of the consensus module.
      */
-    public static void logOnCanvassPosition(
+    public static void traceOnCanvassPosition(
         final int memberId,
         final long logLeadershipTermId,
         final long logPosition,
@@ -290,7 +290,7 @@ public final class ClusterLog
      * @param candidateId         id of the candidate node.
      * @param protocolVersion     from the request.
      */
-    public static void logOnRequestVote(
+    public static void traceOnRequestVote(
         final int memberId,
         final long logLeadershipTermId,
         final long logPosition,
@@ -318,7 +318,7 @@ public final class ClusterLog
      * @param voterId             id of the follower node that voted.
      * @param vote                expressed by the follower node.
      */
-    public static void logOnVote(
+    public static void traceOnVote(
         final int memberId,
         final long logLeadershipTermId,
         final long logPosition,
@@ -345,7 +345,7 @@ public final class ClusterLog
      * @param followerMemberId the id of the follower that is catching up
      * @param catchupEndpoint  the endpoint to send catchup messages
      */
-    public static void logOnCatchupPosition(
+    public static void traceOnCatchupPosition(
         final int memberId,
         final long leadershipTermId,
         final long logPosition,
@@ -368,7 +368,7 @@ public final class ClusterLog
      * @param leadershipTermId current leadershipTermId.
      * @param followerMemberId id of follower currently catching up.
      */
-    public static void logOnStopCatchup(final int memberId, final long leadershipTermId, final int followerMemberId)
+    public static void traceOnStopCatchup(final int memberId, final long leadershipTermId, final int followerMemberId)
     {
         if (!LOG_STOP_CATCHUP_ENABLED)
         {
@@ -393,7 +393,7 @@ public final class ClusterLog
      * @param oldPosition         truncated from.
      * @param newPosition         truncated to.
      */
-    public static <E extends Enum<E>> void logOnTruncateLogEntry(
+    public static <E extends Enum<E>> void traceOnTruncateLogEntry(
         final int memberId,
         final E state,
         final long logLeadershipTermId,
@@ -435,7 +435,7 @@ public final class ClusterLog
      * @param timeUnit            cluster time unit.
      * @param appVersion          version of the application.
      */
-    public static void logOnReplayNewLeadershipTermEvent(
+    public static void traceOnReplayNewLeadershipTermEvent(
         final int memberId,
         final boolean isInElection,
         final long leadershipTermId,
@@ -470,7 +470,7 @@ public final class ClusterLog
      * @param followerMemberId follower member sending the Append position.
      * @param flags            applied to append position by follower.
      */
-    public static void logOnAppendPosition(
+    public static void traceOnAppendPosition(
         final int memberId,
         final long leadershipTermId,
         final long logPosition,
@@ -494,7 +494,7 @@ public final class ClusterLog
      * @param logPosition      the current position in the log.
      * @param leaderMemberId   leader member sending the commit position.
      */
-    public static void logOnCommitPosition(
+    public static void traceOnCommitPosition(
         final int memberId, final long leadershipTermId, final long logPosition, final int leaderMemberId)
     {
         if (!LOG_COMMIT_POSITION_ENABLED)
@@ -515,7 +515,7 @@ public final class ClusterLog
      * @param timestamp        the current timestamp.
      * @param timeUnit         units for the timestamp.
      */
-    public static void logAppendSessionClose(
+    public static void traceAppendSessionClose(
         final int memberId,
         final long sessionId,
         final CloseReason closeReason,
@@ -542,7 +542,7 @@ public final class ClusterLog
      * @param timestamp        the current timestamp.
      * @param timeUnit         units for the timestamp.
      */
-    public static void logAppendSessionOpen(
+    public static void traceAppendSessionOpen(
         final int memberId,
         final long sessionId,
         final long leadershipTermId,
@@ -566,7 +566,7 @@ public final class ClusterLog
      * @param oldState  before the change.
      * @param newState  after the change.
      */
-    public static <E extends Enum<E>> void logClusterBackupStateChange(
+    public static <E extends Enum<E>> void traceClusterBackupStateChange(
         final E oldState,
         final E newState)
     {
@@ -585,7 +585,7 @@ public final class ClusterLog
      * @param leadershipTermId    leadership term for the supplied position.
      * @param logPosition         position to terminate at.
      */
-    public static void logTerminationPosition(final int memberId, final long leadershipTermId, final long logPosition)
+    public static void traceTerminationPosition(final int memberId, final long leadershipTermId, final long logPosition)
     {
         if (!LOG_TERMINATION_POSITION_ENABLED)
         {
@@ -603,7 +603,7 @@ public final class ClusterLog
      * @param logPosition         position to terminate at.
      * @param senderMemberId      member sending the ack.
      */
-    public static void logTerminationAck(
+    public static void traceTerminationAck(
         final int memberId, final long leadershipTermId, final long logPosition, final int senderMemberId)
     {
         if (!LOG_TERMINATION_ACK_ENABLED)
@@ -625,7 +625,7 @@ public final class ClusterLog
      * @param relevantId  associated id used in the ack, e.g. recordingId for snapshot acks.
      * @param serviceId   the id of the service that sent the ack.
      */
-    public static void logServiceAck(
+    public static void traceServiceAck(
         final int memberId,
         final long logPosition,
         final long timestamp,
@@ -654,7 +654,7 @@ public final class ClusterLog
      * @param position       the position where the recording ended.
      * @param hasSynced      was the sync event been received for the replication.
      */
-    public static void logReplicationEnded(
+    public static void traceReplicationEnded(
         final int memberId,
         final String purpose,
         final String channel,
@@ -685,7 +685,7 @@ public final class ClusterLog
      * @param serviceId           the serviceId for the snapshot.
      * @param archiveEndpoint     the endpoint holding the standby snapshot.
      */
-    public static void logStandbySnapshotNotification(
+    public static void traceStandbySnapshotNotification(
         final int memberId,
         final long recordingId,
         final long leadershipTermId,
@@ -722,7 +722,7 @@ public final class ClusterLog
      * @param appendPosition   the append position.
      * @param reason           for election to be started.
      */
-    public static void logNewElection(
+    public static void traceNewElection(
         final int memberId,
         final long leadershipTermId,
         final long logPosition,
@@ -749,7 +749,7 @@ public final class ClusterLog
      * @param newState  after the change.
      * @param reason    for the change.
      */
-    public static <A extends Enum<A>, S extends Enum<S>> void logClusterSessionStateChange(
+    public static <A extends Enum<A>, S extends Enum<S>> void traceClusterSessionStateChange(
         final int memberId,
         final long sessionId,
         final A action,
@@ -775,7 +775,7 @@ public final class ClusterLog
      * @param logPosition   of the snapshot.
      * @param serviceId     that took the snapshot.
      */
-    public static void logSnapshotEntryInvalidation(
+    public static void traceSnapshotEntryInvalidation(
         final int memberId,
         final int entryIndex,
         final long recordingId,
@@ -796,7 +796,7 @@ public final class ClusterLog
      *
      * @param version   of the cluster.
      */
-    public static void logStart(final String version)
+    public static void traceStart(final String version)
     {
         if (!LOG_START)
         {

--- a/aeron-cluster/src/main/java/io/aeron/cluster/logging/ClusterTracing.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/logging/ClusterTracing.java
@@ -141,7 +141,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.LOGGER.logElectionStateChange(
+        ClusterTracer.TRACER.logElectionStateChange(
             memberId,
             oldState,
             newState,
@@ -197,7 +197,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.LOGGER.logOnNewLeadershipTerm(
+        ClusterTracer.TRACER.logOnNewLeadershipTerm(
             memberId,
             logLeadershipTermId,
             nextLeadershipTermId,
@@ -232,7 +232,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.LOGGER.logStateChange(memberId, oldState, newState, reason);
+        ClusterTracer.TRACER.logStateChange(memberId, oldState, newState, reason);
     }
 
     /**
@@ -250,7 +250,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.LOGGER.logRoleChange(memberId, oldRole, newRole, "");
+        ClusterTracer.TRACER.logRoleChange(memberId, oldRole, newRole, "");
     }
 
     /**
@@ -276,7 +276,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.LOGGER.logOnCanvassPosition(
+        ClusterTracer.TRACER.logOnCanvassPosition(
             memberId, logLeadershipTermId, logPosition, leadershipTermId, followerMemberId, protocolVersion);
     }
 
@@ -303,7 +303,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.LOGGER.logOnRequestVote(
+        ClusterTracer.TRACER.logOnRequestVote(
             memberId, logLeadershipTermId, logPosition, candidateTermId, candidateId, protocolVersion);
     }
 
@@ -332,7 +332,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.LOGGER.logOnVote(
+        ClusterTracer.TRACER.logOnVote(
             memberId, logLeadershipTermId, logPosition, candidateTermId, candidateId, voterId, vote);
     }
 
@@ -357,7 +357,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.LOGGER.logOnCatchupPosition(
+        ClusterTracer.TRACER.logOnCatchupPosition(
             memberId, leadershipTermId, logPosition, followerMemberId, catchupEndpoint);
     }
 
@@ -375,7 +375,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.LOGGER.logOnStopCatchup(memberId, leadershipTermId, followerMemberId);
+        ClusterTracer.TRACER.logOnStopCatchup(memberId, leadershipTermId, followerMemberId);
     }
 
     /**
@@ -410,7 +410,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.LOGGER.logOnTruncateLogEntry(
+        ClusterTracer.TRACER.logOnTruncateLogEntry(
             memberId,
             state,
             logLeadershipTermId,
@@ -450,7 +450,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.LOGGER.logOnReplayNewLeadershipTermEvent(
+        ClusterTracer.TRACER.logOnReplayNewLeadershipTermEvent(
             memberId,
             isInElection,
             leadershipTermId,
@@ -482,7 +482,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.LOGGER.logOnAppendPosition(
+        ClusterTracer.TRACER.logOnAppendPosition(
             memberId, leadershipTermId, logPosition, followerMemberId, flags);
     }
 
@@ -502,7 +502,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.LOGGER.logOnCommitPosition(memberId, leadershipTermId, logPosition, leaderMemberId);
+        ClusterTracer.TRACER.logOnCommitPosition(memberId, leadershipTermId, logPosition, leaderMemberId);
     }
 
     /**
@@ -528,7 +528,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.LOGGER.logAppendSessionClose(
+        ClusterTracer.TRACER.logAppendSessionClose(
             memberId, sessionId, closeReason, leadershipTermId, timestamp, timeUnit);
     }
 
@@ -555,7 +555,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.LOGGER.logAppendSessionOpen(
+        ClusterTracer.TRACER.logAppendSessionOpen(
             memberId, sessionId, leadershipTermId, logPosition, timestamp, timeUnit);
     }
 
@@ -575,7 +575,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.LOGGER.logClusterBackupStateChange(Aeron.NULL_VALUE, oldState, newState, "");
+        ClusterTracer.TRACER.logClusterBackupStateChange(Aeron.NULL_VALUE, oldState, newState, "");
     }
 
     /**
@@ -592,7 +592,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.LOGGER.logTerminationPosition(memberId, leadershipTermId, logPosition);
+        ClusterTracer.TRACER.logTerminationPosition(memberId, leadershipTermId, logPosition);
     }
 
     /**
@@ -611,7 +611,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.LOGGER.logTerminationAck(memberId, leadershipTermId, logPosition, senderMemberId);
+        ClusterTracer.TRACER.logTerminationAck(memberId, leadershipTermId, logPosition, senderMemberId);
     }
 
     /**
@@ -639,7 +639,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.LOGGER.logServiceAck(
+        ClusterTracer.TRACER.logServiceAck(
             memberId, logPosition, timestamp, timeUnit, ackId, relevantId, serviceId);
     }
 
@@ -668,7 +668,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.LOGGER.logReplicationEnded(
+        ClusterTracer.TRACER.logReplicationEnded(
             memberId, purpose, channel, srcRecordingId, dstRecordingId, position, hasSynced);
     }
 
@@ -701,7 +701,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.LOGGER.logStandbySnapshotNotification(
+        ClusterTracer.TRACER.logStandbySnapshotNotification(
             memberId,
             recordingId,
             leadershipTermId,
@@ -734,7 +734,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.LOGGER.logNewElection(memberId, leadershipTermId, logPosition, appendPosition, reason);
+        ClusterTracer.TRACER.logNewElection(memberId, leadershipTermId, logPosition, appendPosition, reason);
     }
 
     /**
@@ -762,7 +762,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.LOGGER.logClusterSessionStateChange(
+        ClusterTracer.TRACER.logClusterSessionStateChange(
             memberId, sessionId, action, oldState, newState, reason);
     }
 
@@ -787,7 +787,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.LOGGER.logSnapshotEntryInvalidation(
+        ClusterTracer.TRACER.logSnapshotEntryInvalidation(
             memberId, entryIndex, recordingId, logPosition, serviceId);
     }
 
@@ -803,6 +803,6 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.LOGGER.logStart(version);
+        ClusterTracer.TRACER.logStart(version);
     }
 }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/logging/ClusterTracing.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/logging/ClusterTracing.java
@@ -61,36 +61,36 @@ public final class ClusterTracing
         ENABLED_EVENT_CODES = Collections.unmodifiableSet(enabledEventCodeSet);
     }
 
-    static final boolean LOG_ELECTION_STATE_CHANGE_ENABLED = isEnabled(ClusterEventCode.ELECTION_STATE_CHANGE);
-    static final boolean LOG_NEW_LEADERSHIP_TERM_ENABLED = isEnabled(ClusterEventCode.NEW_LEADERSHIP_TERM);
-    static final boolean LOG_STATE_CHANGE_ENABLED = isEnabled(ClusterEventCode.STATE_CHANGE);
-    static final boolean LOG_ROLE_CHANGE_ENABLED = isEnabled(ClusterEventCode.ROLE_CHANGE);
-    static final boolean LOG_CANVASS_POSITION_ENABLED = isEnabled(ClusterEventCode.CANVASS_POSITION);
-    static final boolean LOG_REQUEST_VOTE_ENABLED = isEnabled(ClusterEventCode.REQUEST_VOTE);
-    static final boolean LOG_CATCHUP_POSITION_ENABLED = isEnabled(ClusterEventCode.CATCHUP_POSITION);
-    static final boolean LOG_STOP_CATCHUP_ENABLED = isEnabled(ClusterEventCode.STOP_CATCHUP);
-    static final boolean LOG_TRUNCATE_LOG_ENTRY_ENABLED = isEnabled(ClusterEventCode.TRUNCATE_LOG_ENTRY);
-    static final boolean LOG_REPLAY_NEW_LEADERSHIP_TERM_ENABLED =
+    static final boolean TRACE_ELECTION_STATE_CHANGE_ENABLED = isEnabled(ClusterEventCode.ELECTION_STATE_CHANGE);
+    static final boolean TRACE_NEW_LEADERSHIP_TERM_ENABLED = isEnabled(ClusterEventCode.NEW_LEADERSHIP_TERM);
+    static final boolean TRACE_STATE_CHANGE_ENABLED = isEnabled(ClusterEventCode.STATE_CHANGE);
+    static final boolean TRACE_ROLE_CHANGE_ENABLED = isEnabled(ClusterEventCode.ROLE_CHANGE);
+    static final boolean TRACE_CANVASS_POSITION_ENABLED = isEnabled(ClusterEventCode.CANVASS_POSITION);
+    static final boolean TRACE_REQUEST_VOTE_ENABLED = isEnabled(ClusterEventCode.REQUEST_VOTE);
+    static final boolean TRACE_CATCHUP_POSITION_ENABLED = isEnabled(ClusterEventCode.CATCHUP_POSITION);
+    static final boolean TRACE_STOP_CATCHUP_ENABLED = isEnabled(ClusterEventCode.STOP_CATCHUP);
+    static final boolean TRACE_TRUNCATE_LOG_ENTRY_ENABLED = isEnabled(ClusterEventCode.TRUNCATE_LOG_ENTRY);
+    static final boolean TRACE_REPLAY_NEW_LEADERSHIP_TERM_ENABLED =
         isEnabled(ClusterEventCode.REPLAY_NEW_LEADERSHIP_TERM);
-    static final boolean LOG_APPEND_POSITION_ENABLED = isEnabled(ClusterEventCode.APPEND_POSITION);
-    static final boolean LOG_COMMIT_POSITION_ENABLED = isEnabled(ClusterEventCode.COMMIT_POSITION);
-    static final boolean LOG_APPEND_SESSION_CLOSE_ENABLED = isEnabled(ClusterEventCode.APPEND_SESSION_CLOSE);
-    static final boolean LOG_CLUSTER_BACKUP_STATE_CHANGE_ENABLED =
+    static final boolean TRACE_APPEND_POSITION_ENABLED = isEnabled(ClusterEventCode.APPEND_POSITION);
+    static final boolean TRACE_COMMIT_POSITION_ENABLED = isEnabled(ClusterEventCode.COMMIT_POSITION);
+    static final boolean TRACE_APPEND_SESSION_CLOSE_ENABLED = isEnabled(ClusterEventCode.APPEND_SESSION_CLOSE);
+    static final boolean TRACE_CLUSTER_BACKUP_STATE_CHANGE_ENABLED =
         isEnabled(ClusterEventCode.CLUSTER_BACKUP_STATE_CHANGE);
-    static final boolean LOG_TERMINATION_POSITION_ENABLED = isEnabled(ClusterEventCode.TERMINATION_POSITION);
-    static final boolean LOG_TERMINATION_ACK_ENABLED = isEnabled(ClusterEventCode.TERMINATION_ACK);
-    static final boolean LOG_SERVICE_ACK_ENABLED = isEnabled(ClusterEventCode.SERVICE_ACK);
-    static final boolean LOG_REPLICATION_ENDED_ENABLED = isEnabled(ClusterEventCode.REPLICATION_ENDED);
-    static final boolean LOG_STANDBY_SNAPSHOT_NOTIFICATION_ENABLED =
+    static final boolean TRACE_TERMINATION_POSITION_ENABLED = isEnabled(ClusterEventCode.TERMINATION_POSITION);
+    static final boolean TRACE_TERMINATION_ACK_ENABLED = isEnabled(ClusterEventCode.TERMINATION_ACK);
+    static final boolean TRACE_SERVICE_ACK_ENABLED = isEnabled(ClusterEventCode.SERVICE_ACK);
+    static final boolean TRACE_REPLICATION_ENDED_ENABLED = isEnabled(ClusterEventCode.REPLICATION_ENDED);
+    static final boolean TRACE_STANDBY_SNAPSHOT_NOTIFICATION_ENABLED =
         isEnabled(ClusterEventCode.STANDBY_SNAPSHOT_NOTIFICATION);
-    static final boolean LOG_NEW_ELECTION_ENABLED = isEnabled(ClusterEventCode.NEW_ELECTION);
-    static final boolean LOG_APPEND_SESSION_OPEN_ENABLED = isEnabled(ClusterEventCode.APPEND_SESSION_OPEN);
-    static final boolean LOG_CLUSTER_SESSION_STATE_CHANGE_ENABLED =
+    static final boolean TRACE_NEW_ELECTION_ENABLED = isEnabled(ClusterEventCode.NEW_ELECTION);
+    static final boolean TRACE_APPEND_SESSION_OPEN_ENABLED = isEnabled(ClusterEventCode.APPEND_SESSION_OPEN);
+    static final boolean TRACE_CLUSTER_SESSION_STATE_CHANGE_ENABLED =
         isEnabled(ClusterEventCode.CLUSTER_SESSION_STATE_CHANGE);
-    static final boolean LOG_VOTE_ENABLED = isEnabled(ClusterEventCode.VOTE);
-    static final boolean LOG_SNAPSHOT_ENTRY_INVALIDATION_ENABLED =
+    static final boolean TRACE_VOTE_ENABLED = isEnabled(ClusterEventCode.VOTE);
+    static final boolean TRACE_SNAPSHOT_ENTRY_INVALIDATION_ENABLED =
         isEnabled(ClusterEventCode.SNAPSHOT_ENTRY_INVALIDATION);
-    static final boolean LOG_START = !ENABLED_EVENT_CODES.isEmpty();
+    static final boolean TRACE_START = !ENABLED_EVENT_CODES.isEmpty();
 
     private ClusterTracing()
     {
@@ -136,7 +136,7 @@ public final class ClusterTracing
         final long catchupPosition,
         final String reason)
     {
-        if (!LOG_ELECTION_STATE_CHANGE_ENABLED)
+        if (!TRACE_ELECTION_STATE_CHANGE_ENABLED)
         {
             return;
         }
@@ -192,7 +192,7 @@ public final class ClusterTracing
         final int appVersion,
         final boolean isStartup)
     {
-        if (!LOG_NEW_LEADERSHIP_TERM_ENABLED)
+        if (!TRACE_NEW_LEADERSHIP_TERM_ENABLED)
         {
             return;
         }
@@ -227,7 +227,7 @@ public final class ClusterTracing
     public static <E extends Enum<E>> void traceStateChange(
         final int memberId, final E oldState, final E newState, final String reason)
     {
-        if (!LOG_STATE_CHANGE_ENABLED)
+        if (!TRACE_STATE_CHANGE_ENABLED)
         {
             return;
         }
@@ -245,7 +245,7 @@ public final class ClusterTracing
      */
     public static <E extends Enum<E>> void traceRoleChange(final int memberId, final E oldRole, final E newRole)
     {
-        if (!LOG_ROLE_CHANGE_ENABLED)
+        if (!TRACE_ROLE_CHANGE_ENABLED)
         {
             return;
         }
@@ -271,7 +271,7 @@ public final class ClusterTracing
         final int followerMemberId,
         final int protocolVersion)
     {
-        if (!LOG_CANVASS_POSITION_ENABLED)
+        if (!TRACE_CANVASS_POSITION_ENABLED)
         {
             return;
         }
@@ -298,7 +298,7 @@ public final class ClusterTracing
         final int candidateId,
         final int protocolVersion)
     {
-        if (!LOG_REQUEST_VOTE_ENABLED)
+        if (!TRACE_REQUEST_VOTE_ENABLED)
         {
             return;
         }
@@ -327,7 +327,7 @@ public final class ClusterTracing
         final int voterId,
         final boolean vote)
     {
-        if (!LOG_VOTE_ENABLED)
+        if (!TRACE_VOTE_ENABLED)
         {
             return;
         }
@@ -352,7 +352,7 @@ public final class ClusterTracing
         final int followerMemberId,
         final String catchupEndpoint)
     {
-        if (!LOG_CATCHUP_POSITION_ENABLED)
+        if (!TRACE_CATCHUP_POSITION_ENABLED)
         {
             return;
         }
@@ -370,7 +370,7 @@ public final class ClusterTracing
      */
     public static void traceOnStopCatchup(final int memberId, final long leadershipTermId, final int followerMemberId)
     {
-        if (!LOG_STOP_CATCHUP_ENABLED)
+        if (!TRACE_STOP_CATCHUP_ENABLED)
         {
             return;
         }
@@ -405,7 +405,7 @@ public final class ClusterTracing
         final long oldPosition,
         final long newPosition)
     {
-        if (!LOG_TRUNCATE_LOG_ENTRY_ENABLED)
+        if (!TRACE_TRUNCATE_LOG_ENTRY_ENABLED)
         {
             return;
         }
@@ -445,7 +445,7 @@ public final class ClusterTracing
         final TimeUnit timeUnit,
         final int appVersion)
     {
-        if (!LOG_REPLAY_NEW_LEADERSHIP_TERM_ENABLED)
+        if (!TRACE_REPLAY_NEW_LEADERSHIP_TERM_ENABLED)
         {
             return;
         }
@@ -477,7 +477,7 @@ public final class ClusterTracing
         final int followerMemberId,
         final short flags)
     {
-        if (!LOG_APPEND_POSITION_ENABLED)
+        if (!TRACE_APPEND_POSITION_ENABLED)
         {
             return;
         }
@@ -497,7 +497,7 @@ public final class ClusterTracing
     public static void traceOnCommitPosition(
         final int memberId, final long leadershipTermId, final long logPosition, final int leaderMemberId)
     {
-        if (!LOG_COMMIT_POSITION_ENABLED)
+        if (!TRACE_COMMIT_POSITION_ENABLED)
         {
             return;
         }
@@ -523,7 +523,7 @@ public final class ClusterTracing
         final long timestamp,
         final TimeUnit timeUnit)
     {
-        if (!LOG_APPEND_SESSION_CLOSE_ENABLED)
+        if (!TRACE_APPEND_SESSION_CLOSE_ENABLED)
         {
             return;
         }
@@ -550,7 +550,7 @@ public final class ClusterTracing
         final long timestamp,
         final TimeUnit timeUnit)
     {
-        if (!LOG_APPEND_SESSION_OPEN_ENABLED)
+        if (!TRACE_APPEND_SESSION_OPEN_ENABLED)
         {
             return;
         }
@@ -570,7 +570,7 @@ public final class ClusterTracing
         final E oldState,
         final E newState)
     {
-        if (!LOG_CLUSTER_BACKUP_STATE_CHANGE_ENABLED)
+        if (!TRACE_CLUSTER_BACKUP_STATE_CHANGE_ENABLED)
         {
             return;
         }
@@ -587,7 +587,7 @@ public final class ClusterTracing
      */
     public static void traceTerminationPosition(final int memberId, final long leadershipTermId, final long logPosition)
     {
-        if (!LOG_TERMINATION_POSITION_ENABLED)
+        if (!TRACE_TERMINATION_POSITION_ENABLED)
         {
             return;
         }
@@ -606,7 +606,7 @@ public final class ClusterTracing
     public static void traceTerminationAck(
         final int memberId, final long leadershipTermId, final long logPosition, final int senderMemberId)
     {
-        if (!LOG_TERMINATION_ACK_ENABLED)
+        if (!TRACE_TERMINATION_ACK_ENABLED)
         {
             return;
         }
@@ -634,7 +634,7 @@ public final class ClusterTracing
         final long relevantId,
         final int serviceId)
     {
-        if (!LOG_SERVICE_ACK_ENABLED)
+        if (!TRACE_SERVICE_ACK_ENABLED)
         {
             return;
         }
@@ -663,7 +663,7 @@ public final class ClusterTracing
         final long position,
         final boolean hasSynced)
     {
-        if (!LOG_REPLICATION_ENDED_ENABLED)
+        if (!TRACE_REPLICATION_ENDED_ENABLED)
         {
             return;
         }
@@ -696,7 +696,7 @@ public final class ClusterTracing
         final int serviceId,
         final String archiveEndpoint)
     {
-        if (!LOG_STANDBY_SNAPSHOT_NOTIFICATION_ENABLED)
+        if (!TRACE_STANDBY_SNAPSHOT_NOTIFICATION_ENABLED)
         {
             return;
         }
@@ -729,7 +729,7 @@ public final class ClusterTracing
         final long appendPosition,
         final String reason)
     {
-        if (!LOG_NEW_ELECTION_ENABLED)
+        if (!TRACE_NEW_ELECTION_ENABLED)
         {
             return;
         }
@@ -757,7 +757,7 @@ public final class ClusterTracing
         final S newState,
         final String reason)
     {
-        if (!LOG_CLUSTER_SESSION_STATE_CHANGE_ENABLED)
+        if (!TRACE_CLUSTER_SESSION_STATE_CHANGE_ENABLED)
         {
             return;
         }
@@ -782,7 +782,7 @@ public final class ClusterTracing
         final long logPosition,
         final int serviceId)
     {
-        if (!LOG_SNAPSHOT_ENTRY_INVALIDATION_ENABLED)
+        if (!TRACE_SNAPSHOT_ENTRY_INVALIDATION_ENABLED)
         {
             return;
         }
@@ -798,7 +798,7 @@ public final class ClusterTracing
      */
     public static void traceStart(final String version)
     {
-        if (!LOG_START)
+        if (!TRACE_START)
         {
             return;
         }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/logging/ClusterTracing.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/logging/ClusterTracing.java
@@ -141,7 +141,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.TRACER.logElectionStateChange(
+        ClusterTracer.TRACER.traceElectionStateChange(
             memberId,
             oldState,
             newState,
@@ -197,7 +197,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.TRACER.logOnNewLeadershipTerm(
+        ClusterTracer.TRACER.traceOnNewLeadershipTerm(
             memberId,
             logLeadershipTermId,
             nextLeadershipTermId,
@@ -232,7 +232,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.TRACER.logStateChange(memberId, oldState, newState, reason);
+        ClusterTracer.TRACER.traceStateChange(memberId, oldState, newState, reason);
     }
 
     /**
@@ -250,7 +250,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.TRACER.logRoleChange(memberId, oldRole, newRole, "");
+        ClusterTracer.TRACER.traceRoleChange(memberId, oldRole, newRole, "");
     }
 
     /**
@@ -276,7 +276,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.TRACER.logOnCanvassPosition(
+        ClusterTracer.TRACER.traceOnCanvassPosition(
             memberId, logLeadershipTermId, logPosition, leadershipTermId, followerMemberId, protocolVersion);
     }
 
@@ -303,7 +303,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.TRACER.logOnRequestVote(
+        ClusterTracer.TRACER.traceOnRequestVote(
             memberId, logLeadershipTermId, logPosition, candidateTermId, candidateId, protocolVersion);
     }
 
@@ -332,7 +332,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.TRACER.logOnVote(
+        ClusterTracer.TRACER.traceOnVote(
             memberId, logLeadershipTermId, logPosition, candidateTermId, candidateId, voterId, vote);
     }
 
@@ -357,7 +357,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.TRACER.logOnCatchupPosition(
+        ClusterTracer.TRACER.traceOnCatchupPosition(
             memberId, leadershipTermId, logPosition, followerMemberId, catchupEndpoint);
     }
 
@@ -375,7 +375,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.TRACER.logOnStopCatchup(memberId, leadershipTermId, followerMemberId);
+        ClusterTracer.TRACER.traceOnStopCatchup(memberId, leadershipTermId, followerMemberId);
     }
 
     /**
@@ -410,7 +410,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.TRACER.logOnTruncateLogEntry(
+        ClusterTracer.TRACER.traceOnTruncateLogEntry(
             memberId,
             state,
             logLeadershipTermId,
@@ -450,7 +450,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.TRACER.logOnReplayNewLeadershipTermEvent(
+        ClusterTracer.TRACER.traceOnReplayNewLeadershipTermEvent(
             memberId,
             isInElection,
             leadershipTermId,
@@ -482,7 +482,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.TRACER.logOnAppendPosition(
+        ClusterTracer.TRACER.traceOnAppendPosition(
             memberId, leadershipTermId, logPosition, followerMemberId, flags);
     }
 
@@ -502,7 +502,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.TRACER.logOnCommitPosition(memberId, leadershipTermId, logPosition, leaderMemberId);
+        ClusterTracer.TRACER.traceOnCommitPosition(memberId, leadershipTermId, logPosition, leaderMemberId);
     }
 
     /**
@@ -528,7 +528,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.TRACER.logAppendSessionClose(
+        ClusterTracer.TRACER.traceAppendSessionClose(
             memberId, sessionId, closeReason, leadershipTermId, timestamp, timeUnit);
     }
 
@@ -555,7 +555,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.TRACER.logAppendSessionOpen(
+        ClusterTracer.TRACER.traceAppendSessionOpen(
             memberId, sessionId, leadershipTermId, logPosition, timestamp, timeUnit);
     }
 
@@ -575,7 +575,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.TRACER.logClusterBackupStateChange(Aeron.NULL_VALUE, oldState, newState, "");
+        ClusterTracer.TRACER.traceClusterBackupStateChange(Aeron.NULL_VALUE, oldState, newState, "");
     }
 
     /**
@@ -592,7 +592,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.TRACER.logTerminationPosition(memberId, leadershipTermId, logPosition);
+        ClusterTracer.TRACER.traceTerminationPosition(memberId, leadershipTermId, logPosition);
     }
 
     /**
@@ -611,7 +611,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.TRACER.logTerminationAck(memberId, leadershipTermId, logPosition, senderMemberId);
+        ClusterTracer.TRACER.traceTerminationAck(memberId, leadershipTermId, logPosition, senderMemberId);
     }
 
     /**
@@ -639,7 +639,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.TRACER.logServiceAck(
+        ClusterTracer.TRACER.traceServiceAck(
             memberId, logPosition, timestamp, timeUnit, ackId, relevantId, serviceId);
     }
 
@@ -668,7 +668,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.TRACER.logReplicationEnded(
+        ClusterTracer.TRACER.traceReplicationEnded(
             memberId, purpose, channel, srcRecordingId, dstRecordingId, position, hasSynced);
     }
 
@@ -701,7 +701,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.TRACER.logStandbySnapshotNotification(
+        ClusterTracer.TRACER.traceStandbySnapshotNotification(
             memberId,
             recordingId,
             leadershipTermId,
@@ -734,7 +734,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.TRACER.logNewElection(memberId, leadershipTermId, logPosition, appendPosition, reason);
+        ClusterTracer.TRACER.traceNewElection(memberId, leadershipTermId, logPosition, appendPosition, reason);
     }
 
     /**
@@ -762,7 +762,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.TRACER.logClusterSessionStateChange(
+        ClusterTracer.TRACER.traceClusterSessionStateChange(
             memberId, sessionId, action, oldState, newState, reason);
     }
 
@@ -787,7 +787,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.TRACER.logSnapshotEntryInvalidation(
+        ClusterTracer.TRACER.traceSnapshotEntryInvalidation(
             memberId, entryIndex, recordingId, logPosition, serviceId);
     }
 
@@ -803,6 +803,6 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterTracer.TRACER.logStart(version);
+        ClusterTracer.TRACER.traceStart(version);
     }
 }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/logging/ClusterTracing.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/logging/ClusterTracing.java
@@ -141,7 +141,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterEventLogger.LOGGER.logElectionStateChange(
+        ClusterTracer.LOGGER.logElectionStateChange(
             memberId,
             oldState,
             newState,
@@ -197,7 +197,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterEventLogger.LOGGER.logOnNewLeadershipTerm(
+        ClusterTracer.LOGGER.logOnNewLeadershipTerm(
             memberId,
             logLeadershipTermId,
             nextLeadershipTermId,
@@ -232,7 +232,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterEventLogger.LOGGER.logStateChange(memberId, oldState, newState, reason);
+        ClusterTracer.LOGGER.logStateChange(memberId, oldState, newState, reason);
     }
 
     /**
@@ -250,7 +250,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterEventLogger.LOGGER.logRoleChange(memberId, oldRole, newRole, "");
+        ClusterTracer.LOGGER.logRoleChange(memberId, oldRole, newRole, "");
     }
 
     /**
@@ -276,7 +276,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterEventLogger.LOGGER.logOnCanvassPosition(
+        ClusterTracer.LOGGER.logOnCanvassPosition(
             memberId, logLeadershipTermId, logPosition, leadershipTermId, followerMemberId, protocolVersion);
     }
 
@@ -303,7 +303,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterEventLogger.LOGGER.logOnRequestVote(
+        ClusterTracer.LOGGER.logOnRequestVote(
             memberId, logLeadershipTermId, logPosition, candidateTermId, candidateId, protocolVersion);
     }
 
@@ -332,7 +332,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterEventLogger.LOGGER.logOnVote(
+        ClusterTracer.LOGGER.logOnVote(
             memberId, logLeadershipTermId, logPosition, candidateTermId, candidateId, voterId, vote);
     }
 
@@ -357,7 +357,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterEventLogger.LOGGER.logOnCatchupPosition(
+        ClusterTracer.LOGGER.logOnCatchupPosition(
             memberId, leadershipTermId, logPosition, followerMemberId, catchupEndpoint);
     }
 
@@ -375,7 +375,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterEventLogger.LOGGER.logOnStopCatchup(memberId, leadershipTermId, followerMemberId);
+        ClusterTracer.LOGGER.logOnStopCatchup(memberId, leadershipTermId, followerMemberId);
     }
 
     /**
@@ -410,7 +410,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterEventLogger.LOGGER.logOnTruncateLogEntry(
+        ClusterTracer.LOGGER.logOnTruncateLogEntry(
             memberId,
             state,
             logLeadershipTermId,
@@ -450,7 +450,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterEventLogger.LOGGER.logOnReplayNewLeadershipTermEvent(
+        ClusterTracer.LOGGER.logOnReplayNewLeadershipTermEvent(
             memberId,
             isInElection,
             leadershipTermId,
@@ -482,7 +482,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterEventLogger.LOGGER.logOnAppendPosition(
+        ClusterTracer.LOGGER.logOnAppendPosition(
             memberId, leadershipTermId, logPosition, followerMemberId, flags);
     }
 
@@ -502,7 +502,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterEventLogger.LOGGER.logOnCommitPosition(memberId, leadershipTermId, logPosition, leaderMemberId);
+        ClusterTracer.LOGGER.logOnCommitPosition(memberId, leadershipTermId, logPosition, leaderMemberId);
     }
 
     /**
@@ -528,7 +528,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterEventLogger.LOGGER.logAppendSessionClose(
+        ClusterTracer.LOGGER.logAppendSessionClose(
             memberId, sessionId, closeReason, leadershipTermId, timestamp, timeUnit);
     }
 
@@ -555,7 +555,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterEventLogger.LOGGER.logAppendSessionOpen(
+        ClusterTracer.LOGGER.logAppendSessionOpen(
             memberId, sessionId, leadershipTermId, logPosition, timestamp, timeUnit);
     }
 
@@ -575,7 +575,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterEventLogger.LOGGER.logClusterBackupStateChange(Aeron.NULL_VALUE, oldState, newState, "");
+        ClusterTracer.LOGGER.logClusterBackupStateChange(Aeron.NULL_VALUE, oldState, newState, "");
     }
 
     /**
@@ -592,7 +592,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterEventLogger.LOGGER.logTerminationPosition(memberId, leadershipTermId, logPosition);
+        ClusterTracer.LOGGER.logTerminationPosition(memberId, leadershipTermId, logPosition);
     }
 
     /**
@@ -611,7 +611,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterEventLogger.LOGGER.logTerminationAck(memberId, leadershipTermId, logPosition, senderMemberId);
+        ClusterTracer.LOGGER.logTerminationAck(memberId, leadershipTermId, logPosition, senderMemberId);
     }
 
     /**
@@ -639,7 +639,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterEventLogger.LOGGER.logServiceAck(
+        ClusterTracer.LOGGER.logServiceAck(
             memberId, logPosition, timestamp, timeUnit, ackId, relevantId, serviceId);
     }
 
@@ -668,7 +668,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterEventLogger.LOGGER.logReplicationEnded(
+        ClusterTracer.LOGGER.logReplicationEnded(
             memberId, purpose, channel, srcRecordingId, dstRecordingId, position, hasSynced);
     }
 
@@ -701,7 +701,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterEventLogger.LOGGER.logStandbySnapshotNotification(
+        ClusterTracer.LOGGER.logStandbySnapshotNotification(
             memberId,
             recordingId,
             leadershipTermId,
@@ -734,7 +734,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterEventLogger.LOGGER.logNewElection(memberId, leadershipTermId, logPosition, appendPosition, reason);
+        ClusterTracer.LOGGER.logNewElection(memberId, leadershipTermId, logPosition, appendPosition, reason);
     }
 
     /**
@@ -762,7 +762,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterEventLogger.LOGGER.logClusterSessionStateChange(
+        ClusterTracer.LOGGER.logClusterSessionStateChange(
             memberId, sessionId, action, oldState, newState, reason);
     }
 
@@ -787,7 +787,7 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterEventLogger.LOGGER.logSnapshotEntryInvalidation(
+        ClusterTracer.LOGGER.logSnapshotEntryInvalidation(
             memberId, entryIndex, recordingId, logPosition, serviceId);
     }
 
@@ -803,6 +803,6 @@ public final class ClusterTracing
             return;
         }
 
-        ClusterEventLogger.LOGGER.logStart(version);
+        ClusterTracer.LOGGER.logStart(version);
     }
 }

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ClusterEventEnablementTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ClusterEventEnablementTest.java
@@ -17,7 +17,7 @@ package io.aeron.cluster;
 
 import io.aeron.CommonContext;
 import io.aeron.cluster.logging.ClusterEventCode;
-import io.aeron.cluster.logging.ClusterLog;
+import io.aeron.cluster.logging.ClusterTracing;
 import io.aeron.logging.EventConfiguration;
 import io.aeron.cluster.codecs.CloseReason;
 import io.aeron.test.InterruptAfter;
@@ -140,8 +140,8 @@ public class ClusterEventEnablementTest
 
     private void callGeneralLogMethods()
     {
-        final List<Method> logMethods = Arrays.stream(ClusterLog.class.getDeclaredMethods())
-            .filter((m) -> m.getName().startsWith("log"))
+        final List<Method> logMethods = Arrays.stream(ClusterTracing.class.getDeclaredMethods())
+            .filter((m) -> m.getName().startsWith("trace"))
             .filter((m) -> 0 != (m.getModifiers() & Modifier.STATIC))
             .toList();
 

--- a/aeron-cluster/src/test/java/io/aeron/cluster/logging/CborClusterEventCodecTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/logging/CborClusterEventCodecTest.java
@@ -58,7 +58,7 @@ class CborClusterEventCodecTest
         final CborDecode cborDecode = new CborDecode(List.of(new ProxyLoggerEventCallback(mockLoggingCallback)));
         final CborClusterTracer cborClusterEventLogger = new CborClusterTracer(ringBuffer);
 
-        cborClusterEventLogger.logElectionStateChange(
+        cborClusterEventLogger.traceElectionStateChange(
             12,
             ElectionState.CANVASS,
             ElectionState.CLOSED,
@@ -112,7 +112,7 @@ class CborClusterEventCodecTest
         final CborDecode cborDecode = new CborDecode(List.of(new ProxyLoggerEventCallback(mockLoggingCallback)));
         final CborClusterTracer cborClusterEventLogger = new CborClusterTracer(ringBuffer);
 
-        cborClusterEventLogger.logElectionStateChange(
+        cborClusterEventLogger.traceElectionStateChange(
             12,
             ElectionState.CANVASS,
             ElectionState.CLOSED,
@@ -147,7 +147,7 @@ class CborClusterEventCodecTest
         final CborDecode cborDecode = new CborDecode(List.of(new ProxyLoggerEventCallback(mockLoggingCallback)));
         final CborClusterTracer cborClusterEventLogger = new CborClusterTracer(ringBuffer);
 
-        cborClusterEventLogger.logElectionStateChange(
+        cborClusterEventLogger.traceElectionStateChange(
             value,
             ElectionState.CANVASS,
             ElectionState.CLOSED,
@@ -191,7 +191,7 @@ class CborClusterEventCodecTest
         final CborDecode cborDecode = new CborDecode(List.of(new ProxyLoggerEventCallback(mockLoggingCallback)));
         final CborClusterTracer cborClusterEventLogger = new CborClusterTracer(ringBuffer);
 
-        cborClusterEventLogger.logElectionStateChange(
+        cborClusterEventLogger.traceElectionStateChange(
             12,
             ElectionState.CANVASS,
             ElectionState.CLOSED,
@@ -222,7 +222,7 @@ class CborClusterEventCodecTest
 
         final String reason = "R".repeat(10_000);
 
-        cborClusterEventLogger.logElectionStateChange(
+        cborClusterEventLogger.traceElectionStateChange(
             12,
             ElectionState.CANVASS,
             ElectionState.CLOSED,

--- a/aeron-cluster/src/test/java/io/aeron/cluster/logging/CborClusterEventCodecTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/logging/CborClusterEventCodecTest.java
@@ -56,7 +56,7 @@ class CborClusterEventCodecTest
     {
         final LoggerEventCallback mockLoggingCallback = mock(LoggerEventCallback.class);
         final CborDecode cborDecode = new CborDecode(List.of(new ProxyLoggerEventCallback(mockLoggingCallback)));
-        final CborClusterEventLogger cborClusterEventLogger = new CborClusterEventLogger(ringBuffer);
+        final CborClusterTracer cborClusterEventLogger = new CborClusterTracer(ringBuffer);
 
         cborClusterEventLogger.logElectionStateChange(
             12,
@@ -110,7 +110,7 @@ class CborClusterEventCodecTest
     {
         final LoggerEventCallback mockLoggingCallback = mock(LoggerEventCallback.class);
         final CborDecode cborDecode = new CborDecode(List.of(new ProxyLoggerEventCallback(mockLoggingCallback)));
-        final CborClusterEventLogger cborClusterEventLogger = new CborClusterEventLogger(ringBuffer);
+        final CborClusterTracer cborClusterEventLogger = new CborClusterTracer(ringBuffer);
 
         cborClusterEventLogger.logElectionStateChange(
             12,
@@ -145,7 +145,7 @@ class CborClusterEventCodecTest
     {
         final LoggerEventCallback mockLoggingCallback = mock(LoggerEventCallback.class);
         final CborDecode cborDecode = new CborDecode(List.of(new ProxyLoggerEventCallback(mockLoggingCallback)));
-        final CborClusterEventLogger cborClusterEventLogger = new CborClusterEventLogger(ringBuffer);
+        final CborClusterTracer cborClusterEventLogger = new CborClusterTracer(ringBuffer);
 
         cborClusterEventLogger.logElectionStateChange(
             value,
@@ -189,7 +189,7 @@ class CborClusterEventCodecTest
     {
         final LoggerEventCallback mockLoggingCallback = mock(LoggerEventCallback.class);
         final CborDecode cborDecode = new CborDecode(List.of(new ProxyLoggerEventCallback(mockLoggingCallback)));
-        final CborClusterEventLogger cborClusterEventLogger = new CborClusterEventLogger(ringBuffer);
+        final CborClusterTracer cborClusterEventLogger = new CborClusterTracer(ringBuffer);
 
         cborClusterEventLogger.logElectionStateChange(
             12,
@@ -218,7 +218,7 @@ class CborClusterEventCodecTest
     {
         final LoggerEventCallback mockLoggingCallback = mock(LoggerEventCallback.class);
         final CborDecode cborDecode = new CborDecode(List.of(new ProxyLoggerEventCallback(mockLoggingCallback)));
-        final CborClusterEventLogger cborClusterEventLogger = new CborClusterEventLogger(ringBuffer);
+        final CborClusterTracer cborClusterEventLogger = new CborClusterTracer(ringBuffer);
 
         final String reason = "R".repeat(10_000);
 

--- a/aeron-cluster/src/test/java/io/aeron/cluster/logging/CborClusterTracerTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/logging/CborClusterTracerTest.java
@@ -43,7 +43,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-class ClusterEventLoggerCborImplTest
+class CborClusterTracerTest
 {
     private final ManyToOneRingBuffer ringBuffer = new ManyToOneRingBuffer(
         new UnsafeBuffer(BufferUtil.allocateDirectAligned(64 * 1024 + TRAILER_LENGTH, CACHE_LINE_LENGTH)));

--- a/aeron-cluster/src/test/java/io/aeron/cluster/logging/ClusterEventLoggerCborImplTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/logging/ClusterEventLoggerCborImplTest.java
@@ -50,7 +50,7 @@ class ClusterEventLoggerCborImplTest
 
     private final LoggerEventCallback mockLoggingCallback = mock(LoggerEventCallback.class);
     private final CborDecode cborDecode = new CborDecode(List.of(new ProxyLoggerEventCallback(mockLoggingCallback)));
-    private final ClusterEventLogger logger = new CborClusterEventLogger(ringBuffer);
+    private final ClusterTracer logger = new CborClusterTracer(ringBuffer);
 
     private void drain()
     {

--- a/aeron-cluster/src/test/java/io/aeron/cluster/logging/ClusterEventLoggerCborImplTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/logging/ClusterEventLoggerCborImplTest.java
@@ -63,7 +63,7 @@ class ClusterEventLoggerCborImplTest
     @Test
     void logElectionStateChangeMatchesTheHandWrittenTemplateShape()
     {
-        logger.logElectionStateChange(
+        logger.traceElectionStateChange(
             12,
             ElectionState.CANVASS,
             ElectionState.CLOSED,
@@ -103,7 +103,7 @@ class ClusterEventLoggerCborImplTest
     {
         final String reason = "R".repeat(10_000);
 
-        logger.logElectionStateChange(
+        logger.traceElectionStateChange(
             12, ElectionState.CANVASS, ElectionState.CLOSED, 2342, 23434, 62354, 2789345, 87345, 345345, 2345,
             reason);
 
@@ -120,7 +120,7 @@ class ClusterEventLoggerCborImplTest
     @Test
     void logAppendSessionCloseEncodesCloseReasonAndTimeUnitAsEnumTag()
     {
-        logger.logAppendSessionClose(7, 555L, CloseReason.CLIENT_ACTION, 99L, 123456789L, TimeUnit.MICROSECONDS);
+        logger.traceAppendSessionClose(7, 555L, CloseReason.CLIENT_ACTION, 99L, 123456789L, TimeUnit.MICROSECONDS);
 
         drain();
 
@@ -142,7 +142,7 @@ class ClusterEventLoggerCborImplTest
     @Test
     void logOnVoteEncodesBooleanFieldWithNoTagInDeclaredParameterOrder()
     {
-        logger.logOnVote(1, 10L, 20L, 30L, 2, 3, true);
+        logger.traceOnVote(1, 10L, 20L, 30L, 2, 3, true);
 
         drain();
 
@@ -165,7 +165,7 @@ class ClusterEventLoggerCborImplTest
     @Test
     void logStateChangeUsesTheDynamicallyPassedEventCodeForTheHeader()
     {
-        logger.logStateChange(4, ElectionState.NOMINATE, ElectionState.LEADER_READY, "because");
+        logger.traceStateChange(4, ElectionState.NOMINATE, ElectionState.LEADER_READY, "because");
 
         drain();
 

--- a/aeron-cluster/src/test/java/io/aeron/cluster/logging/GenericLoggingTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/logging/GenericLoggingTest.java
@@ -25,7 +25,7 @@ import static org.agrona.BitUtil.CACHE_LINE_LENGTH;
 import static org.agrona.concurrent.ringbuffer.RingBufferDescriptor.TRAILER_LENGTH;
 
 /**
- * Reflectively drives every {@link ClusterEventLogger} method with a range of nominal, boundary, and {@code null}
+ * Reflectively drives every {@link ClusterTracer} method with a range of nominal, boundary, and {@code null}
  * values and verifies (via {@link io.aeron.logging.CborDecode}) that they all survive the CBOR round trip.
  */
 class GenericLoggingTest
@@ -35,8 +35,8 @@ class GenericLoggingTest
     {
         final ManyToOneRingBuffer ringBuffer = new ManyToOneRingBuffer(
             new UnsafeBuffer(BufferUtil.allocateDirectAligned(64 * 1024 + TRAILER_LENGTH, CACHE_LINE_LENGTH)));
-        final ClusterEventLogger logger = new CborClusterEventLogger(ringBuffer);
+        final ClusterTracer logger = new CborClusterTracer(ringBuffer);
 
-        GenericLoggerEventVerifier.verifyAllLogMethods(ClusterEventLogger.class, logger, ringBuffer);
+        GenericLoggerEventVerifier.verifyAllLogMethods(ClusterTracer.class, logger, ringBuffer);
     }
 }

--- a/aeron-driver/src/main/java/io/aeron/driver/AbstractMinMulticastFlowControl.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/AbstractMinMulticastFlowControl.java
@@ -16,7 +16,7 @@
 package io.aeron.driver;
 
 import io.aeron.CommonContext;
-import io.aeron.driver.logging.DriverLog;
+import io.aeron.driver.logging.DriverTracing;
 import io.aeron.driver.media.UdpChannel;
 import io.aeron.driver.status.FlowControlReceivers;
 import io.aeron.protocol.ErrorFlyweight;
@@ -436,13 +436,13 @@ public abstract class AbstractMinMulticastFlowControl
     private void receiverAdded(
         final long receiverId, final int sessionId, final int streamId, final String channel, final int receiverCount)
     {
-        DriverLog.logFlowControlReceiverAdded(receiverId, sessionId, streamId, channel, receiverCount);
+        DriverTracing.traceFlowControlReceiverAdded(receiverId, sessionId, streamId, channel, receiverCount);
     }
 
     private void receiverRemoved(
         final long receiverId, final int sessionId, final int streamId, final String channel, final int receiverCount)
     {
-        DriverLog.logFlowControlReceiverRemoved(receiverId, sessionId, streamId, channel, receiverCount);
+        DriverTracing.traceFlowControlReceiverRemoved(receiverId, sessionId, streamId, channel, receiverCount);
     }
 
     private long lastSetupSenderLimit(final long nowNs)

--- a/aeron-driver/src/main/java/io/aeron/driver/ClientCommandAdapter.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/ClientCommandAdapter.java
@@ -29,7 +29,7 @@ import io.aeron.command.RemoveSubscriptionFlyweight;
 import io.aeron.command.StaticCounterMessageFlyweight;
 import io.aeron.command.SubscriptionMessageFlyweight;
 import io.aeron.command.TerminateDriverFlyweight;
-import io.aeron.driver.logging.DriverLog;
+import io.aeron.driver.logging.DriverTracing;
 import io.aeron.exceptions.ControlProtocolException;
 import io.aeron.exceptions.StorageSpaceException;
 import org.agrona.ErrorHandler;
@@ -110,7 +110,7 @@ final class ClientCommandAdapter implements ControlledMessageHandler
     public ControlledMessageHandler.Action onMessage(
         final int msgTypeId, final MutableDirectBuffer buffer, final int index, final int length)
     {
-        DriverLog.logCmd(msgTypeId, buffer, index, length);
+        DriverTracing.traceCmd(msgTypeId, buffer, index, length);
 
         long correlationId = 0;
 

--- a/aeron-driver/src/main/java/io/aeron/driver/ClientProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/ClientProxy.java
@@ -18,7 +18,7 @@ package io.aeron.driver;
 import io.aeron.Aeron;
 import io.aeron.ErrorCode;
 import io.aeron.command.*;
-import io.aeron.driver.logging.DriverLog;
+import io.aeron.driver.logging.DriverTracing;
 import org.agrona.DirectBuffer;
 import org.agrona.ExpandableArrayBuffer;
 import org.agrona.MutableDirectBuffer;
@@ -216,7 +216,7 @@ final class ClientProxy
 
     private void transmit(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
     {
-        DriverLog.logCmd(msgTypeId, buffer, index, length);
+        DriverTracing.traceCmd(msgTypeId, buffer, index, length);
         transmitter.transmit(msgTypeId, buffer, index, length);
     }
 

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -20,7 +20,7 @@ import io.aeron.driver.MediaDriver.Context;
 import io.aeron.driver.buffer.RawLog;
 import io.aeron.driver.exceptions.InvalidChannelException;
 import io.aeron.driver.exceptions.UnknownSubscriptionException;
-import io.aeron.driver.logging.DriverLog;
+import io.aeron.driver.logging.DriverTracing;
 import io.aeron.driver.media.ControlMode;
 import io.aeron.driver.media.ReceiveChannelEndpoint;
 import io.aeron.driver.media.ReceiveDestinationTransport;
@@ -252,7 +252,7 @@ public final class DriverConductor implements Agent
     @Override
     public void onStart()
     {
-        DriverLog.logStart(MediaDriverVersion.VERSION);
+        DriverTracing.traceStart(MediaDriverVersion.VERSION);
 
         final long nowNs = nanoClock.nanoTime();
         cachedNanoClock.update(nowNs);
@@ -585,7 +585,7 @@ public final class DriverConductor implements Agent
 
     void cleanupPublication(final NetworkPublication publication)
     {
-        DriverLog.logPublicationRemoval(publication.channel(), publication.sessionId(), publication.streamId());
+        DriverTracing.tracePublicationRemoval(publication.channel(), publication.sessionId(), publication.streamId());
 
         senderProxy.removeNetworkPublication(publication);
 
@@ -610,7 +610,7 @@ public final class DriverConductor implements Agent
 
     void cleanupSubscriptionLink(final SubscriptionLink subscription)
     {
-        DriverLog.logSubscriptionRemoval(
+        DriverTracing.traceSubscriptionRemoval(
             subscription.channel(), subscription.streamId(), subscription.registrationId());
 
         final ReceiveChannelEndpoint channelEndpoint = subscription.channelEndpoint();
@@ -676,7 +676,7 @@ public final class DriverConductor implements Agent
 
     void cleanupImage(final PublicationImage image)
     {
-        DriverLog.logImageRemoval(image.channel(), image.sessionId(), image.streamId(), image.correlationId());
+        DriverTracing.traceImageRemoval(image.channel(), image.sessionId(), image.streamId(), image.correlationId());
 
         for (int i = 0, size = subscriptionLinks.size(); i < size; i++)
         {
@@ -686,7 +686,7 @@ public final class DriverConductor implements Agent
 
     void cleanupIpcPublication(final IpcPublication publication)
     {
-        DriverLog.logPublicationRemoval(publication.channel(), publication.sessionId(), publication.streamId());
+        DriverTracing.tracePublicationRemoval(publication.channel(), publication.sessionId(), publication.streamId());
 
         for (int i = 0, size = subscriptionLinks.size(); i < size; i++)
         {

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverNameResolver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverNameResolver.java
@@ -17,7 +17,7 @@ package io.aeron.driver;
 
 import io.aeron.AeronCounters;
 import io.aeron.CounterProvider;
-import io.aeron.driver.logging.DriverLog;
+import io.aeron.driver.logging.DriverTracing;
 import io.aeron.driver.media.NetworkUtil;
 import io.aeron.driver.media.UdpChannel;
 import io.aeron.driver.media.UdpNameResolutionTransport;
@@ -648,12 +648,12 @@ final class DriverNameResolver implements UdpNameResolutionTransport.UdpFrameHan
 
         static void neighborAdded(final long nowMs, final InetSocketAddress address)
         {
-            DriverLog.logNeighborAdded(address);
+            DriverTracing.traceNeighborAdded(address);
         }
 
         static void neighborRemoved(final long nowMs, final InetSocketAddress address)
         {
-            DriverLog.logNeighborRemoved(address);
+            DriverTracing.traceNeighborRemoved(address);
         }
     }
 

--- a/aeron-driver/src/main/java/io/aeron/driver/IpcPublication.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/IpcPublication.java
@@ -18,7 +18,7 @@ package io.aeron.driver;
 import io.aeron.Aeron;
 import io.aeron.CommonContext;
 import io.aeron.driver.buffer.RawLog;
-import io.aeron.driver.logging.DriverLog;
+import io.aeron.driver.logging.DriverTracing;
 import io.aeron.driver.status.SystemCounters;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.logbuffer.LogBufferUnblocker;
@@ -665,6 +665,6 @@ public final class IpcPublication implements DriverManagedResource, Subscribable
         final int streamId,
         final String channel)
     {
-        DriverLog.logPublicationRevoke(revokedPos, sessionId, streamId, channel);
+        DriverTracing.tracePublicationRevoke(revokedPos, sessionId, streamId, channel);
     }
 }

--- a/aeron-driver/src/main/java/io/aeron/driver/NetworkPublication.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/NetworkPublication.java
@@ -18,7 +18,7 @@ package io.aeron.driver;
 import io.aeron.Aeron;
 import io.aeron.CommonContext;
 import io.aeron.driver.buffer.RawLog;
-import io.aeron.driver.logging.DriverLog;
+import io.aeron.driver.logging.DriverTracing;
 import io.aeron.driver.media.SendChannelEndpoint;
 import io.aeron.driver.status.SystemCounters;
 import io.aeron.logbuffer.FrameDescriptor;
@@ -1322,6 +1322,6 @@ public final class NetworkPublication
         final int streamId,
         final String channel)
     {
-        DriverLog.logPublicationRevoke(revokedPos, sessionId, streamId, channel);
+        DriverTracing.tracePublicationRevoke(revokedPos, sessionId, streamId, channel);
     }
 }

--- a/aeron-driver/src/main/java/io/aeron/driver/PublicationImage.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/PublicationImage.java
@@ -16,7 +16,7 @@
 package io.aeron.driver;
 
 import io.aeron.driver.buffer.RawLog;
-import io.aeron.driver.logging.DriverLog;
+import io.aeron.driver.logging.DriverTracing;
 import io.aeron.driver.media.ImageConnection;
 import io.aeron.driver.media.ReceiveChannelEndpoint;
 import io.aeron.driver.media.ReceiveDestinationTransport;
@@ -808,7 +808,7 @@ public final class PublicationImage
         final int streamId,
         final String channel)
     {
-        DriverLog.logPublicationImageRevoke(revokedPos, sessionId, streamId, channel);
+        DriverTracing.tracePublicationImageRevoke(revokedPos, sessionId, streamId, channel);
     }
 
     /**

--- a/aeron-driver/src/main/java/io/aeron/driver/ReceiverProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/ReceiverProxy.java
@@ -15,7 +15,7 @@
  */
 package io.aeron.driver;
 
-import io.aeron.driver.logging.DriverLog;
+import io.aeron.driver.logging.DriverTracing;
 import io.aeron.driver.media.ReceiveChannelEndpoint;
 import io.aeron.driver.media.ReceiveDestinationTransport;
 import io.aeron.driver.media.UdpChannel;
@@ -73,13 +73,13 @@ final class ReceiverProxy extends CommandProxy
 
     void registerReceiveChannelEndpoint(final ReceiveChannelEndpoint channelEndpoint)
     {
-        DriverLog.logReceiveChannelCreation(channelEndpoint.udpChannel().description());
+        DriverTracing.traceReceiveChannelCreation(channelEndpoint.udpChannel().description());
         offer(() -> receiver.onRegisterReceiveChannelEndpoint(channelEndpoint));
     }
 
     void closeReceiveChannelEndpoint(final ReceiveChannelEndpoint channelEndpoint)
     {
-        DriverLog.logReceiveChannelClose(channelEndpoint.udpChannel().description());
+        DriverTracing.traceReceiveChannelClose(channelEndpoint.udpChannel().description());
         offer(() -> receiver.onCloseReceiveChannelEndpoint(channelEndpoint));
     }
 

--- a/aeron-driver/src/main/java/io/aeron/driver/SenderProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/SenderProxy.java
@@ -16,7 +16,7 @@
 package io.aeron.driver;
 
 import io.aeron.ChannelUri;
-import io.aeron.driver.logging.DriverLog;
+import io.aeron.driver.logging.DriverTracing;
 import io.aeron.driver.media.SendChannelEndpoint;
 import org.agrona.concurrent.OneToOneConcurrentArrayQueue;
 import org.agrona.concurrent.status.AtomicCounter;
@@ -42,13 +42,13 @@ final class SenderProxy extends CommandProxy
 
     void registerSendChannelEndpoint(final SendChannelEndpoint channelEndpoint)
     {
-        DriverLog.logSendChannelCreation(channelEndpoint.udpChannel().description());
+        DriverTracing.traceSendChannelCreation(channelEndpoint.udpChannel().description());
         offer(() -> sender.onRegisterSendChannelEndpoint(channelEndpoint));
     }
 
     void closeSendChannelEndpoint(final SendChannelEndpoint channelEndpoint)
     {
-        DriverLog.logSendChannelClose(channelEndpoint.udpChannel().description());
+        DriverTracing.traceSendChannelClose(channelEndpoint.udpChannel().description());
         offer(() -> sender.onCloseSendChannelEndpoint(channelEndpoint));
     }
 

--- a/aeron-driver/src/main/java/io/aeron/driver/TimeTrackingNameResolver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/TimeTrackingNameResolver.java
@@ -16,7 +16,7 @@
 package io.aeron.driver;
 
 import io.aeron.CounterProvider;
-import io.aeron.driver.logging.DriverLog;
+import io.aeron.driver.logging.DriverTracing;
 import org.agrona.concurrent.NanoClock;
 import org.agrona.concurrent.status.CountersReader;
 
@@ -131,7 +131,7 @@ final class TimeTrackingNameResolver implements NameResolverAgent
 
     static void logHostName(final long durationNs, final String hostName)
     {
-        DriverLog.logHostName(durationNs, hostName);
+        DriverTracing.traceHostName(durationNs, hostName);
     }
 
     private static void logResolve(
@@ -141,7 +141,7 @@ final class TimeTrackingNameResolver implements NameResolverAgent
         final boolean isReResolution,
         final InetAddress resolvedAddress)
     {
-        DriverLog.logResolve(resolverName, durationNs, name, isReResolution, resolvedAddress);
+        DriverTracing.traceResolve(resolverName, durationNs, name, isReResolution, resolvedAddress);
     }
 
     private static void logLookup(
@@ -151,6 +151,6 @@ final class TimeTrackingNameResolver implements NameResolverAgent
         final boolean isReLookup,
         final String resolvedName)
     {
-        DriverLog.logLookup(resolverName, durationNs, name, isReLookup, resolvedName);
+        DriverTracing.traceLookup(resolverName, durationNs, name, isReLookup, resolvedName);
     }
 }

--- a/aeron-driver/src/main/java/io/aeron/driver/UntetheredSubscription.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/UntetheredSubscription.java
@@ -15,7 +15,7 @@
  */
 package io.aeron.driver;
 
-import io.aeron.driver.logging.DriverLog;
+import io.aeron.driver.logging.DriverTracing;
 import org.agrona.concurrent.status.ReadablePosition;
 
 class UntetheredSubscription
@@ -55,6 +55,6 @@ class UntetheredSubscription
         final int sessionId,
         final long nowNs)
     {
-        DriverLog.logUntetheredSubscriptionStateChange(oldState, newState, subscriptionId, streamId, sessionId);
+        DriverTracing.traceUntetheredSubscriptionStateChange(oldState, newState, subscriptionId, streamId, sessionId);
     }
 }

--- a/aeron-driver/src/main/java/io/aeron/driver/logging/DriverTracer.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/logging/DriverTracer.java
@@ -64,7 +64,7 @@ public interface DriverTracer
      * @param messageLength of the encoded event.
      */
     @LoggerMethod(bufferView = { "buffer", "offset", "messageLength" })
-    default void log(
+    default void trace(
         final DriverEventCode code,
         @Tag(AERON_DRIVER_ADMIN_TAG) final DirectBuffer buffer,
         final int offset,
@@ -82,7 +82,7 @@ public interface DriverTracer
      * @param frameLength of the frame.
      */
     @LoggerMethod(eventCode = "FRAME_IN", bufferView = { "buffer", "offset", "frameLength" })
-    default void logFrameIn(
+    default void traceFrameIn(
         final InetAddress srcAddress,
         final int srcPort,
         @Tag(AERON_PROTOCOL_TAG) @AllowTruncate final DirectBuffer buffer,
@@ -99,7 +99,7 @@ public interface DriverTracer
      * @param buffer     containing the frame.
      */
     @LoggerMethod(eventCode = "FRAME_OUT")
-    default void logFrameOut(
+    default void traceFrameOut(
         final InetAddress dstAddress,
         final int dstPort,
         @Tag(AERON_PROTOCOL_TAG) @AllowTruncate final ByteBuffer buffer)
@@ -114,7 +114,7 @@ public interface DriverTracer
      * @param streamId  within the channel.
      */
     @LoggerMethod(eventCode = "REMOVE_PUBLICATION_CLEANUP")
-    default void logPublicationRemoval(final String channel, final int sessionId, final int streamId)
+    default void tracePublicationRemoval(final String channel, final int sessionId, final int streamId)
     {
     }
 
@@ -126,7 +126,7 @@ public interface DriverTracer
      * @param subscriptionId for the subscription.
      */
     @LoggerMethod(eventCode = "REMOVE_SUBSCRIPTION_CLEANUP")
-    default void logSubscriptionRemoval(final String channel, final int streamId, final long subscriptionId)
+    default void traceSubscriptionRemoval(final String channel, final int streamId, final long subscriptionId)
     {
     }
 
@@ -139,7 +139,7 @@ public interface DriverTracer
      * @param correlationId for the image.
      */
     @LoggerMethod(eventCode = "REMOVE_IMAGE_CLEANUP")
-    default void logImageRemoval(
+    default void traceImageRemoval(
         final String channel,
         final int sessionId,
         final int streamId,
@@ -153,7 +153,7 @@ public interface DriverTracer
      * @param value description of the channel.
      */
     @LoggerMethod(eventCode = "SEND_CHANNEL_CREATION")
-    default void logSendChannelCreation(final String value)
+    default void traceSendChannelCreation(final String value)
     {
     }
 
@@ -163,7 +163,7 @@ public interface DriverTracer
      * @param value description of the channel.
      */
     @LoggerMethod(eventCode = "SEND_CHANNEL_CLOSE")
-    default void logSendChannelClose(final String value)
+    default void traceSendChannelClose(final String value)
     {
     }
 
@@ -173,7 +173,7 @@ public interface DriverTracer
      * @param value description of the channel.
      */
     @LoggerMethod(eventCode = "RECEIVE_CHANNEL_CREATION")
-    default void logReceiveChannelCreation(final String value)
+    default void traceReceiveChannelCreation(final String value)
     {
     }
 
@@ -183,7 +183,7 @@ public interface DriverTracer
      * @param value description of the channel.
      */
     @LoggerMethod(eventCode = "RECEIVE_CHANNEL_CLOSE")
-    default void logReceiveChannelClose(final String value)
+    default void traceReceiveChannelClose(final String value)
     {
     }
 
@@ -194,7 +194,7 @@ public interface DriverTracer
      * @param value of the string to be logged.
      */
     @LoggerMethod
-    default void logString(final DriverEventCode code, final String value)
+    default void traceString(final DriverEventCode code, final String value)
     {
     }
 
@@ -209,7 +209,7 @@ public interface DriverTracer
      * @param sessionId      of the image.
      */
     @LoggerMethod(eventCode = "UNTETHERED_SUBSCRIPTION_STATE_CHANGE")
-    default <E extends Enum<E>> void logUntetheredSubscriptionStateChange(
+    default <E extends Enum<E>> void traceUntetheredSubscriptionStateChange(
         final E oldState, final E newState, final long subscriptionId, final int streamId, final int sessionId)
     {
     }
@@ -221,7 +221,7 @@ public interface DriverTracer
      * @param port    of the neighbor.
      */
     @LoggerMethod(eventCode = "NAME_RESOLUTION_NEIGHBOR_ADDED")
-    default void logNeighborAdded(final InetAddress address, final int port)
+    default void traceNeighborAdded(final InetAddress address, final int port)
     {
     }
 
@@ -232,7 +232,7 @@ public interface DriverTracer
      * @param port    of the neighbor.
      */
     @LoggerMethod(eventCode = "NAME_RESOLUTION_NEIGHBOR_REMOVED")
-    default void logNeighborRemoved(final InetAddress address, final int port)
+    default void traceNeighborRemoved(final InetAddress address, final int port)
     {
     }
 
@@ -246,7 +246,7 @@ public interface DriverTracer
      * @param address        address that was resolved to, can be {@code null}.
      */
     @LoggerMethod(eventCode = "NAME_RESOLUTION_RESOLVE")
-    default void logResolve(
+    default void traceResolve(
         final String resolverName,
         final long durationNs,
         final String name,
@@ -265,7 +265,7 @@ public interface DriverTracer
      * @param resolvedName       address that was resolved to, can be null.
      */
     @LoggerMethod(eventCode = "NAME_RESOLUTION_LOOKUP")
-    default void logLookup(
+    default void traceLookup(
         final String resolverName,
         final long durationNs,
         final String name,
@@ -281,7 +281,7 @@ public interface DriverTracer
      * @param hostName   host name being resolved.
      */
     @LoggerMethod(eventCode = "NAME_RESOLUTION_HOST_NAME")
-    default void logHostName(final long durationNs, final String hostName)
+    default void traceHostName(final long durationNs, final String hostName)
     {
     }
 
@@ -295,7 +295,7 @@ public interface DriverTracer
      * @param receiverCount number of the receivers after the event.
      */
     @LoggerMethod(eventCode = "FLOW_CONTROL_RECEIVER_ADDED")
-    default void logFlowControlReceiverAdded(
+    default void traceFlowControlReceiverAdded(
         final long receiverId,
         final int sessionId,
         final int streamId,
@@ -314,7 +314,7 @@ public interface DriverTracer
      * @param receiverCount number of the receivers after the event.
      */
     @LoggerMethod(eventCode = "FLOW_CONTROL_RECEIVER_REMOVED")
-    default void logFlowControlReceiverRemoved(
+    default void traceFlowControlReceiverRemoved(
         final long receiverId,
         final int sessionId,
         final int streamId,
@@ -336,7 +336,7 @@ public interface DriverTracer
      * @param channel    of the Nak.
      */
     @LoggerMethod(eventCode = "NAK_SENT")
-    default void logNakSent(
+    default void traceNakSent(
         final InetAddress address,
         final int port,
         final int sessionId,
@@ -361,7 +361,7 @@ public interface DriverTracer
      * @param channel    of the Nak.
      */
     @LoggerMethod(eventCode = "NAK_RECEIVED")
-    default void logNakReceived(
+    default void traceNakReceived(
         final InetAddress address,
         final int port,
         final int sessionId,
@@ -384,7 +384,7 @@ public interface DriverTracer
      * @param channel      of the Resend.
      */
     @LoggerMethod(eventCode = "RESEND")
-    default void logResend(
+    default void traceResend(
         final int sessionId,
         final int streamId,
         final int termId,
@@ -403,7 +403,7 @@ public interface DriverTracer
      * @param channel    of the PublicationRevoke
      */
     @LoggerMethod(eventCode = "PUBLICATION_REVOKE")
-    default void logPublicationRevoke(
+    default void tracePublicationRevoke(
         final long revokedPos,
         final int sessionId,
         final int streamId,
@@ -420,7 +420,7 @@ public interface DriverTracer
      * @param channel    of the PublicationImageRevoke
      */
     @LoggerMethod(eventCode = "PUBLICATION_IMAGE_REVOKE")
-    default void logPublicationImageRevoke(
+    default void tracePublicationImageRevoke(
         final long revokedPos,
         final int sessionId,
         final int streamId,
@@ -434,7 +434,7 @@ public interface DriverTracer
      * @param version   of the driver.
      */
     @LoggerMethod(eventCode = "START")
-    default void logStart(final String version)
+    default void traceStart(final String version)
     {
     }
 

--- a/aeron-driver/src/main/java/io/aeron/driver/logging/DriverTracer.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/logging/DriverTracer.java
@@ -38,12 +38,12 @@ import static io.aeron.logging.CborUtils.AERON_PROTOCOL_TAG;
  * {@link LoggerMethod}-annotated methods below.
  */
 @GeneratedLogger(eventCodeType = "io.aeron.driver.logging.DriverEventCode")
-public interface DriverEventLogger
+public interface DriverTracer
 {
     /**
      * Logger for writing into the {@link ManyToOneRingBuffer} held by {@link EventConfiguration#eventReader}.
      */
-    DriverEventLogger LOGGER = new CborDriverEventLogger(EventConfiguration.eventReader().ringBuffer());
+    DriverTracer LOGGER = new CborDriverTracer(EventConfiguration.eventReader().ringBuffer());
 
     /**
      * Maximum length of a host name.

--- a/aeron-driver/src/main/java/io/aeron/driver/logging/DriverTracer.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/logging/DriverTracer.java
@@ -43,7 +43,7 @@ public interface DriverTracer
     /**
      * Logger for writing into the {@link ManyToOneRingBuffer} held by {@link EventConfiguration#eventReader}.
      */
-    DriverTracer LOGGER = new CborDriverTracer(EventConfiguration.eventReader().ringBuffer());
+    DriverTracer TRACER = new CborDriverTracer(EventConfiguration.eventReader().ringBuffer());
 
     /**
      * Maximum length of a host name.

--- a/aeron-driver/src/main/java/io/aeron/driver/logging/DriverTracing.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/logging/DriverTracing.java
@@ -35,7 +35,7 @@ import static io.aeron.driver.logging.DriverEventLogger.LOGGER;
  * Direct-call entry points for logging {@link io.aeron.driver.MediaDriver} events, replacing the previous
  * ByteBuddy-based instrumentation.
  */
-public final class DriverLog
+public final class DriverTracing
 {
     private static final Object2ObjectHashMap<String, EnumSet<DriverEventCode>> SPECIAL_EVENTS =
         new Object2ObjectHashMap<>();
@@ -98,7 +98,7 @@ public final class DriverLog
     private static final boolean LOG_TEXT_DATA_ENABLED = isEnabled(TEXT_DATA);
     private static final boolean LOG_DRIVER_START = !ENABLED_EVENT_CODES.isEmpty();
 
-    private DriverLog()
+    private DriverTracing()
     {
     }
 
@@ -121,7 +121,7 @@ public final class DriverLog
      * @param offset      in the buffer at which the frame begins.
      * @param frameLength of the frame.
      */
-    public static void logFrameIn(
+    public static void traceFrameIn(
         final InetSocketAddress srcAddress,
         final DirectBuffer buffer,
         final int offset,
@@ -141,7 +141,7 @@ public final class DriverLog
      * @param buffer     containing the frame.
      * @param dstAddress for the frame.
      */
-    public static void logFrameOut(final ByteBuffer buffer, final InetSocketAddress dstAddress)
+    public static void traceFrameOut(final ByteBuffer buffer, final InetSocketAddress dstAddress)
     {
         if (!LOG_FRAME_OUT_ENABLED)
         {
@@ -158,7 +158,7 @@ public final class DriverLog
      * @param sessionId for the publication.
      * @param streamId  within the channel.
      */
-    public static void logPublicationRemoval(final String channel, final int sessionId, final int streamId)
+    public static void tracePublicationRemoval(final String channel, final int sessionId, final int streamId)
     {
         if (!LOG_REMOVE_PUBLICATION_CLEANUP_ENABLED)
         {
@@ -175,7 +175,7 @@ public final class DriverLog
      * @param streamId       within the channel.
      * @param subscriptionId for the subscription.
      */
-    public static void logSubscriptionRemoval(final String channel, final int streamId, final long subscriptionId)
+    public static void traceSubscriptionRemoval(final String channel, final int streamId, final long subscriptionId)
     {
         if (!LOG_REMOVE_SUBSCRIPTION_CLEANUP_ENABLED)
         {
@@ -193,7 +193,7 @@ public final class DriverLog
      * @param streamId      for the image.
      * @param correlationId for the image.
      */
-    public static void logImageRemoval(
+    public static void traceImageRemoval(
         final String channel, final int sessionId, final int streamId, final long correlationId)
     {
         if (!LOG_REMOVE_IMAGE_CLEANUP_ENABLED)
@@ -209,7 +209,7 @@ public final class DriverLog
      *
      * @param description of the channel.
      */
-    public static void logSendChannelCreation(final String description)
+    public static void traceSendChannelCreation(final String description)
     {
         if (!LOG_SEND_CHANNEL_CREATION_ENABLED)
         {
@@ -224,7 +224,7 @@ public final class DriverLog
      *
      * @param description of the channel.
      */
-    public static void logSendChannelClose(final String description)
+    public static void traceSendChannelClose(final String description)
     {
         if (!LOG_SEND_CHANNEL_CLOSE_ENABLED)
         {
@@ -239,7 +239,7 @@ public final class DriverLog
      *
      * @param description of the channel.
      */
-    public static void logReceiveChannelCreation(final String description)
+    public static void traceReceiveChannelCreation(final String description)
     {
         if (!LOG_RECEIVE_CHANNEL_CREATION_ENABLED)
         {
@@ -254,7 +254,7 @@ public final class DriverLog
      *
      * @param description of the channel.
      */
-    public static void logReceiveChannelClose(final String description)
+    public static void traceReceiveChannelClose(final String description)
     {
         if (!LOG_RECEIVE_CHANNEL_CLOSE_ENABLED)
         {
@@ -274,7 +274,7 @@ public final class DriverLog
      * @param streamId       of the image.
      * @param sessionId      of the image.
      */
-    public static <E extends Enum<E>> void logUntetheredSubscriptionStateChange(
+    public static <E extends Enum<E>> void traceUntetheredSubscriptionStateChange(
         final E oldState, final E newState, final long subscriptionId, final int streamId, final int sessionId)
     {
         if (!LOG_UNTETHERED_SUBSCRIPTION_STATE_CHANGE_ENABLED)
@@ -291,7 +291,7 @@ public final class DriverLog
      *
      * @param address of the neighbor.
      */
-    public static void logNeighborAdded(final InetSocketAddress address)
+    public static void traceNeighborAdded(final InetSocketAddress address)
     {
         if (!LOG_NAME_RESOLUTION_NEIGHBOR_ADDED_ENABLED)
         {
@@ -306,7 +306,7 @@ public final class DriverLog
      *
      * @param address of the neighbor.
      */
-    public static void logNeighborRemoved(final InetSocketAddress address)
+    public static void traceNeighborRemoved(final InetSocketAddress address)
     {
         if (!LOG_NAME_RESOLUTION_NEIGHBOR_REMOVED_ENABLED)
         {
@@ -325,7 +325,7 @@ public final class DriverLog
      * @param isReResolution {@code true} if this is a re-resolution or {@code false} if initial resolution.
      * @param address        address that was resolved to, can be {@code null}.
      */
-    public static void logResolve(
+    public static void traceResolve(
         final String resolverName,
         final long durationNs,
         final String name,
@@ -349,7 +349,7 @@ public final class DriverLog
      * @param isReLookup   {@code true} if this is a re-lookup.
      * @param resolvedName address that was resolved to, can be {@code null}.
      */
-    public static void logLookup(
+    public static void traceLookup(
         final String resolverName,
         final long durationNs,
         final String name,
@@ -370,7 +370,7 @@ public final class DriverLog
      * @param durationNs of the call in nanoseconds.
      * @param hostName   host name being resolved.
      */
-    public static void logHostName(final long durationNs, final String hostName)
+    public static void traceHostName(final long durationNs, final String hostName)
     {
         if (!LOG_NAME_RESOLUTION_HOST_NAME_ENABLED)
         {
@@ -389,7 +389,7 @@ public final class DriverLog
      * @param channel       uri of the channel.
      * @param receiverCount number of the receivers after the event.
      */
-    public static void logFlowControlReceiverAdded(
+    public static void traceFlowControlReceiverAdded(
         final long receiverId,
         final int sessionId,
         final int streamId,
@@ -414,7 +414,7 @@ public final class DriverLog
      * @param channel       uri of the channel.
      * @param receiverCount number of the receivers after the event.
      */
-    public static void logFlowControlReceiverRemoved(
+    public static void traceFlowControlReceiverRemoved(
         final long receiverId,
         final int sessionId,
         final int streamId,
@@ -440,7 +440,7 @@ public final class DriverLog
      * @param nakLength  of the NAK.
      * @param channel    of the NAK.
      */
-    private static void logNakSent(
+    private static void traceNakSent(
         final InetSocketAddress address,
         final int sessionId,
         final int streamId,
@@ -464,7 +464,7 @@ public final class DriverLog
      * @param nakLength         of the NAK.
      * @param channel           of the NAK.
      */
-    public static void logNaksSent(
+    public static void traceNaksSent(
         final ImageConnection[] controlAddresses,
         final int sessionId,
         final int streamId,
@@ -482,7 +482,7 @@ public final class DriverLog
         {
             if (null != connection)
             {
-                logNakSent(
+                traceNakSent(
                     connection.controlAddress, sessionId, streamId, termId, termOffset, nakLength, channel);
             }
         }
@@ -499,7 +499,7 @@ public final class DriverLog
      * @param nakLength  of the NAK.
      * @param channel    of the NAK.
      */
-    public static void logNakReceived(
+    public static void traceNakReceived(
         final InetSocketAddress address,
         final int sessionId,
         final int streamId,
@@ -527,7 +527,7 @@ public final class DriverLog
      * @param resendLength of the resend.
      * @param channel      of the resend.
      */
-    public static void logResend(
+    public static void traceResend(
         final int sessionId,
         final int streamId,
         final int termId,
@@ -551,7 +551,7 @@ public final class DriverLog
      * @param streamId   of the publication revoke.
      * @param channel    of the publication revoke.
      */
-    public static void logPublicationRevoke(
+    public static void tracePublicationRevoke(
         final long revokedPos, final int sessionId, final int streamId, final String channel)
     {
         if (!LOG_PUBLICATION_REVOKE_ENABLED)
@@ -570,7 +570,7 @@ public final class DriverLog
      * @param streamId   of the publication image revoke.
      * @param channel    of the publication image revoke.
      */
-    public static void logPublicationImageRevoke(
+    public static void tracePublicationImageRevoke(
         final long revokedPos, final int sessionId, final int streamId, final String channel)
     {
         if (!LOG_PUBLICATION_IMAGE_REVOKE_ENABLED)
@@ -589,7 +589,7 @@ public final class DriverLog
      * @param index     at which the message begins.
      * @param length    of the encoded message.
      */
-    public static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
+    public static void traceCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
     {
         final DriverEventCode code = cmdEventCode(msgTypeId);
         if (null != code && isEnabled(code))
@@ -603,7 +603,7 @@ public final class DriverLog
      *
      * @param text to be logged.
      */
-    public static void logText(final String text)
+    public static void traceText(final String text)
     {
         if (!LOG_TEXT_DATA_ENABLED)
         {
@@ -618,7 +618,7 @@ public final class DriverLog
      *
      * @param version   of the driver.
      */
-    public static void logStart(final String version)
+    public static void traceStart(final String version)
     {
         if (!LOG_DRIVER_START)
         {

--- a/aeron-driver/src/main/java/io/aeron/driver/logging/DriverTracing.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/logging/DriverTracing.java
@@ -69,34 +69,34 @@ public final class DriverTracing
         ENABLED_EVENT_CODES = Collections.unmodifiableSet(enabledEventCodeSet);
     }
 
-    private static final boolean LOG_FRAME_IN_ENABLED = isEnabled(FRAME_IN);
-    private static final boolean LOG_FRAME_OUT_ENABLED = isEnabled(FRAME_OUT);
-    private static final boolean LOG_REMOVE_PUBLICATION_CLEANUP_ENABLED = isEnabled(REMOVE_PUBLICATION_CLEANUP);
-    private static final boolean LOG_REMOVE_SUBSCRIPTION_CLEANUP_ENABLED = isEnabled(REMOVE_SUBSCRIPTION_CLEANUP);
-    private static final boolean LOG_REMOVE_IMAGE_CLEANUP_ENABLED = isEnabled(REMOVE_IMAGE_CLEANUP);
-    private static final boolean LOG_SEND_CHANNEL_CREATION_ENABLED = isEnabled(SEND_CHANNEL_CREATION);
-    private static final boolean LOG_SEND_CHANNEL_CLOSE_ENABLED = isEnabled(SEND_CHANNEL_CLOSE);
-    private static final boolean LOG_RECEIVE_CHANNEL_CREATION_ENABLED = isEnabled(RECEIVE_CHANNEL_CREATION);
-    private static final boolean LOG_RECEIVE_CHANNEL_CLOSE_ENABLED = isEnabled(RECEIVE_CHANNEL_CLOSE);
-    private static final boolean LOG_UNTETHERED_SUBSCRIPTION_STATE_CHANGE_ENABLED =
+    private static final boolean TRACE_FRAME_IN_ENABLED = isEnabled(FRAME_IN);
+    private static final boolean TRACE_FRAME_OUT_ENABLED = isEnabled(FRAME_OUT);
+    private static final boolean TRACE_REMOVE_PUBLICATION_CLEANUP_ENABLED = isEnabled(REMOVE_PUBLICATION_CLEANUP);
+    private static final boolean TRACE_REMOVE_SUBSCRIPTION_CLEANUP_ENABLED = isEnabled(REMOVE_SUBSCRIPTION_CLEANUP);
+    private static final boolean TRACE_REMOVE_IMAGE_CLEANUP_ENABLED = isEnabled(REMOVE_IMAGE_CLEANUP);
+    private static final boolean TRACE_SEND_CHANNEL_CREATION_ENABLED = isEnabled(SEND_CHANNEL_CREATION);
+    private static final boolean TRACE_SEND_CHANNEL_CLOSE_ENABLED = isEnabled(SEND_CHANNEL_CLOSE);
+    private static final boolean TRACE_RECEIVE_CHANNEL_CREATION_ENABLED = isEnabled(RECEIVE_CHANNEL_CREATION);
+    private static final boolean TRACE_RECEIVE_CHANNEL_CLOSE_ENABLED = isEnabled(RECEIVE_CHANNEL_CLOSE);
+    private static final boolean TRACE_UNTETHERED_SUBSCRIPTION_STATE_CHANGE_ENABLED =
         isEnabled(UNTETHERED_SUBSCRIPTION_STATE_CHANGE);
-    private static final boolean LOG_NAME_RESOLUTION_NEIGHBOR_ADDED_ENABLED =
+    private static final boolean TRACE_NAME_RESOLUTION_NEIGHBOR_ADDED_ENABLED =
         isEnabled(NAME_RESOLUTION_NEIGHBOR_ADDED);
-    private static final boolean LOG_NAME_RESOLUTION_NEIGHBOR_REMOVED_ENABLED =
+    private static final boolean TRACE_NAME_RESOLUTION_NEIGHBOR_REMOVED_ENABLED =
         isEnabled(NAME_RESOLUTION_NEIGHBOR_REMOVED);
-    private static final boolean LOG_NAME_RESOLUTION_RESOLVE_ENABLED = isEnabled(NAME_RESOLUTION_RESOLVE);
-    private static final boolean LOG_NAME_RESOLUTION_LOOKUP_ENABLED = isEnabled(NAME_RESOLUTION_LOOKUP);
-    private static final boolean LOG_NAME_RESOLUTION_HOST_NAME_ENABLED = isEnabled(NAME_RESOLUTION_HOST_NAME);
-    private static final boolean LOG_FLOW_CONTROL_RECEIVER_ADDED_ENABLED = isEnabled(FLOW_CONTROL_RECEIVER_ADDED);
-    private static final boolean LOG_FLOW_CONTROL_RECEIVER_REMOVED_ENABLED =
+    private static final boolean TRACE_NAME_RESOLUTION_RESOLVE_ENABLED = isEnabled(NAME_RESOLUTION_RESOLVE);
+    private static final boolean TRACE_NAME_RESOLUTION_LOOKUP_ENABLED = isEnabled(NAME_RESOLUTION_LOOKUP);
+    private static final boolean TRACE_NAME_RESOLUTION_HOST_NAME_ENABLED = isEnabled(NAME_RESOLUTION_HOST_NAME);
+    private static final boolean TRACE_FLOW_CONTROL_RECEIVER_ADDED_ENABLED = isEnabled(FLOW_CONTROL_RECEIVER_ADDED);
+    private static final boolean TRACE_FLOW_CONTROL_RECEIVER_REMOVED_ENABLED =
         isEnabled(FLOW_CONTROL_RECEIVER_REMOVED);
-    private static final boolean LOG_NAK_SENT_ENABLED = isEnabled(NAK_SENT);
-    private static final boolean LOG_NAK_RECEIVED_ENABLED = isEnabled(NAK_RECEIVED);
-    private static final boolean LOG_RESEND_ENABLED = isEnabled(RESEND);
-    private static final boolean LOG_PUBLICATION_REVOKE_ENABLED = isEnabled(PUBLICATION_REVOKE);
-    private static final boolean LOG_PUBLICATION_IMAGE_REVOKE_ENABLED = isEnabled(PUBLICATION_IMAGE_REVOKE);
-    private static final boolean LOG_TEXT_DATA_ENABLED = isEnabled(TEXT_DATA);
-    private static final boolean LOG_DRIVER_START = !ENABLED_EVENT_CODES.isEmpty();
+    private static final boolean TRACE_NAK_SENT_ENABLED = isEnabled(NAK_SENT);
+    private static final boolean TRACE_NAK_RECEIVED_ENABLED = isEnabled(NAK_RECEIVED);
+    private static final boolean TRACE_RESEND_ENABLED = isEnabled(RESEND);
+    private static final boolean TRACE_PUBLICATION_REVOKE_ENABLED = isEnabled(PUBLICATION_REVOKE);
+    private static final boolean TRACE_PUBLICATION_IMAGE_REVOKE_ENABLED = isEnabled(PUBLICATION_IMAGE_REVOKE);
+    private static final boolean TRACE_TEXT_DATA_ENABLED = isEnabled(TEXT_DATA);
+    private static final boolean TRACE_DRIVER_START = !ENABLED_EVENT_CODES.isEmpty();
 
     private DriverTracing()
     {
@@ -127,7 +127,7 @@ public final class DriverTracing
         final int offset,
         final int frameLength)
     {
-        if (!LOG_FRAME_IN_ENABLED)
+        if (!TRACE_FRAME_IN_ENABLED)
         {
             return;
         }
@@ -143,7 +143,7 @@ public final class DriverTracing
      */
     public static void traceFrameOut(final ByteBuffer buffer, final InetSocketAddress dstAddress)
     {
-        if (!LOG_FRAME_OUT_ENABLED)
+        if (!TRACE_FRAME_OUT_ENABLED)
         {
             return;
         }
@@ -160,7 +160,7 @@ public final class DriverTracing
      */
     public static void tracePublicationRemoval(final String channel, final int sessionId, final int streamId)
     {
-        if (!LOG_REMOVE_PUBLICATION_CLEANUP_ENABLED)
+        if (!TRACE_REMOVE_PUBLICATION_CLEANUP_ENABLED)
         {
             return;
         }
@@ -177,7 +177,7 @@ public final class DriverTracing
      */
     public static void traceSubscriptionRemoval(final String channel, final int streamId, final long subscriptionId)
     {
-        if (!LOG_REMOVE_SUBSCRIPTION_CLEANUP_ENABLED)
+        if (!TRACE_REMOVE_SUBSCRIPTION_CLEANUP_ENABLED)
         {
             return;
         }
@@ -196,7 +196,7 @@ public final class DriverTracing
     public static void traceImageRemoval(
         final String channel, final int sessionId, final int streamId, final long correlationId)
     {
-        if (!LOG_REMOVE_IMAGE_CLEANUP_ENABLED)
+        if (!TRACE_REMOVE_IMAGE_CLEANUP_ENABLED)
         {
             return;
         }
@@ -211,7 +211,7 @@ public final class DriverTracing
      */
     public static void traceSendChannelCreation(final String description)
     {
-        if (!LOG_SEND_CHANNEL_CREATION_ENABLED)
+        if (!TRACE_SEND_CHANNEL_CREATION_ENABLED)
         {
             return;
         }
@@ -226,7 +226,7 @@ public final class DriverTracing
      */
     public static void traceSendChannelClose(final String description)
     {
-        if (!LOG_SEND_CHANNEL_CLOSE_ENABLED)
+        if (!TRACE_SEND_CHANNEL_CLOSE_ENABLED)
         {
             return;
         }
@@ -241,7 +241,7 @@ public final class DriverTracing
      */
     public static void traceReceiveChannelCreation(final String description)
     {
-        if (!LOG_RECEIVE_CHANNEL_CREATION_ENABLED)
+        if (!TRACE_RECEIVE_CHANNEL_CREATION_ENABLED)
         {
             return;
         }
@@ -256,7 +256,7 @@ public final class DriverTracing
      */
     public static void traceReceiveChannelClose(final String description)
     {
-        if (!LOG_RECEIVE_CHANNEL_CLOSE_ENABLED)
+        if (!TRACE_RECEIVE_CHANNEL_CLOSE_ENABLED)
         {
             return;
         }
@@ -277,7 +277,7 @@ public final class DriverTracing
     public static <E extends Enum<E>> void traceUntetheredSubscriptionStateChange(
         final E oldState, final E newState, final long subscriptionId, final int streamId, final int sessionId)
     {
-        if (!LOG_UNTETHERED_SUBSCRIPTION_STATE_CHANGE_ENABLED)
+        if (!TRACE_UNTETHERED_SUBSCRIPTION_STATE_CHANGE_ENABLED)
         {
             return;
         }
@@ -293,7 +293,7 @@ public final class DriverTracing
      */
     public static void traceNeighborAdded(final InetSocketAddress address)
     {
-        if (!LOG_NAME_RESOLUTION_NEIGHBOR_ADDED_ENABLED)
+        if (!TRACE_NAME_RESOLUTION_NEIGHBOR_ADDED_ENABLED)
         {
             return;
         }
@@ -308,7 +308,7 @@ public final class DriverTracing
      */
     public static void traceNeighborRemoved(final InetSocketAddress address)
     {
-        if (!LOG_NAME_RESOLUTION_NEIGHBOR_REMOVED_ENABLED)
+        if (!TRACE_NAME_RESOLUTION_NEIGHBOR_REMOVED_ENABLED)
         {
             return;
         }
@@ -332,7 +332,7 @@ public final class DriverTracing
         final boolean isReResolution,
         final InetAddress address)
     {
-        if (!LOG_NAME_RESOLUTION_RESOLVE_ENABLED)
+        if (!TRACE_NAME_RESOLUTION_RESOLVE_ENABLED)
         {
             return;
         }
@@ -356,7 +356,7 @@ public final class DriverTracing
         final boolean isReLookup,
         final String resolvedName)
     {
-        if (!LOG_NAME_RESOLUTION_LOOKUP_ENABLED)
+        if (!TRACE_NAME_RESOLUTION_LOOKUP_ENABLED)
         {
             return;
         }
@@ -372,7 +372,7 @@ public final class DriverTracing
      */
     public static void traceHostName(final long durationNs, final String hostName)
     {
-        if (!LOG_NAME_RESOLUTION_HOST_NAME_ENABLED)
+        if (!TRACE_NAME_RESOLUTION_HOST_NAME_ENABLED)
         {
             return;
         }
@@ -396,7 +396,7 @@ public final class DriverTracing
         final String channel,
         final int receiverCount)
     {
-        if (!LOG_FLOW_CONTROL_RECEIVER_ADDED_ENABLED)
+        if (!TRACE_FLOW_CONTROL_RECEIVER_ADDED_ENABLED)
         {
             return;
         }
@@ -421,7 +421,7 @@ public final class DriverTracing
         final String channel,
         final int receiverCount)
     {
-        if (!LOG_FLOW_CONTROL_RECEIVER_REMOVED_ENABLED)
+        if (!TRACE_FLOW_CONTROL_RECEIVER_REMOVED_ENABLED)
         {
             return;
         }
@@ -473,7 +473,7 @@ public final class DriverTracing
         final int nakLength,
         final String channel)
     {
-        if (!LOG_NAK_SENT_ENABLED)
+        if (!TRACE_NAK_SENT_ENABLED)
         {
             return;
         }
@@ -508,7 +508,7 @@ public final class DriverTracing
         final int nakLength,
         final String channel)
     {
-        if (!LOG_NAK_RECEIVED_ENABLED)
+        if (!TRACE_NAK_RECEIVED_ENABLED)
         {
             return;
         }
@@ -535,7 +535,7 @@ public final class DriverTracing
         final int resendLength,
         final String channel)
     {
-        if (!LOG_RESEND_ENABLED)
+        if (!TRACE_RESEND_ENABLED)
         {
             return;
         }
@@ -554,7 +554,7 @@ public final class DriverTracing
     public static void tracePublicationRevoke(
         final long revokedPos, final int sessionId, final int streamId, final String channel)
     {
-        if (!LOG_PUBLICATION_REVOKE_ENABLED)
+        if (!TRACE_PUBLICATION_REVOKE_ENABLED)
         {
             return;
         }
@@ -573,7 +573,7 @@ public final class DriverTracing
     public static void tracePublicationImageRevoke(
         final long revokedPos, final int sessionId, final int streamId, final String channel)
     {
-        if (!LOG_PUBLICATION_IMAGE_REVOKE_ENABLED)
+        if (!TRACE_PUBLICATION_IMAGE_REVOKE_ENABLED)
         {
             return;
         }
@@ -605,7 +605,7 @@ public final class DriverTracing
      */
     public static void traceText(final String text)
     {
-        if (!LOG_TEXT_DATA_ENABLED)
+        if (!TRACE_TEXT_DATA_ENABLED)
         {
             return;
         }
@@ -620,7 +620,7 @@ public final class DriverTracing
      */
     public static void traceStart(final String version)
     {
-        if (!LOG_DRIVER_START)
+        if (!TRACE_DRIVER_START)
         {
             return;
         }

--- a/aeron-driver/src/main/java/io/aeron/driver/logging/DriverTracing.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/logging/DriverTracing.java
@@ -29,7 +29,7 @@ import java.util.Set;
 
 import static io.aeron.driver.logging.DriverEventCode.*;
 import static io.aeron.command.ControlProtocolEvents.*;
-import static io.aeron.driver.logging.DriverEventLogger.LOGGER;
+import static io.aeron.driver.logging.DriverTracer.LOGGER;
 
 /**
  * Direct-call entry points for logging {@link io.aeron.driver.MediaDriver} events, replacing the previous

--- a/aeron-driver/src/main/java/io/aeron/driver/logging/DriverTracing.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/logging/DriverTracing.java
@@ -132,7 +132,7 @@ public final class DriverTracing
             return;
         }
 
-        TRACER.logFrameIn(srcAddress.getAddress(), srcAddress.getPort(), buffer, offset, frameLength);
+        TRACER.traceFrameIn(srcAddress.getAddress(), srcAddress.getPort(), buffer, offset, frameLength);
     }
 
     /**
@@ -148,7 +148,7 @@ public final class DriverTracing
             return;
         }
 
-        TRACER.logFrameOut(dstAddress.getAddress(), dstAddress.getPort(), buffer);
+        TRACER.traceFrameOut(dstAddress.getAddress(), dstAddress.getPort(), buffer);
     }
 
     /**
@@ -165,7 +165,7 @@ public final class DriverTracing
             return;
         }
 
-        TRACER.logPublicationRemoval(channel, sessionId, streamId);
+        TRACER.tracePublicationRemoval(channel, sessionId, streamId);
     }
 
     /**
@@ -182,7 +182,7 @@ public final class DriverTracing
             return;
         }
 
-        TRACER.logSubscriptionRemoval(channel, streamId, subscriptionId);
+        TRACER.traceSubscriptionRemoval(channel, streamId, subscriptionId);
     }
 
     /**
@@ -201,7 +201,7 @@ public final class DriverTracing
             return;
         }
 
-        TRACER.logImageRemoval(channel, sessionId, streamId, correlationId);
+        TRACER.traceImageRemoval(channel, sessionId, streamId, correlationId);
     }
 
     /**
@@ -216,7 +216,7 @@ public final class DriverTracing
             return;
         }
 
-        TRACER.logSendChannelCreation(description);
+        TRACER.traceSendChannelCreation(description);
     }
 
     /**
@@ -231,7 +231,7 @@ public final class DriverTracing
             return;
         }
 
-        TRACER.logSendChannelClose(description);
+        TRACER.traceSendChannelClose(description);
     }
 
     /**
@@ -246,7 +246,7 @@ public final class DriverTracing
             return;
         }
 
-        TRACER.logReceiveChannelCreation(description);
+        TRACER.traceReceiveChannelCreation(description);
     }
 
     /**
@@ -261,7 +261,7 @@ public final class DriverTracing
             return;
         }
 
-        TRACER.logReceiveChannelClose(description);
+        TRACER.traceReceiveChannelClose(description);
     }
 
     /**
@@ -282,7 +282,7 @@ public final class DriverTracing
             return;
         }
 
-        TRACER.logUntetheredSubscriptionStateChange(
+        TRACER.traceUntetheredSubscriptionStateChange(
             oldState, newState, subscriptionId, streamId, sessionId);
     }
 
@@ -298,7 +298,7 @@ public final class DriverTracing
             return;
         }
 
-        TRACER.logNeighborAdded(address.getAddress(), address.getPort());
+        TRACER.traceNeighborAdded(address.getAddress(), address.getPort());
     }
 
     /**
@@ -313,7 +313,7 @@ public final class DriverTracing
             return;
         }
 
-        TRACER.logNeighborRemoved(address.getAddress(), address.getPort());
+        TRACER.traceNeighborRemoved(address.getAddress(), address.getPort());
     }
 
     /**
@@ -337,7 +337,7 @@ public final class DriverTracing
             return;
         }
 
-        TRACER.logResolve(resolverName, durationNs, name, isReResolution, address);
+        TRACER.traceResolve(resolverName, durationNs, name, isReResolution, address);
     }
 
     /**
@@ -361,7 +361,7 @@ public final class DriverTracing
             return;
         }
 
-        TRACER.logLookup(resolverName, durationNs, name, isReLookup, resolvedName);
+        TRACER.traceLookup(resolverName, durationNs, name, isReLookup, resolvedName);
     }
 
     /**
@@ -377,7 +377,7 @@ public final class DriverTracing
             return;
         }
 
-        TRACER.logHostName(durationNs, hostName);
+        TRACER.traceHostName(durationNs, hostName);
     }
 
     /**
@@ -401,7 +401,7 @@ public final class DriverTracing
             return;
         }
 
-        TRACER.logFlowControlReceiverAdded(
+        TRACER.traceFlowControlReceiverAdded(
             receiverId, sessionId, streamId, channel, receiverCount);
     }
 
@@ -426,7 +426,7 @@ public final class DriverTracing
             return;
         }
 
-        TRACER.logFlowControlReceiverRemoved(receiverId, sessionId, streamId, channel, receiverCount);
+        TRACER.traceFlowControlReceiverRemoved(receiverId, sessionId, streamId, channel, receiverCount);
     }
 
     /**
@@ -449,7 +449,7 @@ public final class DriverTracing
         final int nakLength,
         final String channel)
     {
-        TRACER.logNakSent(
+        TRACER.traceNakSent(
             address.getAddress(), address.getPort(), sessionId, streamId, termId, termOffset, nakLength, channel);
     }
 
@@ -513,7 +513,7 @@ public final class DriverTracing
             return;
         }
 
-        TRACER.logNakReceived(
+        TRACER.traceNakReceived(
             address.getAddress(), address.getPort(), sessionId, streamId, termId, termOffset, nakLength, channel);
     }
 
@@ -540,7 +540,7 @@ public final class DriverTracing
             return;
         }
 
-        TRACER.logResend(sessionId, streamId, termId, termOffset, resendLength, channel);
+        TRACER.traceResend(sessionId, streamId, termId, termOffset, resendLength, channel);
     }
 
     /**
@@ -559,7 +559,7 @@ public final class DriverTracing
             return;
         }
 
-        TRACER.logPublicationRevoke(revokedPos, sessionId, streamId, channel);
+        TRACER.tracePublicationRevoke(revokedPos, sessionId, streamId, channel);
     }
 
     /**
@@ -578,7 +578,7 @@ public final class DriverTracing
             return;
         }
 
-        TRACER.logPublicationImageRevoke(revokedPos, sessionId, streamId, channel);
+        TRACER.tracePublicationImageRevoke(revokedPos, sessionId, streamId, channel);
     }
 
     /**
@@ -594,7 +594,7 @@ public final class DriverTracing
         final DriverEventCode code = cmdEventCode(msgTypeId);
         if (null != code && isEnabled(code))
         {
-            TRACER.log(code, buffer, index, length);
+            TRACER.trace(code, buffer, index, length);
         }
     }
 
@@ -610,7 +610,7 @@ public final class DriverTracing
             return;
         }
 
-        TRACER.logString(TEXT_DATA, text);
+        TRACER.traceString(TEXT_DATA, text);
     }
 
     /**
@@ -625,7 +625,7 @@ public final class DriverTracing
             return;
         }
 
-        TRACER.logStart(version);
+        TRACER.traceStart(version);
     }
 
     private static DriverEventCode cmdEventCode(final int msgTypeId)

--- a/aeron-driver/src/main/java/io/aeron/driver/logging/DriverTracing.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/logging/DriverTracing.java
@@ -29,7 +29,7 @@ import java.util.Set;
 
 import static io.aeron.driver.logging.DriverEventCode.*;
 import static io.aeron.command.ControlProtocolEvents.*;
-import static io.aeron.driver.logging.DriverTracer.LOGGER;
+import static io.aeron.driver.logging.DriverTracer.TRACER;
 
 /**
  * Direct-call entry points for logging {@link io.aeron.driver.MediaDriver} events, replacing the previous
@@ -132,7 +132,7 @@ public final class DriverTracing
             return;
         }
 
-        LOGGER.logFrameIn(srcAddress.getAddress(), srcAddress.getPort(), buffer, offset, frameLength);
+        TRACER.logFrameIn(srcAddress.getAddress(), srcAddress.getPort(), buffer, offset, frameLength);
     }
 
     /**
@@ -148,7 +148,7 @@ public final class DriverTracing
             return;
         }
 
-        LOGGER.logFrameOut(dstAddress.getAddress(), dstAddress.getPort(), buffer);
+        TRACER.logFrameOut(dstAddress.getAddress(), dstAddress.getPort(), buffer);
     }
 
     /**
@@ -165,7 +165,7 @@ public final class DriverTracing
             return;
         }
 
-        LOGGER.logPublicationRemoval(channel, sessionId, streamId);
+        TRACER.logPublicationRemoval(channel, sessionId, streamId);
     }
 
     /**
@@ -182,7 +182,7 @@ public final class DriverTracing
             return;
         }
 
-        LOGGER.logSubscriptionRemoval(channel, streamId, subscriptionId);
+        TRACER.logSubscriptionRemoval(channel, streamId, subscriptionId);
     }
 
     /**
@@ -201,7 +201,7 @@ public final class DriverTracing
             return;
         }
 
-        LOGGER.logImageRemoval(channel, sessionId, streamId, correlationId);
+        TRACER.logImageRemoval(channel, sessionId, streamId, correlationId);
     }
 
     /**
@@ -216,7 +216,7 @@ public final class DriverTracing
             return;
         }
 
-        LOGGER.logSendChannelCreation(description);
+        TRACER.logSendChannelCreation(description);
     }
 
     /**
@@ -231,7 +231,7 @@ public final class DriverTracing
             return;
         }
 
-        LOGGER.logSendChannelClose(description);
+        TRACER.logSendChannelClose(description);
     }
 
     /**
@@ -246,7 +246,7 @@ public final class DriverTracing
             return;
         }
 
-        LOGGER.logReceiveChannelCreation(description);
+        TRACER.logReceiveChannelCreation(description);
     }
 
     /**
@@ -261,7 +261,7 @@ public final class DriverTracing
             return;
         }
 
-        LOGGER.logReceiveChannelClose(description);
+        TRACER.logReceiveChannelClose(description);
     }
 
     /**
@@ -282,7 +282,7 @@ public final class DriverTracing
             return;
         }
 
-        LOGGER.logUntetheredSubscriptionStateChange(
+        TRACER.logUntetheredSubscriptionStateChange(
             oldState, newState, subscriptionId, streamId, sessionId);
     }
 
@@ -298,7 +298,7 @@ public final class DriverTracing
             return;
         }
 
-        LOGGER.logNeighborAdded(address.getAddress(), address.getPort());
+        TRACER.logNeighborAdded(address.getAddress(), address.getPort());
     }
 
     /**
@@ -313,7 +313,7 @@ public final class DriverTracing
             return;
         }
 
-        LOGGER.logNeighborRemoved(address.getAddress(), address.getPort());
+        TRACER.logNeighborRemoved(address.getAddress(), address.getPort());
     }
 
     /**
@@ -337,7 +337,7 @@ public final class DriverTracing
             return;
         }
 
-        LOGGER.logResolve(resolverName, durationNs, name, isReResolution, address);
+        TRACER.logResolve(resolverName, durationNs, name, isReResolution, address);
     }
 
     /**
@@ -361,7 +361,7 @@ public final class DriverTracing
             return;
         }
 
-        LOGGER.logLookup(resolverName, durationNs, name, isReLookup, resolvedName);
+        TRACER.logLookup(resolverName, durationNs, name, isReLookup, resolvedName);
     }
 
     /**
@@ -377,7 +377,7 @@ public final class DriverTracing
             return;
         }
 
-        LOGGER.logHostName(durationNs, hostName);
+        TRACER.logHostName(durationNs, hostName);
     }
 
     /**
@@ -401,7 +401,7 @@ public final class DriverTracing
             return;
         }
 
-        LOGGER.logFlowControlReceiverAdded(
+        TRACER.logFlowControlReceiverAdded(
             receiverId, sessionId, streamId, channel, receiverCount);
     }
 
@@ -426,7 +426,7 @@ public final class DriverTracing
             return;
         }
 
-        LOGGER.logFlowControlReceiverRemoved(receiverId, sessionId, streamId, channel, receiverCount);
+        TRACER.logFlowControlReceiverRemoved(receiverId, sessionId, streamId, channel, receiverCount);
     }
 
     /**
@@ -449,7 +449,7 @@ public final class DriverTracing
         final int nakLength,
         final String channel)
     {
-        LOGGER.logNakSent(
+        TRACER.logNakSent(
             address.getAddress(), address.getPort(), sessionId, streamId, termId, termOffset, nakLength, channel);
     }
 
@@ -513,7 +513,7 @@ public final class DriverTracing
             return;
         }
 
-        LOGGER.logNakReceived(
+        TRACER.logNakReceived(
             address.getAddress(), address.getPort(), sessionId, streamId, termId, termOffset, nakLength, channel);
     }
 
@@ -540,7 +540,7 @@ public final class DriverTracing
             return;
         }
 
-        LOGGER.logResend(sessionId, streamId, termId, termOffset, resendLength, channel);
+        TRACER.logResend(sessionId, streamId, termId, termOffset, resendLength, channel);
     }
 
     /**
@@ -559,7 +559,7 @@ public final class DriverTracing
             return;
         }
 
-        LOGGER.logPublicationRevoke(revokedPos, sessionId, streamId, channel);
+        TRACER.logPublicationRevoke(revokedPos, sessionId, streamId, channel);
     }
 
     /**
@@ -578,7 +578,7 @@ public final class DriverTracing
             return;
         }
 
-        LOGGER.logPublicationImageRevoke(revokedPos, sessionId, streamId, channel);
+        TRACER.logPublicationImageRevoke(revokedPos, sessionId, streamId, channel);
     }
 
     /**
@@ -594,7 +594,7 @@ public final class DriverTracing
         final DriverEventCode code = cmdEventCode(msgTypeId);
         if (null != code && isEnabled(code))
         {
-            LOGGER.log(code, buffer, index, length);
+            TRACER.log(code, buffer, index, length);
         }
     }
 
@@ -610,7 +610,7 @@ public final class DriverTracing
             return;
         }
 
-        LOGGER.logString(TEXT_DATA, text);
+        TRACER.logString(TEXT_DATA, text);
     }
 
     /**
@@ -625,7 +625,7 @@ public final class DriverTracing
             return;
         }
 
-        LOGGER.logStart(version);
+        TRACER.logStart(version);
     }
 
     private static DriverEventCode cmdEventCode(final int msgTypeId)

--- a/aeron-driver/src/main/java/io/aeron/driver/media/ReceiveChannelEndpoint.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/ReceiveChannelEndpoint.java
@@ -19,7 +19,7 @@ import io.aeron.CommonContext;
 import io.aeron.ErrorCode;
 import io.aeron.driver.DataPacketDispatcher;
 import io.aeron.driver.DriverConductorProxy;
-import io.aeron.driver.logging.DriverLog;
+import io.aeron.driver.logging.DriverTracing;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.status.SystemCounterDescriptor;
 import io.aeron.exceptions.AeronException;
@@ -873,7 +873,8 @@ public class ReceiveChannelEndpoint extends ReceiveChannelEndpointRhsPadding
         final int termOffset,
         final int length)
     {
-        DriverLog.logNaksSent(controlAddresses, sessionId, streamId, termId, termOffset, length, originalUriString());
+        DriverTracing.traceNaksSent(
+            controlAddresses, sessionId, streamId, termId, termOffset, length, originalUriString());
 
         nakBuffer.clear();
         nakFlyweight

--- a/aeron-driver/src/main/java/io/aeron/driver/media/SendChannelEndpoint.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/SendChannelEndpoint.java
@@ -20,7 +20,7 @@ import io.aeron.ChannelUri;
 import io.aeron.CommonContext;
 import io.aeron.ErrorCode;
 import io.aeron.driver.DriverConductorProxy;
-import io.aeron.driver.logging.DriverLog;
+import io.aeron.driver.logging.DriverTracing;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.NetworkPublication;
 import io.aeron.driver.Sender;
@@ -480,7 +480,7 @@ public class SendChannelEndpoint extends UdpChannelTransport
         final int length,
         final InetSocketAddress srcAddress)
     {
-        DriverLog.logNakReceived(
+        DriverTracing.traceNakReceived(
             srcAddress,
             msg.sessionId(),
             msg.streamId(),

--- a/aeron-driver/src/main/java/io/aeron/driver/media/UdpChannelTransport.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/UdpChannelTransport.java
@@ -15,7 +15,7 @@
  */
 package io.aeron.driver.media;
 
-import io.aeron.driver.logging.DriverLog;
+import io.aeron.driver.logging.DriverTracing;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.status.SystemCounterDescriptor;
 import io.aeron.exceptions.AeronEvent;
@@ -411,7 +411,7 @@ public abstract class UdpChannelTransport implements AutoCloseable
      */
     public void sendHook(final ByteBuffer buffer, final InetSocketAddress address)
     {
-        DriverLog.logFrameOut(buffer, address);
+        DriverTracing.traceFrameOut(buffer, address);
     }
 
     /**
@@ -423,7 +423,7 @@ public abstract class UdpChannelTransport implements AutoCloseable
      */
     public void receiveHook(final UnsafeBuffer buffer, final int length, final InetSocketAddress address)
     {
-        DriverLog.logFrameIn(address, buffer, 0, length);
+        DriverTracing.traceFrameIn(address, buffer, 0, length);
     }
 
     /**
@@ -438,7 +438,7 @@ public abstract class UdpChannelTransport implements AutoCloseable
     public void resendHook(
         final int sessionId, final int streamId, final int termId, final int termOffset, final int length)
     {
-        DriverLog.logResend(sessionId, streamId, termId, termOffset, length, udpChannel.originalUriString());
+        DriverTracing.traceResend(sessionId, streamId, termId, termOffset, length, udpChannel.originalUriString());
     }
 
     /**

--- a/aeron-driver/src/test/java/io/aeron/driver/logging/CborDriverEventCodecTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/logging/CborDriverEventCodecTest.java
@@ -77,7 +77,7 @@ class CborDriverEventCodecTest
 
         final LoggerEventCallback mockLoggingCallback = mock(LoggerEventCallback.class);
         final CborDecode cborDecode = new CborDecode(List.of(new ProxyLoggerEventCallback(mockLoggingCallback)));
-        final CborDriverEventLogger cborDriverEventLogger = new CborDriverEventLogger(ringBuffer);
+        final CborDriverTracer cborDriverEventLogger = new CborDriverTracer(ringBuffer);
 
         cborDriverEventLogger.logFrameOut(address, port, ByteBuffer.wrap(testBytes));
 

--- a/aeron-driver/src/test/java/io/aeron/driver/logging/CborDriverEventCodecTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/logging/CborDriverEventCodecTest.java
@@ -79,7 +79,7 @@ class CborDriverEventCodecTest
         final CborDecode cborDecode = new CborDecode(List.of(new ProxyLoggerEventCallback(mockLoggingCallback)));
         final CborDriverTracer cborDriverEventLogger = new CborDriverTracer(ringBuffer);
 
-        cborDriverEventLogger.logFrameOut(address, port, ByteBuffer.wrap(testBytes));
+        cborDriverEventLogger.traceFrameOut(address, port, ByteBuffer.wrap(testBytes));
 
         while (0 == ringBuffer.read(cborDecode))
         {

--- a/aeron-driver/src/test/java/io/aeron/driver/logging/CborDriverTracerTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/logging/CborDriverTracerTest.java
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-class DriverEventLoggerCborImplTest
+class CborDriverTracerTest
 {
     private final ManyToOneRingBuffer ringBuffer = new ManyToOneRingBuffer(
         new UnsafeBuffer(BufferUtil.allocateDirectAligned(64 * 1024 + TRAILER_LENGTH, CACHE_LINE_LENGTH)));

--- a/aeron-driver/src/test/java/io/aeron/driver/logging/DriverEventEnablementTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/logging/DriverEventEnablementTest.java
@@ -165,7 +165,7 @@ public class DriverEventEnablementTest
                 {
                     final Field declaredField = ControlProtocolEvents.class.getDeclaredField(protocolName);
                     final int msgTypeId = (int)(Integer)declaredField.get(null);
-                    DriverLog.logCmd(msgTypeId, new ExpandableArrayBuffer(0), 0, 0);
+                    DriverTracing.traceCmd(msgTypeId, new ExpandableArrayBuffer(0), 0, 0);
                 }
                 catch (final NoSuchFieldException | IllegalAccessException ignore)
                 {
@@ -174,7 +174,7 @@ public class DriverEventEnablementTest
             }
         }
 
-        DriverLog.logCmd(ControlProtocolEvents.CLIENT_KEEPALIVE, new ExpandableArrayBuffer(0), 0, 0);
+        DriverTracing.traceCmd(ControlProtocolEvents.CLIENT_KEEPALIVE, new ExpandableArrayBuffer(0), 0, 0);
     }
 
     private static void callCmdOutLogMethods()
@@ -192,7 +192,7 @@ public class DriverEventEnablementTest
                 {
                     final Field declaredField = ControlProtocolEvents.class.getDeclaredField(protocolName);
                     final int msgTypeId = (int)(Integer)declaredField.get(null);
-                    DriverLog.logCmd(msgTypeId, new ExpandableArrayBuffer(0), 0, 0);
+                    DriverTracing.traceCmd(msgTypeId, new ExpandableArrayBuffer(0), 0, 0);
                 }
                 catch (final NoSuchFieldException | IllegalAccessException ignore)
                 {
@@ -204,10 +204,10 @@ public class DriverEventEnablementTest
 
     private void callGeneralLogMethods()
     {
-        final List<Method> logMethods = Arrays.stream(DriverLog.class.getMethods())
-            .filter((m) -> m.getName().startsWith("log"))
+        final List<Method> logMethods = Arrays.stream(DriverTracing.class.getMethods())
+            .filter((m) -> m.getName().startsWith("trace"))
             .filter((m) -> 0 != (m.getModifiers() & Modifier.STATIC))
-            .filter((m) -> !"logCmd".equals(m.getName()))
+            .filter((m) -> !"traceCmd".equals(m.getName()))
             .toList();
 
         for (final Method logMethod : logMethods)

--- a/aeron-driver/src/test/java/io/aeron/driver/logging/DriverEventLoggerCborImplTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/logging/DriverEventLoggerCborImplTest.java
@@ -73,7 +73,7 @@ class DriverEventLoggerCborImplTest
         Arrays.fill(subRange, (byte)0xAA);
         final UnsafeBuffer buffer = new UnsafeBuffer(backing);
 
-        logger.log(DriverEventCode.CMD_IN_ADD_PUBLICATION, buffer, 100, 16);
+        logger.trace(DriverEventCode.CMD_IN_ADD_PUBLICATION, buffer, 100, 16);
 
         drain();
 
@@ -94,7 +94,7 @@ class DriverEventLoggerCborImplTest
         Arrays.fill(backing, (byte)0x11);
         final UnsafeBuffer buffer = new UnsafeBuffer(backing);
 
-        logger.log(DriverEventCode.CMD_IN_ADD_PUBLICATION, buffer, 0, backing.length);
+        logger.trace(DriverEventCode.CMD_IN_ADD_PUBLICATION, buffer, 0, backing.length);
 
         drain();
 
@@ -111,7 +111,7 @@ class DriverEventLoggerCborImplTest
         final UnsafeBuffer buffer = new UnsafeBuffer(backing);
         final InetSocketAddress address = new InetSocketAddress(InetAddress.getByName("192.168.1.1"), 1234);
 
-        logger.logFrameIn(address.getAddress(), address.getPort(), buffer, 0, backing.length);
+        logger.traceFrameIn(address.getAddress(), address.getPort(), buffer, 0, backing.length);
 
         drain();
 
@@ -134,7 +134,7 @@ class DriverEventLoggerCborImplTest
         final UnsafeBuffer buffer = new UnsafeBuffer(backing);
         final InetSocketAddress address = new InetSocketAddress(InetAddress.getByName("2001:db8::1"), 1234);
 
-        logger.logFrameIn(address.getAddress(), address.getPort(), buffer, 0, backing.length);
+        logger.traceFrameIn(address.getAddress(), address.getPort(), buffer, 0, backing.length);
 
         drain();
 
@@ -152,7 +152,7 @@ class DriverEventLoggerCborImplTest
         byteBuffer.flip();
         final InetSocketAddress address = new InetSocketAddress("192.168.1.1", 1234);
 
-        logger.logFrameOut(address.getAddress(), address.getPort(), byteBuffer);
+        logger.traceFrameOut(address.getAddress(), address.getPort(), byteBuffer);
 
         drain();
 
@@ -171,7 +171,7 @@ class DriverEventLoggerCborImplTest
     @Test
     void logResolveHandlesANullAddressAndEncodesTheBooleanWithNoTag()
     {
-        logger.logResolve("DefaultNameResolver", 42L, "host.example.com", true, null);
+        logger.traceResolve("DefaultNameResolver", 42L, "host.example.com", true, null);
 
         drain();
 
@@ -196,7 +196,7 @@ class DriverEventLoggerCborImplTest
     {
         final InetAddress address = InetAddress.getByName("10.0.0.1");
 
-        logger.logResolve("DefaultNameResolver", 42L, "host.example.com", false, address);
+        logger.traceResolve("DefaultNameResolver", 42L, "host.example.com", false, address);
 
         drain();
 

--- a/aeron-driver/src/test/java/io/aeron/driver/logging/DriverEventLoggerCborImplTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/logging/DriverEventLoggerCborImplTest.java
@@ -54,7 +54,7 @@ class DriverEventLoggerCborImplTest
 
     private final LoggerEventCallback mockLoggingCallback = mock(LoggerEventCallback.class);
     private final CborDecode cborDecode = new CborDecode(List.of(new ProxyLoggerEventCallback(mockLoggingCallback)));
-    private final DriverEventLogger logger = new CborDriverEventLogger(ringBuffer);
+    private final DriverTracer logger = new CborDriverTracer(ringBuffer);
 
     private void drain()
     {

--- a/aeron-driver/src/test/java/io/aeron/driver/logging/GenericLoggingTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/logging/GenericLoggingTest.java
@@ -25,7 +25,7 @@ import static org.agrona.BitUtil.CACHE_LINE_LENGTH;
 import static org.agrona.concurrent.ringbuffer.RingBufferDescriptor.TRAILER_LENGTH;
 
 /**
- * Reflectively drives every {@link DriverEventLogger} method with a range of nominal, boundary, and {@code null}
+ * Reflectively drives every {@link DriverTracer} method with a range of nominal, boundary, and {@code null}
  * values and verifies (via {@link io.aeron.logging.CborDecode}) that they all survive the CBOR round trip.
  */
 class GenericLoggingTest
@@ -35,8 +35,8 @@ class GenericLoggingTest
     {
         final ManyToOneRingBuffer ringBuffer = new ManyToOneRingBuffer(
             new UnsafeBuffer(BufferUtil.allocateDirectAligned(64 * 1024 + TRAILER_LENGTH, CACHE_LINE_LENGTH)));
-        final DriverEventLogger logger = new CborDriverEventLogger(ringBuffer);
+        final DriverTracer logger = new CborDriverTracer(ringBuffer);
 
-        GenericLoggerEventVerifier.verifyAllLogMethods(DriverEventLogger.class, logger, ringBuffer);
+        GenericLoggerEventVerifier.verifyAllLogMethods(DriverTracer.class, logger, ringBuffer);
     }
 }

--- a/aeron-test-support/src/main/java/io/aeron/test/logging/GenericLoggerEventVerifier.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/logging/GenericLoggerEventVerifier.java
@@ -50,7 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Reflectively drives every {@link LoggerMethod}-annotated method on a {@link GeneratedLogger}-annotated event
- * logger interface (e.g. {@code DriverEventLogger}, {@code ClusterEventLogger}, {@code ArchiveEventLogger|}) with
+ * logger interface (e.g. {@code DriverTracer}, {@code ClusterTracer}, {@code ArchiveTracer|}) with
  * a range of representative, boundary, and {@code null} argument values, decodes the resulting CBOR message with
  * {@link CborDecode}, and asserts that every value survived the round trip unchanged.
  * <p>
@@ -84,7 +84,7 @@ public final class GenericLoggerEventVerifier
      * Reflectively exercises every {@code log*} method on {@code loggerInterface}, invoking it on
      * {@code loggerImpl} and verifying the resulting CBOR message decodes back to the values supplied.
      *
-     * @param loggerInterface the {@link GeneratedLogger}-annotated interface, e.g. {@code DriverEventLogger.class}.
+     * @param loggerInterface the {@link GeneratedLogger}-annotated interface, e.g. {@code DriverTracer.class}.
      * @param loggerImpl      an instance implementing {@code loggerInterface}, backed by {@code ringBuffer}.
      * @param ringBuffer      the ring buffer {@code loggerImpl} writes into and this method reads back from.
      */

--- a/aeron-test-support/src/main/java/io/aeron/test/logging/GenericLoggerEventVerifier.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/logging/GenericLoggerEventVerifier.java
@@ -81,7 +81,7 @@ public final class GenericLoggerEventVerifier
     }
 
     /**
-     * Reflectively exercises every {@code log*} method on {@code loggerInterface}, invoking it on
+     * Reflectively exercises every {@code trace*} method on {@code loggerInterface}, invoking it on
      * {@code loggerImpl} and verifying the resulting CBOR message decodes back to the values supplied.
      *
      * @param loggerInterface the {@link GeneratedLogger}-annotated interface, e.g. {@code DriverTracer.class}.
@@ -108,7 +108,7 @@ public final class GenericLoggerEventVerifier
         assertTrue(0 < eventCodeConstants.length, eventCodeClass.getName() + " has no enum constants");
 
         final Method[] logMethods = Arrays.stream(loggerInterface.getMethods())
-            .filter(method -> method.getName().startsWith("log"))
+            .filter(method -> method.getName().startsWith("trace"))
             .filter(method -> null != method.getAnnotation(LoggerMethod.class))
             .toArray(Method[]::new);
 


### PR DESCRIPTION
- Avoids name collisions with concepts like the Cluster Log
- Some EventCode references remain, but are kept in place to avoid breaking downstream projects.