### PR TITLE
[Client/C] persistent_subscription option to control context ownership.

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -39,6 +39,9 @@ NOTE: The corresponding logging event `CMD_IN_CONNECT` was also removed.
 
 === Changelog
 
+* **[Client/C]** Add `aeron_archive_persistent_subscription_get_persistent_subscription_context` and
+`aeron_archive_persistent_subscription_get_and_own_persistent_subscription_context` to allow the caller to take
+ownership of the persistent subscription context, in the same way as `aeron_archive_get_and_own_archive_context`.
 * **[Client/Java]** Remove `Image#controlledPeek` APIs.
 * **[Client/C/C{plus}{plus} Wrapper]** Remove `aeron_image_set_position` and `aeron_image_controlled_peek` APIs.
 * **[Archive]** Abort `ControlSession` on non-recoverable exception.

--- a/aeron-archive/src/main/c/client/aeron_archive.h
+++ b/aeron-archive/src/main/c/client/aeron_archive.h
@@ -546,7 +546,7 @@ aeron_archive_context_t *aeron_archive_get_archive_context(aeron_archive_t *aero
  * Retrieve the underlying aeron_archive_context_t used to configure the provided aeron_archive_t.
  * <p>
  * Additionally, calling this function transfers ownership of the returned aeron_archive_context_t to the caller.
- * i.e. it is now the the caller's responsibility to close the context.
+ * i.e. it is now the caller's responsibility to close the context.
  * This is useful when wrapping the C library in other, higher level languages.
  */
 aeron_archive_context_t *aeron_archive_get_and_own_archive_context(aeron_archive_t *aeron_archive);
@@ -1685,7 +1685,8 @@ aeron_counter_t *aeron_archive_persistent_subscription_context_get_live_joined_c
  * Create a persistent subscription.
  * <p>
  * If creating a subscription succeeds, then the subscription will own the context. And closing the
- * subscription, will close the context.
+ * subscription, will close the context. Ownership of the context can be transferred to the caller
+ * via aeron_archive_persistent_subscription_get_and_own_persistent_subscription_context.
  * <p>
  * If no Aeron client is set on the context, one will be created and owned by the context,
  * and will be closed when the context is closed via aeron_archive_persistent_subscription_context_close.
@@ -1700,11 +1701,33 @@ int aeron_archive_persistent_subscription_create(
 
 /**
  * Close a persistent subscription and dispose of all resources and memory held by it.
+ * <p>
+ * The context is closed as well, unless ownership of it was transferred to the caller via
+ * aeron_archive_persistent_subscription_get_and_own_persistent_subscription_context.
  *
  * @param persistent_subscription to close.
  * @return 0 on success, -1 on error.
  */
 int aeron_archive_persistent_subscription_close(
+    aeron_archive_persistent_subscription_t *persistent_subscription);
+
+/**
+ * Retrieve the underlying aeron_archive_persistent_subscription_context_t used to configure the provided
+ * aeron_archive_persistent_subscription_t.
+ */
+aeron_archive_persistent_subscription_context_t *aeron_archive_persistent_subscription_get_persistent_subscription_context(
+    aeron_archive_persistent_subscription_t *persistent_subscription);
+
+/**
+ * Retrieve the underlying aeron_archive_persistent_subscription_context_t used to configure the provided
+ * aeron_archive_persistent_subscription_t.
+ * <p>
+ * Additionally, calling this function transfers ownership of the returned aeron_archive_persistent_subscription_context_t
+ * to the caller. i.e. it is now the caller's responsibility to close the context, which must be done after
+ * the persistent subscription has been closed.
+ * This is useful when wrapping the C library in other, higher level languages.
+ */
+aeron_archive_persistent_subscription_context_t *aeron_archive_persistent_subscription_get_and_own_persistent_subscription_context(
     aeron_archive_persistent_subscription_t *persistent_subscription);
 
 /**

--- a/aeron-archive/src/main/c/client/aeron_archive_persistent_subscription.c
+++ b/aeron-archive/src/main/c/client/aeron_archive_persistent_subscription.c
@@ -1010,6 +1010,7 @@ int aeron_archive_persistent_subscription_create(
     }
 
     _persistent_subscription->context = context;
+    _persistent_subscription->owns_context = true;
     _persistent_subscription->listener = context->listener;
     _persistent_subscription->message_timeout_ns = aeron_archive_context_get_message_timeout_ns(context->archive_context);
     _persistent_subscription->replay_session_id = AERON_NULL_VALUE;
@@ -1079,13 +1080,31 @@ int aeron_archive_persistent_subscription_close(aeron_archive_persistent_subscri
         aeron_archive_persistent_subscription_clean_up_replay(persistent_subscription);
         aeron_archive_persistent_subscription_clean_up_replay_subscription(persistent_subscription);
         aeron_archive_async_client_destroy(persistent_subscription->archive);
-        aeron_archive_persistent_subscription_context_close(persistent_subscription->context);
+        if (persistent_subscription->owns_context)
+        {
+            aeron_archive_persistent_subscription_context_close(persistent_subscription->context);
+        }
+        persistent_subscription->context = NULL;
         aeron_image_fragment_assembler_delete(persistent_subscription->uncontrolled_assembler);
         aeron_image_controlled_fragment_assembler_delete(persistent_subscription->assembler);
         aeron_free(persistent_subscription);
     }
 
     return 0;
+}
+
+aeron_archive_persistent_subscription_context_t *aeron_archive_persistent_subscription_get_persistent_subscription_context(
+    aeron_archive_persistent_subscription_t *persistent_subscription)
+{
+    return persistent_subscription->context;
+}
+
+aeron_archive_persistent_subscription_context_t *aeron_archive_persistent_subscription_get_and_own_persistent_subscription_context(
+    aeron_archive_persistent_subscription_t *persistent_subscription)
+{
+    persistent_subscription->owns_context = false;
+
+    return persistent_subscription->context;
 }
 
 static int aeron_archive_persistent_subscription_await_archive_connection(

--- a/aeron-archive/src/main/c/client/aeron_archive_persistent_subscription.h
+++ b/aeron-archive/src/main/c/client/aeron_archive_persistent_subscription.h
@@ -121,6 +121,7 @@ aeron_archive_persistent_subscription_list_recording_request_t;
 struct aeron_archive_persistent_subscription_stct
 {
     aeron_archive_persistent_subscription_context_t *context;
+    bool owns_context;
     aeron_archive_persistent_subscription_listener_t listener;
     uint64_t message_timeout_ns;
     aeron_archive_async_client_t *archive;

--- a/aeron-archive/src/test/c/client/aeron_archive_persistent_subscription_test.cpp
+++ b/aeron-archive/src/test/c/client/aeron_archive_persistent_subscription_test.cpp
@@ -934,6 +934,43 @@ TEST_F(AeronArchivePersistentSubscriptionTest, shouldUseUserProvidedCounters)
     aeron_archive_context_close(archive_ctx);
 }
 
+TEST_F(AeronArchivePersistentSubscriptionTest, shouldNotCloseContextWhenOwnershipIsTransferredToCaller)
+{
+    TestArchive archive = createArchive(m_aeronDir);
+
+    AeronResource aeron(m_aeronDir);
+
+    aeron_archive_context_t *archive_ctx = createArchiveContext();
+    ArchiveContextGuard archive_ctx_guard(archive_ctx);
+    aeron_archive_persistent_subscription_context_t *context = createDefaultPersistentSubscriptionContext(
+        aeron.aeron(),
+        archive_ctx,
+        123);
+
+    PersistentSubscriptionContextGuard context_guard(context);
+    aeron_archive_persistent_subscription_t *persistent_subscription;
+    ASSERT_EQ(0, aeron_archive_persistent_subscription_create(&persistent_subscription, context)) << aeron_errmsg();
+    context_guard.release();
+
+    ASSERT_EQ(context, aeron_archive_persistent_subscription_get_persistent_subscription_context(persistent_subscription));
+    ASSERT_EQ(context, aeron_archive_persistent_subscription_get_and_own_persistent_subscription_context(persistent_subscription));
+
+    aeron_counter_t *state_counter = aeron_archive_persistent_subscription_context_get_state_counter(context);
+    ASSERT_NE(nullptr, state_counter);
+
+    ASSERT_EQ(0, aeron_archive_persistent_subscription_close(persistent_subscription)) << aeron_errmsg();
+
+    // The context, and therefore the counters it owns, must survive closing the persistent subscription.
+    ASSERT_FALSE(aeron_counter_is_closed(state_counter));
+    ASSERT_EQ(123, aeron_archive_persistent_subscription_context_get_recording_id(context));
+
+    ASSERT_EQ(0, aeron_archive_persistent_subscription_context_close(context)) << aeron_errmsg();
+    ASSERT_TRUE(aeron_counter_is_closed(state_counter));
+
+    archive_ctx_guard.release();
+    aeron_archive_context_close(archive_ctx);
+}
+
 struct FragmentLimitAndChannel
 {
     int fragment_limit;


### PR DESCRIPTION
The persistent_subscription normally takes ownership of the context. A new method has been added to be able to take ownership of that context and control the lifecycle externally.

It is done in exactly the same way as for the archive_context.