### PR TITLE
[Java] Return replay session id when starting a replay via a response channel

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/client/AeronArchive.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/client/AeronArchive.java
@@ -4356,9 +4356,7 @@ public final class AeronArchive implements AutoCloseable
                 throw new ArchiveException("failed to send replay request");
             }
 
-            pollForResponse(lastCorrelationId);
-
-            return lastCorrelationId;
+            return pollForResponse(lastCorrelationId);
         }
     }
 

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveResponseClientTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveResponseClientTest.java
@@ -168,12 +168,18 @@ public class ArchiveResponseClientTest
             final ReplayParams replayParams = new ReplayParams();
             replayParams.subscriptionRegistrationId(replay.registrationId());
 
-            aeronArchive.startReplay(recordingResult.recordingId(), responseChannel, replayStreamId, replayParams);
+            final long replaySessionId =
+                aeronArchive.startReplay(recordingResult.recordingId(), responseChannel, replayStreamId, replayParams);
+            assertEquals(aeronArchive.controlResponsePoller().relevantId(), replaySessionId);
 
             final MutableLong replayPosition = new MutableLong();
             while (replayPosition.get() < recordingResult.position())
             {
-                if (0 == replay.poll((buffer, offset, length, header) -> replayPosition.set(header.position()), 10))
+                if (0 == replay.poll((buffer, offset, length, header) ->
+                {
+                    assertEquals((int)replaySessionId, header.sessionId());
+                    replayPosition.set(header.position());
+                }, 10))
                 {
                     Tests.yield();
                 }
@@ -204,12 +210,18 @@ public class ArchiveResponseClientTest
                 .boundingLimitCounterId(testBoundedCounter.id())
                 .subscriptionRegistrationId(replay.registrationId());
 
-            aeronArchive.startReplay(recordingResult.recordingId(), responseChannel, replayStreamId, replayParams);
+            final long replaySessionId =
+                aeronArchive.startReplay(recordingResult.recordingId(), responseChannel, replayStreamId, replayParams);
+            assertEquals(aeronArchive.controlResponsePoller().relevantId(), replaySessionId);
 
             final MutableLong replayPosition = new MutableLong();
             while (replayPosition.get() < recordingResult.halfwayPosition())
             {
-                if (0 == replay.poll((buffer, offset, length, header) -> replayPosition.set(header.position()), 10))
+                if (0 == replay.poll((buffer, offset, length, header) ->
+                {
+                    assertEquals((int)replaySessionId, header.sessionId());
+                    replayPosition.set(header.position());
+                }, 10))
                 {
                     Tests.yield();
                 }


### PR DESCRIPTION
  `AeronArchive.startReplay()` returns the request correlation ID when using a response channel, instead of the replay session ID received from the archive. Passing that value to `stopReplay()` therefore fails to stop the intended replay.

  Return the result of `pollForResponse()` and extend the existing regular and bounded response-channel replay tests to verify the returned ID against both the archive response and the received message’s session ID.
